### PR TITLE
test: add reset_chime_tracking test for 100% coverage

### DIFF
--- a/tests/test_clock_service.py
+++ b/tests/test_clock_service.py
@@ -151,6 +151,24 @@ class TestChimeTracking:
         # Should chime at 4:00
         assert service.should_chime_now(time(16, 0, 0)) == "hour"
 
+    def test_reset_chime_tracking(self):
+        """Reset should allow chime again at same minute."""
+        from accessiclock.services.clock_service import ClockService
+
+        service = ClockService()
+        service.chime_hourly = True
+
+        test_time = time(15, 0, 0)
+        # Chime once
+        assert service.should_chime_now(test_time) == "hour"
+        service.mark_chimed(test_time)
+        # Blocked
+        assert service.should_chime_now(test_time) is None
+        # Reset tracking
+        service.reset_chime_tracking()
+        # Should chime again
+        assert service.should_chime_now(test_time) == "hour"
+
 
 class TestGetCurrentHour:
     """Test hour extraction for hourly chimes."""


### PR DESCRIPTION
Adds test coverage for the `reset_chime_tracking` method (line 126), achieving 100% coverage on clock_service.py.

Closes #15