### PR TITLE
feat: add tray hotkeys and audio device controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,7 +92,6 @@ briefcase.*.log
 *.log
 
 # UV package manager
-uv.lock
 .uv/
 
 # Environment

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Settings are stored in:
 - Linux: `~/.config/AccessiClock/config.json`
 - Portable mode: `./data/config.json`
 
+## Migration Notes
+
+- Current migration parity checklist: `docs/wxpython-migration-parity-checklist.md`
+
 ## Development
 
 ### Running Tests

--- a/README.md
+++ b/README.md
@@ -49,22 +49,17 @@ An accessible talking clock application designed for visually impaired users, bu
 git clone https://github.com/orinks/AccessiClock.git
 cd AccessiClock
 
-# Create virtual environment
-python -m venv .venv
-.venv\Scripts\activate  # Windows
-# or: source .venv/bin/activate  # Linux/macOS
-
-# Install dependencies
-pip install -e .
+# Create the local development environment
+uv sync --group dev
 
 # Run the application
-python -m accessiclock
+uv run python -m accessiclock
 ```
 
 ### Development Installation
 
 ```bash
-pip install -e ".[dev]"
+uv sync --group dev
 ```
 
 ## Usage
@@ -137,10 +132,14 @@ Settings are stored in:
 
 ```bash
 # Run all tests
-PYTHONPATH=src pytest tests/ -v
+uv run pytest tests/ -v
 
 # Run with coverage
-PYTHONPATH=src pytest tests/ --cov=accessiclock
+uv run pytest tests/ --cov=accessiclock
+
+# Run lint and type checks
+uv run ruff check src tests
+uv run mypy src
 ```
 
 ### Project Structure

--- a/docs/wxpython-migration-parity-checklist.md
+++ b/docs/wxpython-migration-parity-checklist.md
@@ -1,0 +1,52 @@
+# AccessiClock wxPython Migration: Feature Inventory + Parity Checklist
+
+Branch: `rewrite/wxpython-core-manual`  
+Base: `dev`
+
+## Scope for this phase (must-have)
+
+These are the baseline behaviors required for a usable first wxPython version.
+
+- [x] Native wxPython app entrypoint (`accessiclock.main:main`)
+- [x] Main window opens and can be navigated with keyboard only
+- [x] Predictable startup focus (initial focus lands on a stable control)
+- [x] Config path setup (portable + normal mode)
+- [x] Logging setup (file + console)
+- [x] Settings load/save scaffold with safe defaults
+- [x] Startup/shutdown flow scaffold in app class
+- [x] Initial keyboard shortcut map documented in code and README
+- [x] Smoke tests for settings/shortcuts/logging scaffolding
+
+## Existing feature inventory
+
+### Core clock behavior
+- [x] Time display updates every second
+- [x] Hourly chime logic
+- [x] Half-hour chime logic
+- [x] Quarter-hour chime logic
+- [x] Quiet hours in clock service
+
+### Audio + voice
+- [x] Sound playback through `AudioPlayer`
+- [x] Clock pack sound lookup
+- [x] Test chime action
+- [x] TTS announce current time
+
+### Accessibility + UX
+- [x] Keyboard reachable controls (Tab order + mnemonics)
+- [x] Screen-reader-friendly labels/names on key controls
+- [x] Status text updates for user feedback
+- [x] Focus-safe startup behavior
+
+## Later phase items (not required for this run)
+
+- [ ] Full settings dialog parity audit and cleanup
+- [ ] Clock manager UX polish and validation messaging
+- [ ] Better accessibility pass for dialog content and error states
+- [ ] Structured app state object (if needed after more features land)
+- [ ] CI matrix that runs GUI smoke checks on Windows
+- [ ] Packaging polish (PyInstaller/win installer flow)
+
+## Notes
+
+This phase intentionally keeps architecture lean: minimal new modules for logging, settings persistence, and shortcut mapping. No new heavy framework layer was introduced.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,23 @@ ai = [
     "elevenlabs>=0.2.0",
 ]
 
+[dependency-groups]
+dev = [
+    "pytest",
+    "pytest-mock",
+    "pytest-cov",
+    "ruff>=0.9.0",
+    "mypy>=1.0.0",
+]
+build = [
+    "pyinstaller>=6.0.0",
+    "pillow>=10.0.0",
+]
+ai = [
+    "openai>=1.0.0",
+    "elevenlabs>=0.2.0",
+]
+
 [project.scripts]
 accessiclock = "accessiclock.main:main"
 
@@ -67,3 +84,7 @@ ignore = ["E501"]
 python_version = "3.10"
 warn_return_any = true
 warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+module = ["pyttsx3", "sound_lib", "wx", "wx.*"]
+ignore_missing_imports = true

--- a/src/accessiclock/app.py
+++ b/src/accessiclock/app.py
@@ -1,17 +1,15 @@
-"""
-AccessiClock wxPython application.
-
-Main application class with screen reader accessibility support.
-"""
+"""AccessiClock wxPython application."""
 
 from __future__ import annotations
 
 import logging
+from datetime import time as dt_time
 from typing import TYPE_CHECKING
 
 import wx
 
 from .audio.tts_engine import TTSEngine
+from .core.settings import AppSettings, load_settings, save_settings
 from .paths import Paths
 from .services.clock_pack_loader import ClockPackLoader
 from .services.clock_service import ClockService
@@ -26,351 +24,179 @@ class AccessiClockApp(wx.App):
     """AccessiClock application using wxPython."""
 
     def __init__(self, portable_mode: bool = False):
-        """
-        Initialize the AccessiClock application.
-
-        Args:
-            portable_mode: If True, use portable mode (config alongside app).
-        """
         self._portable_mode = portable_mode
-
-        # Set up paths
         self.paths = Paths(portable_mode=portable_mode)
 
-        # UI components (initialized in OnInit)
         self.main_window: MainWindow | None = None
-
-        # Audio player (initialized in OnInit)
         self.audio_player = None
-
-        # TTS engine (initialized in OnInit)
         self.tts_engine: TTSEngine | None = None
-
-        # Services
         self.clock_service: ClockService | None = None
         self.clock_pack_loader: ClockPackLoader | None = None
 
-        # Configuration
-        self.config: dict = {}
-
-        # Clock state
-        self.current_volume: int = 50
-        self.selected_clock: str = "default"
-        self.chime_hourly: bool = True
-        self.chime_half_hour: bool = False
-        self.chime_quarter_hour: bool = False
+        self.settings = AppSettings()
+        self.current_volume = self.settings.volume
+        self.selected_clock = self.settings.clock
+        self.chime_hourly = self.settings.chime_hourly
+        self.chime_half_hour = self.settings.chime_half_hour
+        self.chime_quarter_hour = self.settings.chime_quarter_hour
 
         super().__init__()
 
     def OnInit(self) -> bool:
-        """Initialize the application (wxPython entry point)."""
-        logger.info("Starting AccessiClock application (wxPython)")
-
+        """Initialize the app and create the main window."""
+        logger.info("Starting AccessiClock wxPython app")
         try:
-            # Initialize services
-            self._init_services()
-
-            # Initialize audio player
-            self._init_audio()
-
-            # Initialize TTS engine
-            self._init_tts()
-
-            # Load configuration
-            self._load_config()
-
-            # Sync service settings with config
-            self._sync_service_settings()
-
-            # Create main window
-            from .ui.main_window import MainWindow
-
-            self.main_window = MainWindow(self)
-            self.main_window.Show()
-            self.SetTopWindow(self.main_window)
-
-            logger.info("AccessiClock initialized successfully")
+            self._startup()
             return True
-
-        except Exception as e:
-            logger.exception(f"Failed to initialize AccessiClock: {e}")
-            wx.MessageBox(
-                f"Failed to start AccessiClock:\n\n{e}",
-                "Startup Error",
-                wx.OK | wx.ICON_ERROR,
-            )
+        except Exception:
+            logger.exception("Startup failed")
+            wx.MessageBox("AccessiClock could not start. See log file for details.", "Startup Error")
             return False
 
-    def _init_services(self) -> None:
-        """Initialize application services."""
-        # Initialize clock service
-        self.clock_service = ClockService()
-        logger.info("Clock service initialized")
+    def _startup(self) -> None:
+        self._init_services()
+        self._init_audio()
+        self._init_tts()
+        self._load_config()
+        self._sync_service_settings()
 
-        # Initialize clock pack loader
+        from .ui.main_window import MainWindow
+
+        self.main_window = MainWindow(self)
+        self.main_window.Show()
+        self.SetTopWindow(self.main_window)
+
+    def _init_services(self) -> None:
+        self.clock_service = ClockService()
         self.clock_pack_loader = ClockPackLoader(self.paths.clocks_dir)
         self.clock_pack_loader.discover_packs()
-        logger.info(f"Discovered {len(self.clock_pack_loader._cache)} clock packs")
-
-    def _sync_service_settings(self) -> None:
-        """Sync service settings with loaded configuration."""
-        if self.clock_service:
-            self.clock_service.chime_hourly = self.chime_hourly
-            self.clock_service.chime_half_hour = self.chime_half_hour
-            self.clock_service.chime_quarter_hour = self.chime_quarter_hour
-            logger.debug("Clock service settings synced with config")
 
     def _init_audio(self) -> None:
-        """Initialize the audio player."""
         try:
             from .audio.player import AudioPlayer
 
             self.audio_player = AudioPlayer(volume_percent=self.current_volume)
-            logger.info("Audio player initialized")
-        except Exception as e:
-            logger.warning(f"Audio player initialization failed: {e}")
+        except Exception:
+            logger.warning("Audio player unavailable", exc_info=True)
             self.audio_player = None
 
     def _init_tts(self) -> None:
-        """Initialize the TTS engine."""
         try:
             self.tts_engine = TTSEngine()
-            logger.info(f"TTS engine initialized ({self.tts_engine.engine_type})")
-        except Exception as e:
-            logger.warning(f"TTS engine initialization failed: {e}")
+        except Exception:
+            logger.warning("TTS unavailable", exc_info=True)
             self.tts_engine = None
 
+    def _sync_service_settings(self) -> None:
+        if not self.clock_service:
+            return
+        self.clock_service.chime_hourly = self.chime_hourly
+        self.clock_service.chime_half_hour = self.chime_half_hour
+        self.clock_service.chime_quarter_hour = self.chime_quarter_hour
+
     def _load_config(self) -> None:
-        """Load configuration from file."""
-        config_file = self.paths.config_file
-        if config_file.exists():
+        self.settings = load_settings(self.paths.config_file)
+
+        self.current_volume = self.settings.volume
+        self.selected_clock = self.settings.clock
+        self.chime_hourly = self.settings.chime_hourly
+        self.chime_half_hour = self.settings.chime_half_hour
+        self.chime_quarter_hour = self.settings.chime_quarter_hour
+
+        if self.clock_service and self.settings.quiet_hours_enabled:
             try:
-                import json
-
-                with open(config_file, encoding="utf-8") as f:
-                    self.config = json.load(f)
-
-                # Apply loaded settings
-                self.current_volume = self.config.get("volume", 50)
-                self.selected_clock = self.config.get("clock", "default")
-                self.chime_hourly = self.config.get("chime_hourly", True)
-                self.chime_half_hour = self.config.get("chime_half_hour", False)
-                self.chime_quarter_hour = self.config.get("chime_quarter_hour", False)
-
-                # Restore quiet hours
-                if self.config.get("quiet_hours_enabled", False) and self.clock_service:
-                    from datetime import time as dt_time
-                    try:
-                        sh, sm = map(int, self.config["quiet_start"].split(":"))
-                        eh, em = map(int, self.config["quiet_end"].split(":"))
-                        self.clock_service.set_quiet_hours(dt_time(sh, sm), dt_time(eh, em))
-                    except (KeyError, ValueError) as e:
-                        logger.warning(f"Failed to restore quiet hours: {e}")
-                elif self.clock_service:
-                    self.clock_service.quiet_hours_enabled = False
-
-                logger.info(f"Configuration loaded from {config_file}")
-            except Exception as e:
-                logger.warning(f"Failed to load config: {e}")
+                sh, sm = map(int, self.settings.quiet_start.split(":"))
+                eh, em = map(int, self.settings.quiet_end.split(":"))
+                self.clock_service.set_quiet_hours(dt_time(sh, sm), dt_time(eh, em))
+            except (TypeError, ValueError):
+                logger.warning("Invalid quiet hours in config; disabling")
+                self.clock_service.quiet_hours_enabled = False
 
     def save_config(self) -> None:
-        """Save configuration to file."""
-        import json
-
-        quiet_config = {}
         if self.clock_service and self.clock_service.quiet_hours_enabled:
-            quiet_config = {
-                "quiet_hours_enabled": True,
-                "quiet_start": self.clock_service.quiet_start.strftime("%H:%M"),
-                "quiet_end": self.clock_service.quiet_end.strftime("%H:%M"),
-            }
+            quiet_enabled = True
+            quiet_start = self.clock_service.quiet_start.strftime("%H:%M")
+            quiet_end = self.clock_service.quiet_end.strftime("%H:%M")
         else:
-            quiet_config = {"quiet_hours_enabled": False}
+            quiet_enabled = False
+            quiet_start = self.settings.quiet_start
+            quiet_end = self.settings.quiet_end
 
-        self.config.update(
-            {
-                "volume": self.current_volume,
-                "clock": self.selected_clock,
-                "chime_hourly": self.chime_hourly,
-                "chime_half_hour": self.chime_half_hour,
-                "chime_quarter_hour": self.chime_quarter_hour,
-                **quiet_config,
-            }
+        self.settings = AppSettings(
+            volume=self.current_volume,
+            clock=self.selected_clock,
+            chime_hourly=self.chime_hourly,
+            chime_half_hour=self.chime_half_hour,
+            chime_quarter_hour=self.chime_quarter_hour,
+            quiet_hours_enabled=quiet_enabled,
+            quiet_start=quiet_start,
+            quiet_end=quiet_end,
         )
-
-        # Sync with clock service
         self._sync_service_settings()
-
-        try:
-            config_file = self.paths.config_file
-            with open(config_file, "w", encoding="utf-8") as f:
-                json.dump(self.config, f, indent=2)
-            logger.info(f"Configuration saved to {config_file}")
-        except Exception as e:
-            logger.error(f"Failed to save config: {e}")
+        save_settings(self.paths.config_file, self.settings)
 
     def set_volume(self, volume: int) -> None:
-        """Set the audio volume."""
         self.current_volume = max(0, min(100, volume))
         if self.audio_player:
             self.audio_player.set_volume(self.current_volume)
         self.save_config()
 
     def play_chime(self, chime_type: str) -> bool:
-        """
-        Play a chime sound from the selected clock pack.
-        
-        Args:
-            chime_type: Type of chime ("hour", "half_hour", "quarter_hour", "preview").
-            
-        Returns:
-            True if successful, False otherwise.
-        """
-        if not self.audio_player:
-            logger.warning("No audio player available")
+        if not self.audio_player or not self.clock_pack_loader:
             return False
-
-        if not self.clock_pack_loader:
-            logger.warning("No clock pack loader available")
-            return False
-
         try:
             pack_info = self.clock_pack_loader.get_pack(self.selected_clock)
             if not pack_info:
-                logger.warning(f"Clock pack not found: {self.selected_clock}")
                 return False
-
             sound_path = pack_info.get_sound_path(chime_type)
             if not sound_path or not sound_path.exists():
-                logger.warning(f"Sound not found: {chime_type} in {self.selected_clock}")
                 return False
-
             self.audio_player.play_sound(str(sound_path))
-            logger.info(f"Playing {chime_type} chime from {self.selected_clock}")
             return True
-
-        except Exception as e:
-            logger.error(f"Failed to play chime: {e}")
+        except Exception:
+            logger.warning("Unable to play %s chime", chime_type, exc_info=True)
             return False
 
     def play_test_sound(self) -> bool:
-        """Play a test/preview sound. Returns True if successful."""
-        # Try to play preview from selected clock pack
-        if self.play_chime("preview"):
-            return True
-        
-        # Fall back to hour chime
-        if self.play_chime("hour"):
-            return True
-
-        # Last resort: try built-in test sound
-        if not self.audio_player:
-            logger.warning("No audio player available")
-            return False
-
-        try:
-            test_sound = self.paths.app_dir / "audio" / "test_sound.wav"
-            if test_sound.exists():
-                self.audio_player.play_sound(str(test_sound))
-                return True
-            else:
-                logger.warning(f"Test sound not found at {test_sound}")
-                return False
-        except Exception as e:
-            logger.error(f"Failed to play test sound: {e}")
-            return False
+        return self.play_chime("preview") or self.play_chime("hour")
 
     def announce_time(self, style: str = "simple") -> bool:
-        """
-        Announce the current time using TTS.
-        
-        Args:
-            style: Time format style ("simple", "natural", "precise").
-            
-        Returns:
-            True if announced, False if TTS unavailable.
-        """
         if not self.tts_engine:
-            logger.warning("TTS engine not available")
             return False
-
         from datetime import datetime
 
-        current_time = datetime.now().time()
-        self.tts_engine.speak_time(current_time, style=style)
-        logger.info(f"Time announced: {current_time.strftime('%I:%M %p')}")
+        self.tts_engine.speak_time(datetime.now().time(), style=style)
         return True
 
     def check_and_play_chime(self) -> str | None:
-        """
-        Check if a chime should play now and play it.
-        
-        Called by the main window's timer tick.
-        
-        Returns:
-            The type of chime played, or None if no chime.
-        """
         if not self.clock_service:
             return None
-
         from datetime import datetime
 
-        current_time = datetime.now().time()
-        chime_type = self.clock_service.should_chime_now(current_time)
-
+        now = datetime.now().time()
+        chime_type = self.clock_service.should_chime_now(now)
         if chime_type and self.play_chime(chime_type):
-            self.clock_service.mark_chimed(current_time)
+            self.clock_service.mark_chimed(now)
             return chime_type
-
         return None
 
     def get_available_clocks(self) -> list[str]:
-        """
-        Get list of available clock pack names.
-        
-        Returns:
-            List of clock pack display names.
-        """
-        if not self.clock_pack_loader:
+        if not self.clock_pack_loader or not self.clock_pack_loader._cache:
             return ["Default"]
-
-        packs = self.clock_pack_loader._cache
-        if not packs:
-            return ["Default"]
-
-        return [info.name for info in packs.values()]
-
-    def get_clock_pack_ids(self) -> list[str]:
-        """
-        Get list of available clock pack IDs.
-        
-        Returns:
-            List of clock pack IDs (directory names).
-        """
-        if not self.clock_pack_loader:
-            return ["default"]
-
-        return list(self.clock_pack_loader._cache.keys()) or ["default"]
+        return [info.name for info in self.clock_pack_loader._cache.values()]
 
     def OnExit(self) -> int:
-        """Clean up before exit."""
-        logger.info("AccessiClock shutting down")
-
-        # Save configuration
+        logger.info("Shutting down AccessiClock")
         self.save_config()
 
-        # Clean up audio
         if self.audio_player:
             try:
                 self.audio_player.cleanup()
-            except Exception as e:
-                logger.warning(f"Error cleaning up audio: {e}")
-
-        # Clean up TTS
+            except Exception:
+                logger.warning("Audio cleanup failed", exc_info=True)
         if self.tts_engine:
             try:
                 self.tts_engine.cleanup()
-            except Exception as e:
-                logger.warning(f"Error cleaning up TTS: {e}")
-
+            except Exception:
+                logger.warning("TTS cleanup failed", exc_info=True)
         return 0

--- a/src/accessiclock/app.py
+++ b/src/accessiclock/app.py
@@ -3,18 +3,20 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from datetime import time as dt_time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import wx
 
-from .audio.tts_engine import TTSEngine
+from .audio.tts_engine import TimeStyle, TTSEngine
 from .core.settings import AppSettings, load_settings, save_settings
 from .paths import Paths
 from .services.clock_pack_loader import ClockPackLoader
-from .services.clock_service import ClockService
+from .services.clock_service import ChimeStyle, ClockService
 
 if TYPE_CHECKING:
+    from .audio.player import AudioPlayer
     from .ui.main_window import MainWindow
 
 logger = logging.getLogger(__name__)
@@ -28,17 +30,28 @@ class AccessiClockApp(wx.App):
         self.paths = Paths(portable_mode=portable_mode)
 
         self.main_window: MainWindow | None = None
-        self.audio_player = None
+        self.audio_player: AudioPlayer | None = None
         self.tts_engine: TTSEngine | None = None
         self.clock_service: ClockService | None = None
         self.clock_pack_loader: ClockPackLoader | None = None
 
         self.settings = AppSettings()
+        self.config = self.settings.to_dict()
         self.current_volume = self.settings.volume
         self.selected_clock = self.settings.clock
         self.chime_hourly = self.settings.chime_hourly
         self.chime_half_hour = self.settings.chime_half_hour
         self.chime_quarter_hour = self.settings.chime_quarter_hour
+        self.chime_style: ChimeStyle = cast(ChimeStyle, self.settings.chime_style)
+        self.hour_count_chimes = self.settings.hour_count_chimes
+        self.minute_tick = self.settings.minute_tick
+        self.alarm_enabled = self.settings.alarm_enabled
+        self.alarm_time = self.settings.alarm_time
+        self.alarm_sound_enabled = self.settings.alarm_sound_enabled
+        self.alarm_spoken_text = self.settings.alarm_spoken_text
+        self.quiet_hours_enabled = self.settings.quiet_hours_enabled
+        self.quiet_start = self.settings.quiet_start
+        self.quiet_end = self.settings.quiet_end
 
         super().__init__()
 
@@ -93,15 +106,42 @@ class AccessiClockApp(wx.App):
         self.clock_service.chime_hourly = self.chime_hourly
         self.clock_service.chime_half_hour = self.chime_half_hour
         self.clock_service.chime_quarter_hour = self.chime_quarter_hour
+        self.clock_service.chime_style = cast(ChimeStyle, self.chime_style)
+        self.clock_service.hour_count_chimes = self.hour_count_chimes
+        self.clock_service.minute_tick = self.minute_tick
+        if self.alarm_enabled:
+            try:
+                alarm_hour, alarm_minute = map(int, self.alarm_time.split(":"))
+                self.clock_service.set_alarm(
+                    dt_time(alarm_hour, alarm_minute),
+                    spoken_text=self.alarm_spoken_text,
+                    sound_enabled=self.alarm_sound_enabled,
+                )
+            except (TypeError, ValueError):
+                logger.warning("Invalid alarm time in config; disabling alarm")
+                self.clock_service.alarm_enabled = False
+        else:
+            self.clock_service.alarm_enabled = False
 
     def _load_config(self) -> None:
         self.settings = load_settings(self.paths.config_file)
+        self.config = self.settings.to_dict()
 
         self.current_volume = self.settings.volume
         self.selected_clock = self.settings.clock
         self.chime_hourly = self.settings.chime_hourly
         self.chime_half_hour = self.settings.chime_half_hour
         self.chime_quarter_hour = self.settings.chime_quarter_hour
+        self.chime_style = cast(ChimeStyle, self.settings.chime_style)
+        self.hour_count_chimes = self.settings.hour_count_chimes
+        self.minute_tick = self.settings.minute_tick
+        self.alarm_enabled = self.settings.alarm_enabled
+        self.alarm_time = self.settings.alarm_time
+        self.alarm_sound_enabled = self.settings.alarm_sound_enabled
+        self.alarm_spoken_text = self.settings.alarm_spoken_text
+        self.quiet_hours_enabled = self.settings.quiet_hours_enabled
+        self.quiet_start = self.settings.quiet_start
+        self.quiet_end = self.settings.quiet_end
 
         if self.clock_service and self.settings.quiet_hours_enabled:
             try:
@@ -111,26 +151,47 @@ class AccessiClockApp(wx.App):
             except (TypeError, ValueError):
                 logger.warning("Invalid quiet hours in config; disabling")
                 self.clock_service.quiet_hours_enabled = False
+                self.quiet_hours_enabled = False
 
     def save_config(self) -> None:
-        if self.clock_service and self.clock_service.quiet_hours_enabled:
+        if (
+            self.clock_service
+            and self.clock_service.quiet_hours_enabled
+            and self.clock_service.quiet_start
+            and self.clock_service.quiet_end
+        ):
             quiet_enabled = True
             quiet_start = self.clock_service.quiet_start.strftime("%H:%M")
             quiet_end = self.clock_service.quiet_end.strftime("%H:%M")
         else:
             quiet_enabled = False
-            quiet_start = self.settings.quiet_start
-            quiet_end = self.settings.quiet_end
+            quiet_start = self.quiet_start
+            quiet_end = self.quiet_end
+        self.quiet_hours_enabled = quiet_enabled
+        self.quiet_start = quiet_start
+        self.quiet_end = quiet_end
 
+        self.config.update(
+            {
+                "volume": self.current_volume,
+                "clock": self.selected_clock,
+                "chime_hourly": self.chime_hourly,
+                "chime_half_hour": self.chime_half_hour,
+                "chime_quarter_hour": self.chime_quarter_hour,
+                "chime_style": self.chime_style,
+                "hour_count_chimes": self.hour_count_chimes,
+                "minute_tick": self.minute_tick,
+                "quiet_hours_enabled": quiet_enabled,
+                "quiet_start": quiet_start,
+                "quiet_end": quiet_end,
+                "alarm_enabled": self.alarm_enabled,
+                "alarm_time": self.alarm_time,
+                "alarm_sound_enabled": self.alarm_sound_enabled,
+                "alarm_spoken_text": self.alarm_spoken_text,
+            }
+        )
         self.settings = AppSettings(
-            volume=self.current_volume,
-            clock=self.selected_clock,
-            chime_hourly=self.chime_hourly,
-            chime_half_hour=self.chime_half_hour,
-            chime_quarter_hour=self.chime_quarter_hour,
-            quiet_hours_enabled=quiet_enabled,
-            quiet_start=quiet_start,
-            quiet_end=quiet_end,
+            **self.config,
         )
         self._sync_service_settings()
         save_settings(self.paths.config_file, self.settings)
@@ -157,6 +218,35 @@ class AccessiClockApp(wx.App):
             logger.warning("Unable to play %s chime", chime_type, exc_info=True)
             return False
 
+    def play_chime_sequence(self, chime_types: Sequence[str]) -> bool:
+        """Play an ordered chime sequence from the selected clock pack."""
+        if not self.audio_player or not self.clock_pack_loader or not chime_types:
+            return False
+        try:
+            pack_info = self.clock_pack_loader.get_pack(self.selected_clock)
+            if not pack_info:
+                return False
+            sound_paths = []
+            for chime_type in chime_types:
+                sound_path = pack_info.get_sound_path(chime_type)
+                if not sound_path or not sound_path.exists():
+                    logger.info("Skipping missing %s sound in %s", chime_type, pack_info.name)
+                    continue
+                sound_paths.append(str(sound_path))
+            if not sound_paths:
+                return False
+            if len(sound_paths) == 1:
+                self.audio_player.play_sound(sound_paths[0])
+                return True
+            if hasattr(self.audio_player, "play_sound_sequence"):
+                return bool(self.audio_player.play_sound_sequence(sound_paths))
+            for sound_path_text in sound_paths:
+                self.audio_player.play_sound(sound_path_text)
+            return True
+        except Exception:
+            logger.warning("Unable to play chime sequence: %s", chime_types, exc_info=True)
+            return False
+
     def play_test_sound(self) -> bool:
         return self.play_chime("preview") or self.play_chime("hour")
 
@@ -165,20 +255,43 @@ class AccessiClockApp(wx.App):
             return False
         from datetime import datetime
 
-        self.tts_engine.speak_time(datetime.now().time(), style=style)
+        self.tts_engine.speak_time(datetime.now().time(), style=cast(TimeStyle, style))
         return True
 
-    def check_and_play_chime(self) -> str | None:
+    def check_and_play_chime(self, current_time: dt_time | None = None) -> str | None:
         if not self.clock_service:
             return None
-        from datetime import datetime
 
-        now = datetime.now().time()
-        chime_type = self.clock_service.should_chime_now(now)
-        if chime_type and self.play_chime(chime_type):
-            self.clock_service.mark_chimed(now)
-            return chime_type
+        if current_time is None:
+            from datetime import datetime
+
+            current_time = datetime.now().time()
+        chime_sequence = self.clock_service.get_chime_sequence(current_time)
+        if chime_sequence and self.play_chime_sequence(chime_sequence):
+            self.clock_service.mark_chimed(current_time)
+            return ", ".join(chime_sequence)
         return None
+
+    def check_and_trigger_alarm(self, current_time: dt_time | None = None) -> bool:
+        """Trigger the configured alarm when it is due."""
+        if not self.clock_service:
+            return False
+
+        if current_time is None:
+            from datetime import datetime
+
+            current_time = datetime.now().time()
+        alarm = self.clock_service.get_due_alarm(current_time)
+        if not alarm:
+            return False
+        did_anything = False
+        if alarm.sound_name:
+            did_anything = self.play_chime(alarm.sound_name) or did_anything
+        if alarm.spoken_text and self.tts_engine:
+            self.tts_engine.speak(alarm.spoken_text)
+            did_anything = True
+        self.clock_service.mark_alarmed(current_time)
+        return did_anything
 
     def get_available_clocks(self) -> list[str]:
         if not self.clock_pack_loader or not self.clock_pack_loader._cache:

--- a/src/accessiclock/app.py
+++ b/src/accessiclock/app.py
@@ -17,7 +17,9 @@ from .services.clock_service import ChimeStyle, ClockService
 
 if TYPE_CHECKING:
     from .audio.player import AudioPlayer
+    from .ui.global_hotkeys import GlobalHotkeyManager
     from .ui.main_window import MainWindow
+    from .ui.system_tray import SystemTrayIcon
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +36,9 @@ class AccessiClockApp(wx.App):
         self.tts_engine: TTSEngine | None = None
         self.clock_service: ClockService | None = None
         self.clock_pack_loader: ClockPackLoader | None = None
+        self.system_tray_icon: SystemTrayIcon | None = None
+        self.global_hotkey_manager: GlobalHotkeyManager | None = None
+        self._exiting = False
 
         self.settings = AppSettings()
         self.config = self.settings.to_dict()
@@ -52,6 +57,10 @@ class AccessiClockApp(wx.App):
         self.quiet_hours_enabled = self.settings.quiet_hours_enabled
         self.quiet_start = self.settings.quiet_start
         self.quiet_end = self.settings.quiet_end
+        self.minimize_to_tray = self.settings.minimize_to_tray
+        self.global_hotkeys_enabled = self.settings.global_hotkeys_enabled
+        self.speak_time_hotkey = self.settings.speak_time_hotkey
+        self.audio_device_name = self.settings.audio_device_name
 
         super().__init__()
 
@@ -68,16 +77,21 @@ class AccessiClockApp(wx.App):
 
     def _startup(self) -> None:
         self._init_services()
+        self._load_config()
         self._init_audio()
         self._init_tts()
-        self._load_config()
         self._sync_service_settings()
 
         from .ui.main_window import MainWindow
 
         self.main_window = MainWindow(self)
-        self.main_window.Show()
         self.SetTopWindow(self.main_window)
+        self._init_system_tray()
+        self._init_global_hotkeys()
+        if self.settings.start_minimized and self.system_tray_icon:
+            self.main_window.Hide()
+        else:
+            self.main_window.Show()
 
     def _init_services(self) -> None:
         self.clock_service = ClockService()
@@ -88,7 +102,10 @@ class AccessiClockApp(wx.App):
         try:
             from .audio.player import AudioPlayer
 
-            self.audio_player = AudioPlayer(volume_percent=self.current_volume)
+            self.audio_player = AudioPlayer(
+                volume_percent=self.current_volume,
+                audio_device_name=self.audio_device_name,
+            )
         except Exception:
             logger.warning("Audio player unavailable", exc_info=True)
             self.audio_player = None
@@ -142,6 +159,10 @@ class AccessiClockApp(wx.App):
         self.quiet_hours_enabled = self.settings.quiet_hours_enabled
         self.quiet_start = self.settings.quiet_start
         self.quiet_end = self.settings.quiet_end
+        self.minimize_to_tray = self.settings.minimize_to_tray
+        self.global_hotkeys_enabled = self.settings.global_hotkeys_enabled
+        self.speak_time_hotkey = self.settings.speak_time_hotkey
+        self.audio_device_name = self.settings.audio_device_name
 
         if self.clock_service and self.settings.quiet_hours_enabled:
             try:
@@ -188,6 +209,10 @@ class AccessiClockApp(wx.App):
                 "alarm_time": self.alarm_time,
                 "alarm_sound_enabled": self.alarm_sound_enabled,
                 "alarm_spoken_text": self.alarm_spoken_text,
+                "minimize_to_tray": self.minimize_to_tray,
+                "global_hotkeys_enabled": self.global_hotkeys_enabled,
+                "speak_time_hotkey": self.speak_time_hotkey,
+                "audio_device_name": self.audio_device_name,
             }
         )
         self.settings = AppSettings(
@@ -201,6 +226,27 @@ class AccessiClockApp(wx.App):
         if self.audio_player:
             self.audio_player.set_volume(self.current_volume)
         self.save_config()
+
+    def get_audio_output_devices(self) -> list[str]:
+        if not self.audio_player:
+            return ["Default system device"]
+        return self.audio_player.list_output_devices()
+
+    def set_audio_device(self, device_name: str) -> bool:
+        clean_name = device_name.strip()
+        if clean_name == "Default system device":
+            clean_name = ""
+        previous_name = self.audio_device_name
+        self.audio_device_name = clean_name
+        if self.audio_player:
+            try:
+                self.audio_player.set_output_device(clean_name)
+            except Exception:
+                self.audio_device_name = previous_name
+                logger.warning("Unable to switch audio device to %s", clean_name, exc_info=True)
+                return False
+        self.save_config()
+        return True
 
     def play_chime(self, chime_type: str) -> bool:
         if not self.audio_player or not self.clock_pack_loader:
@@ -258,6 +304,62 @@ class AccessiClockApp(wx.App):
         self.tts_engine.speak_time(datetime.now().time(), style=cast(TimeStyle, style))
         return True
 
+    def _init_system_tray(self) -> None:
+        try:
+            from .ui.system_tray import SystemTrayIcon
+
+            self.system_tray_icon = SystemTrayIcon(self)
+            logger.info("System tray icon initialized")
+        except Exception:
+            self.system_tray_icon = None
+            logger.warning("System tray icon unavailable", exc_info=True)
+
+    def _init_global_hotkeys(self) -> None:
+        if not self.main_window or not self.global_hotkeys_enabled:
+            return
+        try:
+            from .ui.global_hotkeys import GlobalHotkeyManager
+
+            self.global_hotkey_manager = GlobalHotkeyManager(self.main_window)
+            if self.global_hotkey_manager.register(
+                self.speak_time_hotkey,
+                self._announce_time_from_hotkey,
+            ):
+                logger.info("Registered global hotkey %s", self.speak_time_hotkey)
+            else:
+                logger.warning("Could not register global hotkey %s", self.speak_time_hotkey)
+        except Exception:
+            self.global_hotkey_manager = None
+            logger.warning("Global hotkey registration failed", exc_info=True)
+
+    def _announce_time_from_hotkey(self) -> None:
+        self.announce_time(style=self.config.get("announcement_style", "simple"))
+        if self.main_window:
+            self.main_window.set_status_from_app("Announced current time from global hotkey")
+
+    def refresh_global_hotkeys(self) -> None:
+        if self.global_hotkey_manager:
+            self.global_hotkey_manager.unregister()
+            self.global_hotkey_manager = None
+        self._init_global_hotkeys()
+
+    def should_minimize_to_tray(self) -> bool:
+        return bool(self.minimize_to_tray and self.system_tray_icon and not self._exiting)
+
+    def show_main_window(self) -> None:
+        if not self.main_window:
+            return
+        self.main_window.Show(True)
+        if self.main_window.IsIconized():
+            self.main_window.Iconize(False)
+        self.main_window.Raise()
+        self.main_window.SetFocus()
+
+    def request_exit(self) -> None:
+        self._exiting = True
+        if self.main_window:
+            self.main_window.Close(True)
+
     def check_and_play_chime(self, current_time: dt_time | None = None) -> str | None:
         if not self.clock_service:
             return None
@@ -301,6 +403,17 @@ class AccessiClockApp(wx.App):
     def OnExit(self) -> int:
         logger.info("Shutting down AccessiClock")
         self.save_config()
+
+        if self.global_hotkey_manager:
+            try:
+                self.global_hotkey_manager.unregister()
+            except Exception:
+                logger.warning("Global hotkey cleanup failed", exc_info=True)
+        if self.system_tray_icon:
+            try:
+                self.system_tray_icon.cleanup()
+            except Exception:
+                logger.warning("System tray cleanup failed", exc_info=True)
 
         if self.audio_player:
             try:

--- a/src/accessiclock/audio/player.py
+++ b/src/accessiclock/audio/player.py
@@ -44,7 +44,7 @@ class AudioPlayer:
     without blocking the UI thread. Falls back to playsound3 on non-Windows.
     """
 
-    def __init__(self, volume_percent: int = 50):
+    def __init__(self, volume_percent: int = 50, audio_device_name: str = ""):
         """
         Initialize AudioPlayer.
 
@@ -54,19 +54,13 @@ class AudioPlayer:
         global _bass_initialized
 
         self._current_stream: Any | None = None
+        self._audio_output: Any | None = None
+        self._audio_device_name = audio_device_name.strip()
         self._volume = self._clamp_volume(volume_percent)
 
         # Initialize BASS audio library if using sound_lib
-        if _use_sound_lib and not _bass_initialized:
-            try:
-                from sound_lib import output
-
-                output.Output()  # Initialize default output device
-                _bass_initialized = True
-                logger.info("BASS audio system initialized")
-            except Exception as e:
-                logger.error(f"Failed to initialize BASS audio system: {e}")
-                raise
+        if _use_sound_lib:
+            self._initialize_sound_lib_output(self._audio_device_name)
 
         logger.info(f"AudioPlayer initialized with volume {self._volume}%")
 
@@ -74,6 +68,68 @@ class AudioPlayer:
     def backend_name(self) -> str:
         """Return the active audio backend name."""
         return get_audio_backend_name()
+
+    def _initialize_sound_lib_output(self, device_name: str = "") -> None:
+        """Initialize sound_lib/BASS for the default or named output device."""
+        global _bass_initialized
+
+        try:
+            from sound_lib import output
+
+            self._audio_output = output.Output()
+            if device_name:
+                device_index = self._audio_output.find_user_provided_device(device_name)
+                self._audio_output.set_device(device_index)
+            self._audio_device_name = device_name
+            _bass_initialized = True
+            logger.info(
+                "BASS audio system initialized using %s",
+                device_name or "default system device",
+            )
+        except Exception as e:
+            logger.error(f"Failed to initialize BASS audio system: {e}")
+            raise
+
+    def list_output_devices(self) -> list[str]:
+        """Return available output devices for the current backend."""
+        devices = ["Default system device"]
+        if not _use_sound_lib:
+            return devices
+
+        try:
+            from sound_lib import output
+
+            for name in output.Output.get_device_names():
+                clean_name = str(name).strip()
+                if clean_name and clean_name.lower() != "default" and clean_name not in devices:
+                    devices.append(clean_name)
+        except Exception:
+            logger.warning("Unable to enumerate sound_lib output devices", exc_info=True)
+        return devices
+
+    def set_output_device(self, device_name: str) -> None:
+        """Switch to the default or named sound_lib output device."""
+        global _bass_initialized
+
+        clean_name = device_name.strip()
+        if clean_name == "Default system device":
+            clean_name = ""
+        if not _use_sound_lib:
+            self._audio_device_name = clean_name
+            return
+        if self._current_stream:
+            self.stop()
+        if self._audio_output:
+            try:
+                self._audio_output.free()
+            except Exception:
+                logger.debug("Ignoring error while freeing previous output", exc_info=True)
+        _bass_initialized = False
+        self._initialize_sound_lib_output(clean_name)
+
+    def get_output_device_name(self) -> str:
+        """Return the selected output device name, or blank for the default."""
+        return self._audio_device_name
 
     def _clamp_volume(self, volume_percent: int) -> int:
         """Clamp volume to valid range (0-100)."""
@@ -241,5 +297,11 @@ class AudioPlayer:
 
         # Reset BASS initialization flag
         if _use_sound_lib and _bass_initialized:
+            audio_output = getattr(self, "_audio_output", None)
+            if audio_output:
+                try:
+                    audio_output.free()
+                except Exception:
+                    logger.debug("Ignoring error while freeing output", exc_info=True)
             _bass_initialized = False
             logger.info("BASS audio system cleanup complete")

--- a/src/accessiclock/audio/player.py
+++ b/src/accessiclock/audio/player.py
@@ -8,7 +8,10 @@ Falls back to playsound3 on other platforms.
 from __future__ import annotations
 
 import logging
+import threading
+import time
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +31,11 @@ except Exception as e:
     logger.debug(f"sound_lib initialization failed: {e}")
 
 
+def get_audio_backend_name() -> str:
+    """Return a user-facing name for the active audio backend."""
+    return "sound_lib" if _use_sound_lib else "playsound3 fallback"
+
+
 class AudioPlayer:
     """
     Audio player for playing sound files with volume control.
@@ -45,7 +53,7 @@ class AudioPlayer:
         """
         global _bass_initialized
 
-        self._current_stream = None
+        self._current_stream: Any | None = None
         self._volume = self._clamp_volume(volume_percent)
 
         # Initialize BASS audio library if using sound_lib
@@ -61,6 +69,11 @@ class AudioPlayer:
                 raise
 
         logger.info(f"AudioPlayer initialized with volume {self._volume}%")
+
+    @property
+    def backend_name(self) -> str:
+        """Return the active audio backend name."""
+        return get_audio_backend_name()
 
     def _clamp_volume(self, volume_percent: int) -> int:
         """Clamp volume to valid range (0-100)."""
@@ -105,7 +118,38 @@ class AudioPlayer:
         else:
             self._play_with_fallback(path)
 
-    def _play_with_sound_lib(self, path: Path) -> None:
+    def play_sound_sequence(self, file_paths: list[str]) -> bool:
+        """
+        Play multiple audio files in order without blocking the UI thread.
+
+        Returns False when the sequence is empty. Missing files still raise
+        FileNotFoundError so callers can surface the pack problem.
+        """
+        paths = [Path(file_path) for file_path in file_paths]
+        if not paths:
+            return False
+        for path in paths:
+            if not path.exists():
+                logger.error("Audio file not found: %s", path)
+                raise FileNotFoundError(f"Audio file not found: {path}")
+
+        thread = threading.Thread(target=self._play_sequence_worker, args=(paths,), daemon=True)
+        thread.start()
+        return True
+
+    def _play_sequence_worker(self, paths: list[Path]) -> None:
+        """Worker thread used for ordered chime sequences."""
+        for path in paths:
+            try:
+                if _use_sound_lib:
+                    self._play_with_sound_lib(path, block=True)
+                else:
+                    self._play_with_fallback_blocking(path)
+            except Exception:
+                logger.warning("Stopping sound sequence after playback failure", exc_info=True)
+                return
+
+    def _play_with_sound_lib(self, path: Path, *, block: bool = False) -> None:
         """Play audio using sound_lib (Windows)."""
         try:
             # Stop any currently playing sound
@@ -113,9 +157,15 @@ class AudioPlayer:
                 self.stop()
 
             logger.info(f"Playing audio file: {path}")
-            self._current_stream = stream.FileStream(file=str(path))
-            self._current_stream.volume = self._convert_volume_to_decimal(self._volume)
-            self._current_stream.play()
+            current_stream = stream.FileStream(file=str(path))
+            self._current_stream = current_stream
+            current_stream.volume = self._convert_volume_to_decimal(self._volume)
+            current_stream.play()
+            if block:
+                while current_stream.is_playing:
+                    time.sleep(0.05)
+                current_stream.free()
+                self._current_stream = None
 
         except Exception as e:
             logger.error(f"Error playing audio file {path}: {e}")
@@ -140,6 +190,20 @@ class AudioPlayer:
             logger.error(f"Error playing audio file {path}: {e}")
             raise
 
+    def _play_with_fallback_blocking(self, path: Path) -> None:
+        """Play audio synchronously with the fallback backend."""
+        try:
+            from playsound3 import playsound
+
+            logger.info("Playing audio file in sequence (fallback): %s", path)
+            playsound(str(path))
+        except ImportError:
+            logger.error("playsound3 not installed, cannot play audio")
+            raise
+        except Exception as e:
+            logger.error(f"Error playing audio file {path}: {e}")
+            raise
+
     def stop(self) -> None:
         """Stop currently playing audio."""
         if _use_sound_lib and self._current_stream:
@@ -156,7 +220,7 @@ class AudioPlayer:
         """Check if audio is currently playing."""
         if _use_sound_lib and self._current_stream:
             try:
-                return self._current_stream.is_playing
+                return bool(self._current_stream.is_playing)
             except Exception:
                 return False
         return False

--- a/src/accessiclock/audio/tts_engine.py
+++ b/src/accessiclock/audio/tts_engine.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import contextlib
 import logging
 from datetime import date, time
-from typing import Literal
+from typing import Any, Literal
 
 from ..constants import TTS_RATE_DEFAULT, TTS_RATE_MAX, TTS_RATE_MIN
 
@@ -48,7 +48,7 @@ class TTSEngine:
             force_dummy: Force use of dummy engine (for testing).
         """
         self._rate = self._clamp_rate(rate)
-        self._engine = None
+        self._engine: Any | None = None
         self._voice_id: str | None = None
         
         if force_dummy or not _PYTTSX3_AVAILABLE:
@@ -89,6 +89,9 @@ class TTSEngine:
         """
         if self.engine_type == "dummy":
             logger.debug(f"Dummy TTS: {text}")
+            return
+        if self._engine is None:
+            logger.debug("TTS engine unavailable: %s", text)
             return
 
         try:

--- a/src/accessiclock/clocks/default/clock.json
+++ b/src/accessiclock/clocks/default/clock.json
@@ -8,6 +8,8 @@
     "half_hour": "half_hour.wav",
     "quarter_hour": "quarter_hour.wav",
     "preview": "preview.wav",
-    "startup": "startup.wav"
+    "startup": "startup.wav",
+    "alarm": "startup.wav",
+    "tick": "quarter_hour.wav"
   }
 }

--- a/src/accessiclock/clocks/digital/clock.json
+++ b/src/accessiclock/clocks/digital/clock.json
@@ -4,9 +4,12 @@
   "description": "Simple digital beeps and tones for a modern, minimal clock experience.",
   "version": "1.0.0",
   "sounds": {
-    "hour": "hour_beep.wav",
-    "half_hour": "half_beep.wav",
-    "quarter_hour": "quarter_beep.wav",
-    "preview": "preview.wav"
+    "hour": "hour.wav",
+    "half_hour": "half_hour.wav",
+    "quarter_hour": "quarter_hour.wav",
+    "preview": "preview.wav",
+    "startup": "startup.wav",
+    "alarm": "startup.wav",
+    "tick": "quarter_hour.wav"
   }
 }

--- a/src/accessiclock/clocks/westminster/clock.json
+++ b/src/accessiclock/clocks/westminster/clock.json
@@ -6,8 +6,10 @@
   "sounds": {
     "hour": "hour.wav",
     "half_hour": "half_hour.wav",
-    "quarter_hour": "quarter.wav",
-    "three_quarter": "three_quarter.wav",
-    "preview": "preview.wav"
+    "quarter_hour": "quarter_hour.wav",
+    "preview": "preview.wav",
+    "startup": "startup.wav",
+    "alarm": "startup.wav",
+    "tick": "quarter_hour.wav"
   }
 }

--- a/src/accessiclock/constants.py
+++ b/src/accessiclock/constants.py
@@ -51,4 +51,5 @@ OPTIONAL_CLOCK_SOUNDS = [
     "three_quarter",
     "startup",
     "alarm",
+    "tick",
 ]

--- a/src/accessiclock/core/__init__.py
+++ b/src/accessiclock/core/__init__.py
@@ -1,0 +1,13 @@
+"""Core scaffolding for AccessiClock wxPython app."""
+
+from .settings import AppSettings, load_settings, save_settings
+from .shortcuts import Shortcut, build_shortcut_help, default_shortcuts
+
+__all__ = [
+    "AppSettings",
+    "Shortcut",
+    "build_shortcut_help",
+    "default_shortcuts",
+    "load_settings",
+    "save_settings",
+]

--- a/src/accessiclock/core/logging_setup.py
+++ b/src/accessiclock/core/logging_setup.py
@@ -1,0 +1,28 @@
+"""Logging bootstrap for AccessiClock."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+
+def configure_logging(logs_dir: Path, level: int = logging.INFO) -> Path:
+    """Configure root logging to file + console and return log file path."""
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    log_file = logs_dir / "accessiclock.log"
+
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.setLevel(level)
+
+    formatter = logging.Formatter("%(asctime)s %(levelname)s [%(name)s] %(message)s")
+
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    root_logger.addHandler(file_handler)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+    root_logger.addHandler(console_handler)
+
+    return log_file

--- a/src/accessiclock/core/settings.py
+++ b/src/accessiclock/core/settings.py
@@ -1,0 +1,66 @@
+"""Settings I/O and simple validation for AccessiClock."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass
+class AppSettings:
+    """Persistent user settings used by the app."""
+
+    volume: int = 50
+    clock: str = "default"
+    chime_hourly: bool = True
+    chime_half_hour: bool = False
+    chime_quarter_hour: bool = False
+    quiet_hours_enabled: bool = False
+    quiet_start: str = "22:00"
+    quiet_end: str = "07:00"
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> AppSettings:
+        """Build settings from plain dict with safe defaults."""
+        settings = cls(
+            volume=_clamp_volume(raw.get("volume", 50)),
+            clock=str(raw.get("clock", "default") or "default"),
+            chime_hourly=bool(raw.get("chime_hourly", True)),
+            chime_half_hour=bool(raw.get("chime_half_hour", False)),
+            chime_quarter_hour=bool(raw.get("chime_quarter_hour", False)),
+            quiet_hours_enabled=bool(raw.get("quiet_hours_enabled", False)),
+            quiet_start=str(raw.get("quiet_start", "22:00")),
+            quiet_end=str(raw.get("quiet_end", "07:00")),
+        )
+        return settings
+
+    def to_dict(self) -> dict:
+        """Serialize settings to plain dict."""
+        return asdict(self)
+
+
+def _clamp_volume(value: object) -> int:
+    try:
+        return max(0, min(100, int(value)))
+    except (TypeError, ValueError):
+        return 50
+
+
+def load_settings(config_file: Path) -> AppSettings:
+    """Load settings from config file. Returns defaults on errors."""
+    if not config_file.exists():
+        return AppSettings()
+
+    try:
+        with open(config_file, encoding="utf-8") as handle:
+            return AppSettings.from_dict(json.load(handle))
+    except (OSError, json.JSONDecodeError, TypeError):
+        return AppSettings()
+
+
+def save_settings(config_file: Path, settings: AppSettings) -> None:
+    """Save settings to disk, creating parent directories as needed."""
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_file, "w", encoding="utf-8") as handle:
+        json.dump(settings.to_dict(), handle, indent=2)

--- a/src/accessiclock/core/settings.py
+++ b/src/accessiclock/core/settings.py
@@ -37,6 +37,10 @@ class AppSettings:
     announce_on_focus: bool = False
     speech_rate: int = 150
     announcement_style: str = "simple"
+    minimize_to_tray: bool = False
+    global_hotkeys_enabled: bool = False
+    speak_time_hotkey: str = "Ctrl+Alt+T"
+    audio_device_name: str = ""
     debug_logging: bool = False
 
     @classmethod
@@ -67,6 +71,10 @@ class AppSettings:
             announcement_style=_valid_choice(
                 raw.get("announcement_style"), VALID_ANNOUNCEMENT_STYLES, "simple"
             ),
+            minimize_to_tray=bool(raw.get("minimize_to_tray", False)),
+            global_hotkeys_enabled=bool(raw.get("global_hotkeys_enabled", False)),
+            speak_time_hotkey=_non_blank_string(raw.get("speak_time_hotkey"), "Ctrl+Alt+T"),
+            audio_device_name=_optional_string(raw.get("audio_device_name", "")),
             debug_logging=bool(raw.get("debug_logging", False)),
         )
         return settings
@@ -92,6 +100,15 @@ def _valid_choice(value: object, choices: set[str], default: str) -> str:
     if choice in choices:
         return choice
     return default
+
+
+def _non_blank_string(value: object, default: str) -> str:
+    text = str(value or "").strip()
+    return text or default
+
+
+def _optional_string(value: object) -> str:
+    return str(value or "").strip()
 
 
 def _time_string(value: object, default: str) -> str:

--- a/src/accessiclock/core/settings.py
+++ b/src/accessiclock/core/settings.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Any
+
+VALID_CHIME_STYLES = {"classic", "grandfather"}
+VALID_ANNOUNCEMENT_STYLES = {"simple", "natural", "precise"}
 
 
 @dataclass
@@ -16,9 +20,24 @@ class AppSettings:
     chime_hourly: bool = True
     chime_half_hour: bool = False
     chime_quarter_hour: bool = False
+    chime_style: str = "classic"
+    hour_count_chimes: bool = False
+    minute_tick: bool = False
     quiet_hours_enabled: bool = False
     quiet_start: str = "22:00"
     quiet_end: str = "07:00"
+    alarm_enabled: bool = False
+    alarm_time: str = "07:00"
+    alarm_sound_enabled: bool = True
+    alarm_spoken_text: str = "Time to get up"
+    time_format: str = "12h"
+    start_minimized: bool = False
+    start_with_windows: bool = False
+    play_startup_sound: bool = True
+    announce_on_focus: bool = False
+    speech_rate: int = 150
+    announcement_style: str = "simple"
+    debug_logging: bool = False
 
     @classmethod
     def from_dict(cls, raw: dict) -> AppSettings:
@@ -29,9 +48,26 @@ class AppSettings:
             chime_hourly=bool(raw.get("chime_hourly", True)),
             chime_half_hour=bool(raw.get("chime_half_hour", False)),
             chime_quarter_hour=bool(raw.get("chime_quarter_hour", False)),
+            chime_style=_valid_choice(raw.get("chime_style"), VALID_CHIME_STYLES, "classic"),
+            hour_count_chimes=bool(raw.get("hour_count_chimes", False)),
+            minute_tick=bool(raw.get("minute_tick", False)),
             quiet_hours_enabled=bool(raw.get("quiet_hours_enabled", False)),
-            quiet_start=str(raw.get("quiet_start", "22:00")),
-            quiet_end=str(raw.get("quiet_end", "07:00")),
+            quiet_start=_time_string(raw.get("quiet_start", "22:00"), "22:00"),
+            quiet_end=_time_string(raw.get("quiet_end", "07:00"), "07:00"),
+            alarm_enabled=bool(raw.get("alarm_enabled", False)),
+            alarm_time=_time_string(raw.get("alarm_time", "07:00"), "07:00"),
+            alarm_sound_enabled=bool(raw.get("alarm_sound_enabled", True)),
+            alarm_spoken_text=str(raw.get("alarm_spoken_text", "Time to get up") or "Time to get up"),
+            time_format=_valid_choice(raw.get("time_format"), {"12h", "24h"}, "12h"),
+            start_minimized=bool(raw.get("start_minimized", False)),
+            start_with_windows=bool(raw.get("start_with_windows", False)),
+            play_startup_sound=bool(raw.get("play_startup_sound", True)),
+            announce_on_focus=bool(raw.get("announce_on_focus", False)),
+            speech_rate=_clamp_int(raw.get("speech_rate", 150), 50, 300, 150),
+            announcement_style=_valid_choice(
+                raw.get("announcement_style"), VALID_ANNOUNCEMENT_STYLES, "simple"
+            ),
+            debug_logging=bool(raw.get("debug_logging", False)),
         )
         return settings
 
@@ -41,10 +77,36 @@ class AppSettings:
 
 
 def _clamp_volume(value: object) -> int:
+    return _clamp_int(value, 0, 100, 50)
+
+
+def _clamp_int(value: Any, minimum: int, maximum: int, default: int) -> int:
     try:
-        return max(0, min(100, int(value)))
+        return max(minimum, min(maximum, int(value)))
     except (TypeError, ValueError):
-        return 50
+        return default
+
+
+def _valid_choice(value: object, choices: set[str], default: str) -> str:
+    choice = str(value or default)
+    if choice in choices:
+        return choice
+    return default
+
+
+def _time_string(value: object, default: str) -> str:
+    text = str(value or default)
+    parts = text.split(":")
+    if len(parts) != 2:
+        return default
+    try:
+        hour = int(parts[0])
+        minute = int(parts[1])
+    except ValueError:
+        return default
+    if 0 <= hour <= 23 and 0 <= minute <= 59:
+        return f"{hour:02d}:{minute:02d}"
+    return default
 
 
 def load_settings(config_file: Path) -> AppSettings:

--- a/src/accessiclock/core/shortcuts.py
+++ b/src/accessiclock/core/shortcuts.py
@@ -1,0 +1,27 @@
+"""Keyboard shortcut map for AccessiClock UI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Shortcut:
+    keys: str
+    action: str
+
+
+def default_shortcuts() -> list[Shortcut]:
+    """Return current keyboard shortcut map."""
+    return [
+        Shortcut("F5", "Test chime"),
+        Shortcut("Space", "Announce current time"),
+        Shortcut("Ctrl+,", "Open settings"),
+        Shortcut("Alt+F4", "Exit application"),
+        Shortcut("Tab / Shift+Tab", "Move focus between controls"),
+    ]
+
+
+def build_shortcut_help() -> str:
+    """Create readable help text for the status line / docs."""
+    return " | ".join(f"{s.keys}: {s.action}" for s in default_shortcuts())

--- a/src/accessiclock/core/shortcuts.py
+++ b/src/accessiclock/core/shortcuts.py
@@ -17,6 +17,8 @@ def default_shortcuts() -> list[Shortcut]:
         Shortcut("F5", "Test chime"),
         Shortcut("Space", "Announce current time"),
         Shortcut("Ctrl+,", "Open settings"),
+        Shortcut("Ctrl+D", "Choose audio output device"),
+        Shortcut("Ctrl+Alt+T", "Global hotkey to announce current time when enabled"),
         Shortcut("Alt+F4", "Exit application"),
         Shortcut("Tab / Shift+Tab", "Move focus between controls"),
     ]

--- a/src/accessiclock/main.py
+++ b/src/accessiclock/main.py
@@ -1,30 +1,47 @@
 """Main entry point for AccessiClock."""
 
+from __future__ import annotations
+
+import argparse
 import logging
 import sys
 
+from .core.logging_setup import configure_logging
+from .paths import Paths
 
-def main() -> int:
-    """Run the AccessiClock application."""
-    # Configure logging
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        handlers=[logging.StreamHandler(sys.stdout)],
+logger = logging.getLogger(__name__)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="AccessiClock")
+    parser.add_argument(
+        "--portable",
+        action="store_true",
+        help="Store config and logs beside the app (portable mode)",
     )
-    logger = logging.getLogger(__name__)
-    logger.info("Starting AccessiClock")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the AccessiClock application."""
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+
+    paths = Paths(portable_mode=args.portable)
+    log_file = configure_logging(paths.logs_dir)
+    logger.info("Starting AccessiClock (portable=%s)", args.portable)
+    logger.info("Logging to %s", log_file)
 
     try:
         from accessiclock.app import AccessiClockApp
 
-        app = AccessiClockApp()
+        app = AccessiClockApp(portable_mode=args.portable)
         app.MainLoop()
+        logger.info("AccessiClock exited cleanly")
         return 0
-    except Exception as e:
-        logger.exception(f"Failed to start AccessiClock: {e}")
+    except Exception:
+        logger.exception("Failed to start AccessiClock")
         return 1
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main())

--- a/src/accessiclock/services/clock_service.py
+++ b/src/accessiclock/services/clock_service.py
@@ -3,12 +3,22 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from datetime import time
 from typing import Literal
 
 logger = logging.getLogger(__name__)
 
-ChimeType = Literal["hour", "half_hour", "quarter_hour"]
+ChimeType = Literal["hour", "half_hour", "quarter_hour", "tick"]
+ChimeStyle = Literal["classic", "grandfather"]
+
+
+@dataclass(frozen=True)
+class AlarmEvent:
+    """A due alarm action with optional sound and spoken text."""
+
+    sound_name: str | None
+    spoken_text: str | None
 
 
 class ClockService:
@@ -27,13 +37,22 @@ class ClockService:
         self.chime_hourly: bool = True
         self.chime_half_hour: bool = False
         self.chime_quarter_hour: bool = False
-        
+        self.chime_style: ChimeStyle = "classic"
+        self.hour_count_chimes: bool = False
+        self.minute_tick: bool = False
+
         # Quiet hours (None = disabled)
         self.quiet_start: time | None = None
         self.quiet_end: time | None = None
-        
+
+        # Alarm settings. Quiet hours intentionally do not suppress alarms.
+        self.alarm_time: time | None = None
+        self.alarm_spoken_text: str = "Time to get up"
+        self.alarm_sound_enabled: bool = True
+
         # Track last chime to prevent repeats
         self._last_chime_minute: tuple[int, int] | None = None  # (hour, minute)
+        self._last_alarm_minute: tuple[int, int] | None = None
 
     def should_chime_now(self, current_time: time) -> ChimeType | None:
         """
@@ -48,32 +67,74 @@ class ClockService:
         # Check quiet hours
         if self._is_quiet_time(current_time):
             return None
-        
+
         # Check if we already chimed this minute
         current_minute = (current_time.hour, current_time.minute)
         if self._last_chime_minute == current_minute:
             return None
-        
+
+        return self._get_interval_chime_type(current_time)
+
+    def get_chime_sequence(self, current_time: time) -> list[ChimeType]:
+        """
+        Build the scheduled sound sequence for the given time.
+
+        This supports talking-clock behavior inspired by classic accessible
+        clocks: optional minute ticks, quarter-position counts, and hour-count
+        chimes. Manual commands such as "announce time now" bypass this schedule.
+        """
+        if self._is_quiet_time(current_time):
+            return []
+
+        current_minute = (current_time.hour, current_time.minute)
+        if self._last_chime_minute == current_minute:
+            return []
+
+        sequence: list[ChimeType] = []
+        if self.minute_tick:
+            sequence.append("tick")
+
+        chime_type = self._get_interval_chime_type(current_time)
+        if chime_type:
+            sequence.extend(self._expand_chime(chime_type, current_time))
+
+        return sequence
+
+    def _get_interval_chime_type(self, current_time: time) -> ChimeType | None:
+        """Return the scheduled interval chime type, ignoring tick sounds."""
         minute = current_time.minute
-        
+
         # Check intervals in priority order
         if minute == 0 and self.chime_hourly:
             return "hour"
-        
+
         if minute == 30 and self.chime_half_hour:
             return "half_hour"
-        
+
         if minute in (15, 45) and self.chime_quarter_hour:
             return "quarter_hour"
-        
+
         # Also check 0 and 30 for quarter hour if half_hour not enabled
         if minute == 0 and self.chime_quarter_hour and not self.chime_hourly:
             return "quarter_hour"
-        
+
         if minute == 30 and self.chime_quarter_hour and not self.chime_half_hour:
             return "quarter_hour"
-        
+
         return None
+
+    def _expand_chime(self, chime_type: ChimeType, current_time: time) -> list[ChimeType]:
+        """Expand one logical chime into the configured audible sequence."""
+        if chime_type == "hour" and self.hour_count_chimes:
+            return ["hour"] * self.get_hour_12h(current_time)
+
+        if chime_type == "quarter_hour" and self.chime_style == "grandfather":
+            quarter_count = current_time.minute // 15
+            if quarter_count == 0:
+                quarter_count = 4
+            return ["quarter_hour"] * quarter_count
+
+        return [chime_type]
 
     def mark_chimed(self, current_time: time) -> None:
         """
@@ -147,3 +208,50 @@ class ClockService:
     def reset_chime_tracking(self) -> None:
         """Reset the chime tracking (e.g., after settings change)."""
         self._last_chime_minute = None
+
+    @property
+    def alarm_enabled(self) -> bool:
+        """Return whether an alarm time is configured."""
+        return self.alarm_time is not None
+
+    @alarm_enabled.setter
+    def alarm_enabled(self, value: bool) -> None:
+        """Disable the alarm when set to False."""
+        if not value:
+            self.alarm_time = None
+
+    def set_alarm(
+        self,
+        alarm_time: time,
+        *,
+        spoken_text: str = "Time to get up",
+        sound_enabled: bool = True,
+    ) -> None:
+        """Configure the daily alarm."""
+        self.alarm_time = alarm_time
+        self.alarm_spoken_text = spoken_text.strip() or "Time to get up"
+        self.alarm_sound_enabled = sound_enabled
+
+    def get_due_alarm(self, current_time: time) -> AlarmEvent | None:
+        """Return the due alarm event for the current minute, if any."""
+        if not self.alarm_time:
+            return None
+
+        current_minute = (current_time.hour, current_time.minute)
+        if self._last_alarm_minute == current_minute:
+            return None
+
+        if (
+            current_time.hour != self.alarm_time.hour
+            or current_time.minute != self.alarm_time.minute
+        ):
+            return None
+
+        return AlarmEvent(
+            sound_name="alarm" if self.alarm_sound_enabled else None,
+            spoken_text=self.alarm_spoken_text,
+        )
+
+    def mark_alarmed(self, current_time: time) -> None:
+        """Mark the alarm handled for the current minute."""
+        self._last_alarm_minute = (current_time.hour, current_time.minute)

--- a/src/accessiclock/ui/dialogs/__init__.py
+++ b/src/accessiclock/ui/dialogs/__init__.py
@@ -1,6 +1,7 @@
 """Dialog windows for AccessiClock."""
 
+from .audio_device_dialog import AudioDeviceDialog
 from .clock_manager_dialog import ClockManagerDialog
 from .settings_dialog import SettingsDialog
 
-__all__ = ["SettingsDialog", "ClockManagerDialog"]
+__all__ = ["AudioDeviceDialog", "SettingsDialog", "ClockManagerDialog"]

--- a/src/accessiclock/ui/dialogs/audio_device_dialog.py
+++ b/src/accessiclock/ui/dialogs/audio_device_dialog.py
@@ -1,0 +1,68 @@
+"""Audio output device picker dialog."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import wx
+
+if TYPE_CHECKING:
+    from ...app import AccessiClockApp
+
+
+class AudioDeviceDialog(wx.Dialog):
+    """Keyboard-friendly dialog for choosing the sound_lib output device."""
+
+    def __init__(self, parent: wx.Window, app: AccessiClockApp):
+        super().__init__(
+            parent,
+            title="Audio Device",
+            size=(460, 220),
+            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
+        )
+        self.app = app
+        self._create_widgets()
+        self.CentreOnParent()
+
+    def _create_widgets(self) -> None:
+        panel = wx.Panel(self)
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+
+        label = wx.StaticText(panel, label="Audio output device:")
+        main_sizer.Add(label, 0, wx.ALL, 10)
+
+        choices = self.app.get_audio_output_devices()
+        self.device_choice = wx.Choice(panel, choices=choices, name="Audio output device")
+        current_name = self.app.audio_device_name or "Default system device"
+        if current_name in choices:
+            self.device_choice.SetSelection(choices.index(current_name))
+        elif choices:
+            self.device_choice.SetSelection(0)
+        main_sizer.Add(self.device_choice, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
+
+        self.test_button = wx.Button(panel, label="&Test Device")
+        main_sizer.Add(self.test_button, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
+
+        buttons = wx.StdDialogButtonSizer()
+        ok_btn = wx.Button(panel, wx.ID_OK, "OK")
+        ok_btn.SetDefault()
+        cancel_btn = wx.Button(panel, wx.ID_CANCEL, "Cancel")
+        buttons.AddButton(ok_btn)
+        buttons.AddButton(cancel_btn)
+        buttons.Realize()
+        main_sizer.Add(buttons, 0, wx.ALIGN_RIGHT | wx.ALL, 10)
+
+        panel.SetSizer(main_sizer)
+        self.test_button.Bind(wx.EVT_BUTTON, self._on_test_device)
+
+    def get_selected_device_name(self) -> str:
+        value = self.device_choice.GetStringSelection()
+        return "" if value == "Default system device" else value
+
+    def _on_test_device(self, event: wx.CommandEvent) -> None:
+        previous = self.app.audio_device_name
+        selected = self.get_selected_device_name()
+        if self.app.set_audio_device(selected):
+            self.app.play_test_sound()
+        self.app.set_audio_device(previous)
+

--- a/src/accessiclock/ui/dialogs/settings_dialog.py
+++ b/src/accessiclock/ui/dialogs/settings_dialog.py
@@ -8,9 +8,11 @@ voice settings, quiet hours, and display options.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import wx
+
+from ...audio.tts_engine import TimeStyle
 
 if TYPE_CHECKING:
     from ...app import AccessiClockApp
@@ -157,12 +159,11 @@ class SettingsDialog(wx.Dialog):
         # Get available voices
         voices = []
         if self.app.tts_engine:
-            voices = self.app.tts_engine.list_voices()
+            voices = [voice["name"] for voice in self.app.tts_engine.list_voices()]
         if not voices:
             voices = ["(Default system voice)"]
         
         self.voice_choice = wx.Choice(panel, choices=voices)
-        self.voice_choice.SetName("Voice")
         self.voice_choice.SetSelection(0)
         sizer.Add(self.voice_choice, 0, wx.EXPAND | wx.ALL, 10)
         
@@ -175,7 +176,6 @@ class SettingsDialog(wx.Dialog):
             panel, value=150, minValue=50, maxValue=300,
             style=wx.SL_HORIZONTAL | wx.SL_VALUE_LABEL
         )
-        self.rate_slider.SetName("Speech rate")
         rate_sizer.Add(self.rate_slider, 1, wx.EXPAND)
         sizer.Add(rate_sizer, 0, wx.EXPAND | wx.ALL, 10)
         
@@ -222,44 +222,40 @@ class SettingsDialog(wx.Dialog):
         
         # Start time
         start_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        start_label = wx.StaticText(panel, label="Start:")
+        start_label = wx.StaticText(panel, label="Start hour:")
         start_sizer.Add(start_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
         
         self.quiet_start_hour = wx.SpinCtrl(
             panel, min=0, max=23, initial=22, size=(60, -1)
         )
-        self.quiet_start_hour.SetName("Quiet hours start hour")
         start_sizer.Add(self.quiet_start_hour, 0, wx.RIGHT, 5)
         
-        start_colon = wx.StaticText(panel, label=":")
-        start_sizer.Add(start_colon, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        start_minute_label = wx.StaticText(panel, label="Start minute:")
+        start_sizer.Add(start_minute_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
         
         self.quiet_start_min = wx.SpinCtrl(
             panel, min=0, max=59, initial=0, size=(60, -1)
         )
-        self.quiet_start_min.SetName("Quiet hours start minute")
         start_sizer.Add(self.quiet_start_min, 0)
         
         time_sizer.Add(start_sizer, 0, wx.ALL, 5)
         
         # End time
         end_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        end_label = wx.StaticText(panel, label="End:")
+        end_label = wx.StaticText(panel, label="End hour:")
         end_sizer.Add(end_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
         
         self.quiet_end_hour = wx.SpinCtrl(
             panel, min=0, max=23, initial=7, size=(60, -1)
         )
-        self.quiet_end_hour.SetName("Quiet hours end hour")
         end_sizer.Add(self.quiet_end_hour, 0, wx.RIGHT, 5)
         
-        end_colon = wx.StaticText(panel, label=":")
-        end_sizer.Add(end_colon, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        end_minute_label = wx.StaticText(panel, label="End minute:")
+        end_sizer.Add(end_minute_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
         
         self.quiet_end_min = wx.SpinCtrl(
             panel, min=0, max=59, initial=0, size=(60, -1)
         )
-        self.quiet_end_min.SetName("Quiet hours end minute")
         end_sizer.Add(self.quiet_end_min, 0)
         
         time_sizer.Add(end_sizer, 0, wx.ALL, 5)
@@ -423,7 +419,7 @@ class SettingsDialog(wx.Dialog):
         
         # Update app state
         if self.app.tts_engine:
-            self.app.tts_engine.set_rate(config["speech_rate"])
+            self.app.tts_engine.rate = config["speech_rate"]
         
         if self.app.clock_service:
             if config["quiet_hours_enabled"]:
@@ -434,8 +430,12 @@ class SettingsDialog(wx.Dialog):
                     time(start_h, start_m),
                     time(end_h, end_m)
                 )
+                self.app.quiet_hours_enabled = True
             else:
                 self.app.clock_service.quiet_hours_enabled = False
+                self.app.quiet_hours_enabled = False
+            self.app.quiet_start = config["quiet_start"]
+            self.app.quiet_end = config["quiet_end"]
         
         # Save to file
         self.app.save_config()
@@ -477,7 +477,7 @@ class SettingsDialog(wx.Dialog):
         if self.app.tts_engine:
             # Temporarily apply rate
             rate = self.rate_slider.GetValue()
-            self.app.tts_engine.set_rate(rate)
+            self.app.tts_engine.rate = rate
             
             # Get style
             if self.style_simple.GetValue():
@@ -488,7 +488,9 @@ class SettingsDialog(wx.Dialog):
                 style = "precise"
             
             from datetime import datetime
-            self.app.tts_engine.speak_time(datetime.now().time(), style=style)
+            self.app.tts_engine.speak_time(
+                datetime.now().time(), style=cast(TimeStyle, style)
+            )
         else:
             wx.MessageBox(
                 "TTS engine is not available.",

--- a/src/accessiclock/ui/dialogs/settings_dialog.py
+++ b/src/accessiclock/ui/dialogs/settings_dialog.py
@@ -130,13 +130,33 @@ class SettingsDialog(wx.Dialog):
         startup_sizer = wx.StaticBoxSizer(startup_box, wx.VERTICAL)
         
         self.start_minimized = wx.CheckBox(panel, label="Start minimized to tray")
+        self.minimize_to_tray = wx.CheckBox(panel, label="Minimize to tray when closing")
         self.start_with_windows = wx.CheckBox(panel, label="Start with Windows")
         self.play_startup_sound = wx.CheckBox(panel, label="Play startup sound")
         
         startup_sizer.Add(self.start_minimized, 0, wx.ALL, 5)
+        startup_sizer.Add(self.minimize_to_tray, 0, wx.ALL, 5)
         startup_sizer.Add(self.start_with_windows, 0, wx.ALL, 5)
         startup_sizer.Add(self.play_startup_sound, 0, wx.ALL, 5)
         sizer.Add(startup_sizer, 0, wx.EXPAND | wx.ALL, 10)
+
+        hotkey_box = wx.StaticBox(panel, label="Global Hotkey")
+        hotkey_sizer = wx.StaticBoxSizer(hotkey_box, wx.VERTICAL)
+        self.global_hotkeys_enabled = wx.CheckBox(
+            panel, label="Enable global hotkey to announce the time"
+        )
+        hotkey_sizer.Add(self.global_hotkeys_enabled, 0, wx.ALL, 5)
+        self.hotkey_label = wx.StaticText(panel, label="Current global hotkey: Ctrl+Alt+T")
+        hotkey_sizer.Add(self.hotkey_label, 0, wx.ALL, 5)
+        sizer.Add(hotkey_sizer, 0, wx.EXPAND | wx.ALL, 10)
+
+        audio_box = wx.StaticBox(panel, label="Audio Output")
+        audio_sizer = wx.StaticBoxSizer(audio_box, wx.VERTICAL)
+        self.audio_device_label = wx.StaticText(panel, label="Audio output: Default system device")
+        audio_sizer.Add(self.audio_device_label, 0, wx.ALL, 5)
+        self.audio_device_btn = wx.Button(panel, label="Choose Audio Device...")
+        audio_sizer.Add(self.audio_device_btn, 0, wx.ALL, 5)
+        sizer.Add(audio_sizer, 0, wx.EXPAND | wx.ALL, 10)
         
         # Announce on focus
         self.announce_on_focus = wx.CheckBox(
@@ -328,12 +348,14 @@ class SettingsDialog(wx.Dialog):
         self.Bind(wx.EVT_BUTTON, self._on_apply, id=wx.ID_APPLY)
         
         self.test_voice_btn.Bind(wx.EVT_BUTTON, self._on_test_voice)
+        self.audio_device_btn.Bind(wx.EVT_BUTTON, self._on_audio_device)
         self.open_logs_btn.Bind(wx.EVT_BUTTON, self._on_open_logs)
         self.reset_btn.Bind(wx.EVT_BUTTON, self._on_reset)
         
         # Track changes
         for ctrl in [self.format_12h, self.format_24h, self.start_minimized,
-                     self.start_with_windows, self.play_startup_sound,
+                     self.minimize_to_tray, self.start_with_windows, self.play_startup_sound,
+                     self.global_hotkeys_enabled,
                      self.announce_on_focus, self.voice_choice, self.rate_slider,
                      self.style_simple, self.style_natural, self.style_precise,
                      self.quiet_hours_enabled, self.quiet_start_hour,
@@ -357,9 +379,17 @@ class SettingsDialog(wx.Dialog):
         
         # Startup options
         self.start_minimized.SetValue(config.get("start_minimized", False))
+        self.minimize_to_tray.SetValue(config.get("minimize_to_tray", False))
         self.start_with_windows.SetValue(config.get("start_with_windows", False))
         self.play_startup_sound.SetValue(config.get("play_startup_sound", True))
         self.announce_on_focus.SetValue(config.get("announce_on_focus", False))
+        self.global_hotkeys_enabled.SetValue(config.get("global_hotkeys_enabled", False))
+        self.hotkey_label.SetLabel(
+            f"Current global hotkey: {config.get('speak_time_hotkey', 'Ctrl+Alt+T')}"
+        )
+        self.audio_device_label.SetLabel(
+            f"Audio output: {config.get('audio_device_name') or 'Default system device'}"
+        )
         
         # Voice settings
         if self.app.tts_engine:
@@ -395,9 +425,13 @@ class SettingsDialog(wx.Dialog):
         
         # Startup options
         config["start_minimized"] = self.start_minimized.GetValue()
+        config["minimize_to_tray"] = self.minimize_to_tray.GetValue()
         config["start_with_windows"] = self.start_with_windows.GetValue()
         config["play_startup_sound"] = self.play_startup_sound.GetValue()
         config["announce_on_focus"] = self.announce_on_focus.GetValue()
+        config["global_hotkeys_enabled"] = self.global_hotkeys_enabled.GetValue()
+        config["speak_time_hotkey"] = self.app.speak_time_hotkey
+        config["audio_device_name"] = self.app.audio_device_name
         
         # Voice settings
         config["speech_rate"] = self.rate_slider.GetValue()
@@ -420,6 +454,10 @@ class SettingsDialog(wx.Dialog):
         # Update app state
         if self.app.tts_engine:
             self.app.tts_engine.rate = config["speech_rate"]
+
+        self.app.minimize_to_tray = config["minimize_to_tray"]
+        self.app.global_hotkeys_enabled = config["global_hotkeys_enabled"]
+        self.app.speak_time_hotkey = config["speak_time_hotkey"]
         
         if self.app.clock_service:
             if config["quiet_hours_enabled"]:
@@ -439,6 +477,7 @@ class SettingsDialog(wx.Dialog):
         
         # Save to file
         self.app.save_config()
+        self.app.refresh_global_hotkeys()
         logger.info("Settings saved")
 
     def _on_change(self, event: wx.CommandEvent) -> None:
@@ -498,6 +537,22 @@ class SettingsDialog(wx.Dialog):
                 wx.OK | wx.ICON_WARNING
             )
 
+    def _on_audio_device(self, event: wx.CommandEvent) -> None:
+        """Open the audio output picker from settings."""
+        from .audio_device_dialog import AudioDeviceDialog
+
+        dlg = AudioDeviceDialog(self, self.app)
+        try:
+            if dlg.ShowModal() == wx.ID_OK:
+                selected = dlg.get_selected_device_name()
+                if self.app.set_audio_device(selected):
+                    self.audio_device_label.SetLabel(
+                        f"Audio output: {self.app.audio_device_name or 'Default system device'}"
+                    )
+                    self._changes_made = True
+        finally:
+            dlg.Destroy()
+
     def _on_open_logs(self, event: wx.CommandEvent) -> None:
         """Open the logs folder in file explorer."""
         import subprocess
@@ -526,8 +581,10 @@ class SettingsDialog(wx.Dialog):
             self.format_12h.SetValue(True)
             self.format_24h.SetValue(False)
             self.start_minimized.SetValue(False)
+            self.minimize_to_tray.SetValue(False)
             self.start_with_windows.SetValue(False)
             self.play_startup_sound.SetValue(True)
+            self.global_hotkeys_enabled.SetValue(False)
             self.announce_on_focus.SetValue(False)
             self.rate_slider.SetValue(150)
             self.style_simple.SetValue(True)

--- a/src/accessiclock/ui/global_hotkeys.py
+++ b/src/accessiclock/ui/global_hotkeys.py
@@ -1,0 +1,93 @@
+"""Global hotkey registration for AccessiClock."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import wx
+
+HotkeyCallback = Callable[[], None]
+
+
+@dataclass(frozen=True)
+class ParsedHotkey:
+    modifiers: int
+    keycode: int
+
+
+def parse_hotkey(hotkey_text: str, *, wx_module: Any = wx) -> ParsedHotkey | None:
+    """Parse a compact hotkey string such as Ctrl+Alt+T."""
+    parts = [part.strip() for part in hotkey_text.split("+") if part.strip()]
+    if not parts:
+        return None
+
+    modifiers = 0
+    key_text = parts[-1].upper()
+    for part in parts[:-1]:
+        token = part.lower()
+        if token == "ctrl":
+            modifiers |= int(wx_module.MOD_CONTROL)
+        elif token == "alt":
+            modifiers |= int(wx_module.MOD_ALT)
+        elif token == "shift":
+            modifiers |= int(wx_module.MOD_SHIFT)
+        else:
+            return None
+
+    if len(key_text) == 1:
+        keycode = ord(key_text)
+    elif key_text.startswith("F") and key_text[1:].isdigit():
+        keycode = int(getattr(wx_module, f"WXK_{key_text}", 0))
+        if not keycode:
+            return None
+    else:
+        return None
+    return ParsedHotkey(modifiers=modifiers, keycode=keycode)
+
+
+class GlobalHotkeyManager:
+    """Small wrapper around wx.RegisterHotKey with a testable parser."""
+
+    def __init__(self, frame: wx.Frame, *, wx_module: Any = wx):
+        self._frame = frame
+        self._wx = wx_module
+        self._hotkey_id = self._make_hotkey_id()
+        self._callback: HotkeyCallback | None = None
+        self._registered = False
+
+    def _make_hotkey_id(self) -> int:
+        if hasattr(self._wx, "NewIdRef"):
+            return int(self._wx.NewIdRef())
+        return 9001
+
+    def register(self, hotkey_text: str, callback: HotkeyCallback) -> bool:
+        """Register a single announce-time global hotkey."""
+        parsed = parse_hotkey(hotkey_text, wx_module=self._wx)
+        if parsed is None:
+            return False
+        self.unregister()
+        if not self._frame.RegisterHotKey(self._hotkey_id, parsed.modifiers, parsed.keycode):
+            return False
+        self._callback = callback
+        self._registered = True
+        self._frame.Bind(self._wx.EVT_HOTKEY, self._on_hotkey)
+        return True
+
+    def unregister(self) -> None:
+        """Unregister the active hotkey if there is one."""
+        if not self._registered:
+            return
+        try:
+            self._frame.UnregisterHotKey(self._hotkey_id)
+        finally:
+            self._registered = False
+            self._callback = None
+
+    def _on_hotkey(self, event: wx.KeyEvent) -> None:
+        if event.GetId() != self._hotkey_id:
+            event.Skip()
+            return
+        if self._callback:
+            self._callback()

--- a/src/accessiclock/ui/main_window.py
+++ b/src/accessiclock/ui/main_window.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import wx
 
 from ..constants import TIME_FORMAT_12H, VOLUME_LEVELS
+from ..core.shortcuts import build_shortcut_help
 
 if TYPE_CHECKING:
     from ..app import AccessiClockApp
@@ -60,8 +61,9 @@ class MainWindow(wx.Frame):
         # Start clock timer
         self._start_clock_timer()
 
-        # Center window
+        # Center window and set predictable focus once shown.
         self.Centre()
+        wx.CallAfter(self._set_initial_focus)
 
         logger.info("Main window created")
 
@@ -217,9 +219,14 @@ class MainWindow(wx.Frame):
         self.settings_button.Bind(wx.EVT_BUTTON, self._on_settings)
 
     def _setup_keyboard_shortcuts(self) -> None:
-        """Set up keyboard shortcuts."""
-        # Keyboard shortcuts are handled via menu accelerators (F5, Space, etc.)
-        # defined in _create_menu_bar()
+        """Set up keyboard shortcuts and announce map in logs/status."""
+        logger.info("Shortcut map: %s", build_shortcut_help())
+
+    def _set_initial_focus(self) -> None:
+        """Move focus to a stable control to help screen reader users on startup."""
+        if self.clock_selection and self.clock_selection.IsShownOnScreen():
+            self.clock_selection.SetFocus()
+            self._set_status("Ready. Focus is on clock selection. Use Tab to navigate.")
 
     def _start_clock_timer(self) -> None:
         """Start the clock update timer."""

--- a/src/accessiclock/ui/main_window.py
+++ b/src/accessiclock/ui/main_window.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 import wx
+import wx.adv
 
 from ..constants import TIME_FORMAT_12H, TIME_FORMAT_24H, VOLUME_LEVELS
 from ..core.shortcuts import build_shortcut_help
@@ -44,7 +45,7 @@ class MainWindow(wx.Frame):
         super().__init__(
             parent=None,
             title="AccessiClock",
-            size=(680, 760),
+            size=(720, 820),
             style=wx.DEFAULT_FRAME_STYLE,
         )
         self.app = app
@@ -137,6 +138,16 @@ class MainWindow(wx.Frame):
         backend_text = self._get_audio_backend_text()
         self.backend_label = wx.StaticText(panel, label=f"Audio backend: {backend_text}")
         main_sizer.Add(self.backend_label, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
+
+        audio_device_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.audio_device_label = wx.StaticText(
+            panel,
+            label=f"Audio output: {self._get_audio_device_text()}",
+        )
+        audio_device_sizer.Add(self.audio_device_label, 1, wx.ALIGN_CENTER_VERTICAL)
+        self.audio_device_button = wx.Button(panel, label="Audio &Device...")
+        audio_device_sizer.Add(self.audio_device_button, 0)
+        main_sizer.Add(audio_device_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
 
         # Chime intervals
         intervals_label = wx.StaticText(panel, label="Chime Intervals:")
@@ -289,6 +300,7 @@ class MainWindow(wx.Frame):
         # File menu
         file_menu = wx.Menu()
         settings_item = file_menu.Append(wx.ID_PREFERENCES, "&Settings\tCtrl+,")
+        audio_device_item = file_menu.Append(wx.ID_ANY, "Audio &Device...\tCtrl+D")
         file_menu.AppendSeparator()
         exit_item = file_menu.Append(wx.ID_EXIT, "E&xit\tAlt+F4")
         menubar.Append(file_menu, "&File")
@@ -310,6 +322,7 @@ class MainWindow(wx.Frame):
 
         # Bind menu events
         self.Bind(wx.EVT_MENU, self._on_settings, settings_item)
+        self.Bind(wx.EVT_MENU, self._on_audio_device, audio_device_item)
         self.Bind(wx.EVT_MENU, self._on_exit, exit_item)
         self.Bind(wx.EVT_MENU, self._on_test_chime, test_item)
         self.Bind(wx.EVT_MENU, self._on_announce_time, announce_item)
@@ -320,10 +333,12 @@ class MainWindow(wx.Frame):
         """Bind event handlers."""
         # Window events
         self.Bind(wx.EVT_CLOSE, self._on_close)
+        self.Bind(wx.EVT_ICONIZE, self._on_iconize)
 
         # Control events
         self.clock_selection.Bind(wx.EVT_COMBOBOX, self._on_clock_changed)
         self.volume_button.Bind(wx.EVT_BUTTON, self._on_change_volume)
+        self.audio_device_button.Bind(wx.EVT_BUTTON, self._on_audio_device)
         self.hourly_checkbox.Bind(wx.EVT_CHECKBOX, self._on_interval_changed)
         self.half_hour_checkbox.Bind(wx.EVT_CHECKBOX, self._on_interval_changed)
         self.quarter_hour_checkbox.Bind(wx.EVT_CHECKBOX, self._on_interval_changed)
@@ -348,6 +363,23 @@ class MainWindow(wx.Frame):
     def _setup_keyboard_shortcuts(self) -> None:
         """Set up keyboard shortcuts and announce map in logs/status."""
         logger.info("Shortcut map: %s", build_shortcut_help())
+        entries = []
+        for keycode, handler in [
+            (wx.WXK_F5, self._on_test_chime),
+            (ord(" "), self._on_announce_time),
+        ]:
+            item_id = wx.NewIdRef()
+            self.Bind(wx.EVT_MENU, handler, id=item_id)
+            entries.append(wx.AcceleratorEntry(wx.ACCEL_NORMAL, keycode, item_id))
+
+        audio_id = wx.NewIdRef()
+        self.Bind(wx.EVT_MENU, self._on_audio_device, id=audio_id)
+        entries.append(wx.AcceleratorEntry(wx.ACCEL_CTRL, ord("D"), audio_id))
+
+        settings_id = wx.NewIdRef()
+        self.Bind(wx.EVT_MENU, self._on_settings, id=settings_id)
+        entries.append(wx.AcceleratorEntry(wx.ACCEL_CTRL, ord(","), settings_id))
+        self.SetAcceleratorTable(wx.AcceleratorTable(entries))
 
     def _set_initial_focus(self) -> None:
         """Move focus to a stable control to help screen reader users on startup."""
@@ -372,6 +404,10 @@ class MainWindow(wx.Frame):
         if not self.app.audio_player:
             return "unavailable"
         return getattr(self.app.audio_player, "backend_name", "available")
+
+    def _get_audio_device_text(self) -> str:
+        """Return the configured audio device display text."""
+        return self.app.audio_device_name or "Default system device"
 
     def _parse_hhmm(self, value: str, default: str) -> tuple[int, int]:
         """Parse HH:MM text for spin controls."""
@@ -406,6 +442,8 @@ class MainWindow(wx.Frame):
     def _on_clock_tick(self, event: wx.TimerEvent) -> None:
         """Handle clock timer tick."""
         self.clock_display.SetValue(self._get_current_time())
+        if self.app.system_tray_icon:
+            self.app.system_tray_icon.update_tooltip(f"AccessiClock {self._get_current_time()}")
 
         if self.app.check_and_trigger_alarm():
             self._set_status("Alarm triggered")
@@ -439,6 +477,9 @@ class MainWindow(wx.Frame):
         self.volume_label.SetLabel(f"Volume: {new_volume}%")
         self._set_status(f"Volume set to {new_volume}%")
         logger.info(f"Volume changed to: {new_volume}%")
+
+    def _on_audio_device(self, event: wx.CommandEvent) -> None:
+        self.open_audio_device_dialog()
 
     def _on_interval_changed(self, event: wx.CommandEvent) -> None:
         """Handle chime interval checkbox changes."""
@@ -563,14 +604,41 @@ class MainWindow(wx.Frame):
 
     def _on_settings(self, event: wx.CommandEvent) -> None:
         """Handle settings button/menu."""
+        self.open_settings_dialog()
+
+    def open_settings_dialog(self) -> None:
+        """Open settings from buttons, menu items, or the tray menu."""
         from .dialogs import SettingsDialog
         
         dlg = SettingsDialog(self, self.app)
-        dlg.ShowModal()
-        dlg.Destroy()
+        try:
+            dlg.ShowModal()
+        finally:
+            dlg.Destroy()
+        self._refresh_runtime_labels()
         
         self._set_status("Settings updated")
         logger.info("Settings dialog closed")
+
+    def open_audio_device_dialog(self) -> None:
+        """Open the audio-device picker and apply the selected output."""
+        from .dialogs import AudioDeviceDialog
+
+        dlg = AudioDeviceDialog(self, self.app)
+        try:
+            if dlg.ShowModal() == wx.ID_OK:
+                selected = dlg.get_selected_device_name()
+                if self.app.set_audio_device(selected):
+                    self._refresh_runtime_labels()
+                    self._set_status(f"Audio output: {self._get_audio_device_text()}")
+                else:
+                    self._set_status("Could not change audio output device")
+        finally:
+            dlg.Destroy()
+
+    def _refresh_runtime_labels(self) -> None:
+        self.backend_label.SetLabel(f"Audio backend: {self._get_audio_backend_text()}")
+        self.audio_device_label.SetLabel(f"Audio output: {self._get_audio_device_text()}")
 
     def _on_manage_clocks(self, event: wx.CommandEvent) -> None:
         """Handle manage clocks menu item."""
@@ -619,11 +687,16 @@ class MainWindow(wx.Frame):
 
     def _on_exit(self, event: wx.CommandEvent) -> None:
         """Handle exit menu item."""
-        self.Close()
+        self.app.request_exit()
 
     def _on_close(self, event: wx.CloseEvent) -> None:
         """Handle window close."""
         logger.info("Main window closing")
+        if self.app.should_minimize_to_tray():
+            event.Veto()
+            self.Hide()
+            self._set_status("AccessiClock minimized to the system tray")
+            return
 
         # Stop timer
         if self._clock_timer:
@@ -635,7 +708,19 @@ class MainWindow(wx.Frame):
         # Destroy window
         self.Destroy()
 
+    def _on_iconize(self, event: wx.IconizeEvent) -> None:
+        """Hide the window when minimized if tray minimization is enabled."""
+        if event.IsIconized() and self.app.should_minimize_to_tray():
+            self.Hide()
+            self._set_status("AccessiClock minimized to the system tray")
+            return
+        event.Skip()
+
     def _set_status(self, message: str) -> None:
         """Update the status label."""
         self.status_label.SetLabel(message)
         logger.debug(f"Status: {message}")
+
+    def set_status_from_app(self, message: str) -> None:
+        """Allow app/tray actions to update the accessible status text."""
+        self._set_status(message)

--- a/src/accessiclock/ui/main_window.py
+++ b/src/accessiclock/ui/main_window.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 import wx
 
-from ..constants import TIME_FORMAT_12H, VOLUME_LEVELS
+from ..constants import TIME_FORMAT_12H, TIME_FORMAT_24H, VOLUME_LEVELS
 from ..core.shortcuts import build_shortcut_help
 
 if TYPE_CHECKING:
@@ -44,7 +44,7 @@ class MainWindow(wx.Frame):
         super().__init__(
             parent=None,
             title="AccessiClock",
-            size=(500, 450),
+            size=(680, 760),
             style=wx.DEFAULT_FRAME_STYLE,
         )
         self.app = app
@@ -69,7 +69,8 @@ class MainWindow(wx.Frame):
 
     def _create_widgets(self) -> None:
         """Create all UI widgets."""
-        panel = wx.Panel(self)
+        panel = wx.ScrolledWindow(self)
+        panel.SetScrollRate(0, 20)
         main_sizer = wx.BoxSizer(wx.VERTICAL)
 
         # Clock display - large, readable, screen reader accessible
@@ -132,6 +133,11 @@ class MainWindow(wx.Frame):
 
         main_sizer.AddSpacer(10)
 
+        # Audio backend status
+        backend_text = self._get_audio_backend_text()
+        self.backend_label = wx.StaticText(panel, label=f"Audio backend: {backend_text}")
+        main_sizer.Add(self.backend_label, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
+
         # Chime intervals
         intervals_label = wx.StaticText(panel, label="Chime Intervals:")
         intervals_label.SetFont(
@@ -151,6 +157,110 @@ class MainWindow(wx.Frame):
         self.quarter_hour_checkbox.SetValue(self.app.chime_quarter_hour)
         main_sizer.Add(self.quarter_hour_checkbox, 0, wx.LEFT | wx.TOP, 15)
 
+        main_sizer.AddSpacer(10)
+
+        # Chime style and extra scheduled sounds
+        style_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        style_label = wx.StaticText(panel, label="Chime style:")
+        style_sizer.Add(style_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
+
+        self.chime_style_choice = wx.Choice(
+            panel,
+            choices=["Classic single chime", "Grandfather counted chimes"],
+        )
+        self.chime_style_choice.SetSelection(1 if self.app.chime_style == "grandfather" else 0)
+        style_sizer.Add(self.chime_style_choice, 1, wx.EXPAND)
+        main_sizer.Add(style_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
+
+        self.hour_count_checkbox = wx.CheckBox(panel, label="Count the hour on hourly chimes")
+        self.hour_count_checkbox.SetValue(self.app.hour_count_chimes)
+        main_sizer.Add(self.hour_count_checkbox, 0, wx.LEFT | wx.TOP, 15)
+
+        self.minute_tick_checkbox = wx.CheckBox(panel, label="Play a minute tick")
+        self.minute_tick_checkbox.SetValue(self.app.minute_tick)
+        main_sizer.Add(self.minute_tick_checkbox, 0, wx.LEFT | wx.TOP, 15)
+
+        main_sizer.AddSpacer(12)
+
+        # Quiet hours controls
+        quiet_label = wx.StaticText(panel, label="Quiet Hours:")
+        quiet_label.SetFont(quiet_label.GetFont().Bold())
+        main_sizer.Add(quiet_label, 0, wx.LEFT, 10)
+
+        self.quiet_enabled_checkbox = wx.CheckBox(panel, label="Enable quiet hours")
+        self.quiet_enabled_checkbox.SetValue(self.app.quiet_hours_enabled)
+        main_sizer.Add(self.quiet_enabled_checkbox, 0, wx.LEFT | wx.TOP, 15)
+
+        quiet_start_hour, quiet_start_minute = self._parse_hhmm(self.app.quiet_start, "22:00")
+        quiet_end_hour, quiet_end_minute = self._parse_hhmm(self.app.quiet_end, "07:00")
+
+        quiet_start_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        quiet_start_hour_label = wx.StaticText(panel, label="Quiet start hour:")
+        quiet_start_sizer.Add(quiet_start_hour_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 8)
+        self.quiet_start_hour_spin = wx.SpinCtrl(
+            panel, min=0, max=23, initial=quiet_start_hour, size=(70, -1)
+        )
+        quiet_start_sizer.Add(self.quiet_start_hour_spin, 0, wx.RIGHT, 12)
+        quiet_start_minute_label = wx.StaticText(panel, label="Quiet start minute:")
+        quiet_start_sizer.Add(quiet_start_minute_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 8)
+        self.quiet_start_minute_spin = wx.SpinCtrl(
+            panel, min=0, max=59, initial=quiet_start_minute, size=(70, -1)
+        )
+        quiet_start_sizer.Add(self.quiet_start_minute_spin, 0)
+        main_sizer.Add(quiet_start_sizer, 0, wx.LEFT | wx.RIGHT | wx.TOP, 15)
+
+        quiet_end_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        quiet_end_hour_label = wx.StaticText(panel, label="Quiet end hour:")
+        quiet_end_sizer.Add(quiet_end_hour_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 8)
+        self.quiet_end_hour_spin = wx.SpinCtrl(
+            panel, min=0, max=23, initial=quiet_end_hour, size=(70, -1)
+        )
+        quiet_end_sizer.Add(self.quiet_end_hour_spin, 0, wx.RIGHT, 12)
+        quiet_end_minute_label = wx.StaticText(panel, label="Quiet end minute:")
+        quiet_end_sizer.Add(quiet_end_minute_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 8)
+        self.quiet_end_minute_spin = wx.SpinCtrl(
+            panel, min=0, max=59, initial=quiet_end_minute, size=(70, -1)
+        )
+        quiet_end_sizer.Add(self.quiet_end_minute_spin, 0)
+        main_sizer.Add(quiet_end_sizer, 0, wx.LEFT | wx.RIGHT | wx.TOP, 15)
+
+        main_sizer.AddSpacer(12)
+
+        # Alarm controls
+        alarm_label = wx.StaticText(panel, label="Alarm:")
+        alarm_label.SetFont(alarm_label.GetFont().Bold())
+        main_sizer.Add(alarm_label, 0, wx.LEFT, 10)
+
+        self.alarm_enabled_checkbox = wx.CheckBox(panel, label="Enable alarm")
+        self.alarm_enabled_checkbox.SetValue(self.app.alarm_enabled)
+        main_sizer.Add(self.alarm_enabled_checkbox, 0, wx.LEFT | wx.TOP, 15)
+
+        alarm_time_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        alarm_hour_label = wx.StaticText(panel, label="Alarm hour:")
+        alarm_time_sizer.Add(alarm_hour_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 8)
+
+        alarm_hour, alarm_minute = self._parse_hhmm(self.app.alarm_time, "07:00")
+        self.alarm_hour_spin = wx.SpinCtrl(panel, min=0, max=23, initial=alarm_hour, size=(70, -1))
+        alarm_time_sizer.Add(self.alarm_hour_spin, 0, wx.RIGHT, 12)
+
+        alarm_minute_label = wx.StaticText(panel, label="Alarm minute:")
+        alarm_time_sizer.Add(alarm_minute_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 8)
+
+        self.alarm_minute_spin = wx.SpinCtrl(
+            panel, min=0, max=59, initial=alarm_minute, size=(70, -1)
+        )
+        alarm_time_sizer.Add(self.alarm_minute_spin, 0)
+        main_sizer.Add(alarm_time_sizer, 0, wx.LEFT | wx.RIGHT | wx.TOP, 15)
+
+        self.alarm_sound_checkbox = wx.CheckBox(panel, label="Play alarm sound")
+        self.alarm_sound_checkbox.SetValue(self.app.alarm_sound_enabled)
+        main_sizer.Add(self.alarm_sound_checkbox, 0, wx.LEFT | wx.TOP, 15)
+
+        alarm_text_label = wx.StaticText(panel, label="Alarm spoken text:")
+        main_sizer.Add(alarm_text_label, 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
+        self.alarm_text_ctrl = wx.TextCtrl(panel, value=self.app.alarm_spoken_text)
+        main_sizer.Add(self.alarm_text_ctrl, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 10)
+
         main_sizer.AddSpacer(15)
 
         # Action buttons
@@ -161,6 +271,9 @@ class MainWindow(wx.Frame):
 
         self.announce_button = wx.Button(panel, label="&Announce Time")
         button_sizer.Add(self.announce_button, 0, wx.RIGHT, 10)
+
+        self.test_alarm_button = wx.Button(panel, label="Test &Alarm")
+        button_sizer.Add(self.test_alarm_button, 0, wx.RIGHT, 10)
 
         self.settings_button = wx.Button(panel, label="&Settings")
         button_sizer.Add(self.settings_button, 0)
@@ -214,8 +327,22 @@ class MainWindow(wx.Frame):
         self.hourly_checkbox.Bind(wx.EVT_CHECKBOX, self._on_interval_changed)
         self.half_hour_checkbox.Bind(wx.EVT_CHECKBOX, self._on_interval_changed)
         self.quarter_hour_checkbox.Bind(wx.EVT_CHECKBOX, self._on_interval_changed)
+        self.chime_style_choice.Bind(wx.EVT_CHOICE, self._on_chime_options_changed)
+        self.hour_count_checkbox.Bind(wx.EVT_CHECKBOX, self._on_chime_options_changed)
+        self.minute_tick_checkbox.Bind(wx.EVT_CHECKBOX, self._on_chime_options_changed)
+        self.quiet_enabled_checkbox.Bind(wx.EVT_CHECKBOX, self._on_quiet_hours_changed)
+        self.quiet_start_hour_spin.Bind(wx.EVT_SPINCTRL, self._on_quiet_hours_changed)
+        self.quiet_start_minute_spin.Bind(wx.EVT_SPINCTRL, self._on_quiet_hours_changed)
+        self.quiet_end_hour_spin.Bind(wx.EVT_SPINCTRL, self._on_quiet_hours_changed)
+        self.quiet_end_minute_spin.Bind(wx.EVT_SPINCTRL, self._on_quiet_hours_changed)
+        self.alarm_enabled_checkbox.Bind(wx.EVT_CHECKBOX, self._on_alarm_changed)
+        self.alarm_hour_spin.Bind(wx.EVT_SPINCTRL, self._on_alarm_changed)
+        self.alarm_minute_spin.Bind(wx.EVT_SPINCTRL, self._on_alarm_changed)
+        self.alarm_sound_checkbox.Bind(wx.EVT_CHECKBOX, self._on_alarm_changed)
+        self.alarm_text_ctrl.Bind(wx.EVT_TEXT, self._on_alarm_changed)
         self.test_button.Bind(wx.EVT_BUTTON, self._on_test_chime)
         self.announce_button.Bind(wx.EVT_BUTTON, self._on_announce_time)
+        self.test_alarm_button.Bind(wx.EVT_BUTTON, self._on_test_alarm)
         self.settings_button.Bind(wx.EVT_BUTTON, self._on_settings)
 
     def _setup_keyboard_shortcuts(self) -> None:
@@ -237,7 +364,26 @@ class MainWindow(wx.Frame):
 
     def _get_current_time(self) -> str:
         """Get the current time as a formatted string."""
-        return datetime.now().strftime(TIME_FORMAT_12H)
+        fmt = TIME_FORMAT_24H if self.app.config.get("time_format") == "24h" else TIME_FORMAT_12H
+        return datetime.now().strftime(fmt)
+
+    def _get_audio_backend_text(self) -> str:
+        """Return current audio backend status for the UI."""
+        if not self.app.audio_player:
+            return "unavailable"
+        return getattr(self.app.audio_player, "backend_name", "available")
+
+    def _parse_hhmm(self, value: str, default: str) -> tuple[int, int]:
+        """Parse HH:MM text for spin controls."""
+        try:
+            hour_text, minute_text = (value or default).split(":")
+            hour = max(0, min(23, int(hour_text)))
+            minute = max(0, min(59, int(minute_text)))
+        except (TypeError, ValueError):
+            hour_text, minute_text = default.split(":")
+            hour = int(hour_text)
+            minute = int(minute_text)
+        return hour, minute
 
     def _get_clock_display_name(self, pack_id: str) -> str:
         """Get the display name for a clock pack ID."""
@@ -261,10 +407,14 @@ class MainWindow(wx.Frame):
         """Handle clock timer tick."""
         self.clock_display.SetValue(self._get_current_time())
 
+        if self.app.check_and_trigger_alarm():
+            self._set_status("Alarm triggered")
+            return
+
         # Check for chime intervals and play sounds
         chime_played = self.app.check_and_play_chime()
         if chime_played:
-            self._set_status(f"Playing {chime_played.replace('_', ' ')} chime")
+            self._set_status(f"Playing {chime_played.replace('_', ' ')}")
 
     def _on_clock_changed(self, event: wx.CommandEvent) -> None:
         """Handle clock pack selection change."""
@@ -309,6 +459,74 @@ class MainWindow(wx.Frame):
         self.app.save_config()
         logger.info(f"Chime intervals updated: {interval_text}")
 
+    def _on_chime_options_changed(self, event: wx.CommandEvent) -> None:
+        """Handle chime style, hour count, and minute tick changes."""
+        self.app.chime_style = (
+            "grandfather" if self.chime_style_choice.GetSelection() == 1 else "classic"
+        )
+        self.app.hour_count_chimes = self.hour_count_checkbox.GetValue()
+        self.app.minute_tick = self.minute_tick_checkbox.GetValue()
+        if self.app.clock_service:
+            self.app.clock_service.reset_chime_tracking()
+
+        style_text = "grandfather counted chimes" if self.app.chime_style == "grandfather" else "classic single chime"
+        tick_text = "minute tick on" if self.app.minute_tick else "minute tick off"
+        hour_count_text = "hour count on" if self.app.hour_count_chimes else "hour count off"
+        self._set_status(f"Chime style: {style_text}; {hour_count_text}; {tick_text}")
+        self.app.save_config()
+        logger.info("Chime options updated: %s, %s, %s", style_text, hour_count_text, tick_text)
+
+    def _on_quiet_hours_changed(self, event: wx.CommandEvent) -> None:
+        """Handle quiet hours changes."""
+        if self.quiet_enabled_checkbox.GetValue() and self.app.clock_service:
+            from datetime import time
+
+            start = time(
+                self.quiet_start_hour_spin.GetValue(),
+                self.quiet_start_minute_spin.GetValue(),
+            )
+            end = time(
+                self.quiet_end_hour_spin.GetValue(),
+                self.quiet_end_minute_spin.GetValue(),
+            )
+            self.app.clock_service.set_quiet_hours(start, end)
+            self.app.quiet_hours_enabled = True
+            self.app.quiet_start = f"{start.hour:02d}:{start.minute:02d}"
+            self.app.quiet_end = f"{end.hour:02d}:{end.minute:02d}"
+        elif self.app.clock_service:
+            self.app.clock_service.quiet_hours_enabled = False
+            self.app.quiet_hours_enabled = False
+            self.app.quiet_start = (
+                f"{self.quiet_start_hour_spin.GetValue():02d}:"
+                f"{self.quiet_start_minute_spin.GetValue():02d}"
+            )
+            self.app.quiet_end = (
+                f"{self.quiet_end_hour_spin.GetValue():02d}:"
+                f"{self.quiet_end_minute_spin.GetValue():02d}"
+            )
+        self.app.save_config()
+        state = "enabled" if self.app.quiet_hours_enabled else "disabled"
+        self._set_status(
+            f"Quiet hours {state}: {self.app.quiet_start} to {self.app.quiet_end}"
+        )
+
+    def _on_alarm_changed(self, event: wx.CommandEvent) -> None:
+        """Handle alarm option changes."""
+        self._sync_alarm_from_controls(save=True)
+        state = "enabled" if self.app.alarm_enabled else "disabled"
+        self._set_status(f"Alarm {state} for {self.app.alarm_time}")
+
+    def _sync_alarm_from_controls(self, *, save: bool) -> None:
+        """Copy alarm UI state into the app and clock service."""
+        self.app.alarm_enabled = self.alarm_enabled_checkbox.GetValue()
+        self.app.alarm_time = (
+            f"{self.alarm_hour_spin.GetValue():02d}:{self.alarm_minute_spin.GetValue():02d}"
+        )
+        self.app.alarm_sound_enabled = self.alarm_sound_checkbox.GetValue()
+        self.app.alarm_spoken_text = self.alarm_text_ctrl.GetValue().strip() or "Time to get up"
+        if save:
+            self.app.save_config()
+
     def _on_test_chime(self, event: wx.CommandEvent) -> None:
         """Handle test chime button/menu."""
         self._set_status("Playing test chime...")
@@ -321,13 +539,27 @@ class MainWindow(wx.Frame):
         """Handle announce time button/menu."""
         current_time = self._get_current_time()
         
-        if self.app.announce_time():
+        if self.app.announce_time(style=self.app.config.get("announcement_style", "simple")):
             self._set_status(f"Announced: {current_time}")
         else:
             # TTS not available, just show status
             self._set_status(f"The time is {current_time}")
         
         logger.info(f"Time announced: {current_time}")
+
+    def _on_test_alarm(self, event: wx.CommandEvent) -> None:
+        """Play the configured alarm sound/message immediately."""
+        self._sync_alarm_from_controls(save=True)
+        did_anything = False
+        if self.app.alarm_sound_enabled:
+            did_anything = self.app.play_chime("alarm") or did_anything
+        if self.app.alarm_spoken_text and self.app.tts_engine:
+            self.app.tts_engine.speak(self.app.alarm_spoken_text)
+            did_anything = True
+        if did_anything:
+            self._set_status("Test alarm played")
+        else:
+            self._set_status("Could not test alarm - audio and speech unavailable")
 
     def _on_settings(self, event: wx.CommandEvent) -> None:
         """Handle settings button/menu."""

--- a/src/accessiclock/ui/system_tray.py
+++ b/src/accessiclock/ui/system_tray.py
@@ -1,0 +1,115 @@
+"""System tray integration for AccessiClock."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import wx
+import wx.adv
+
+if TYPE_CHECKING:
+    from ..app import AccessiClockApp
+
+logger = logging.getLogger(__name__)
+
+TRAY_MENU_LABELS = [
+    "Show AccessiClock",
+    "Announce Time",
+    "Test Chime",
+    "Settings...",
+    "Exit AccessiClock",
+]
+
+
+class TrayActionHandler:
+    """Actions exposed by the system tray menu."""
+
+    def __init__(self, app: AccessiClockApp):
+        self.app = app
+
+    def show_main_window(self) -> None:
+        window = self.app.main_window
+        if not window:
+            return
+        window.Show(True)
+        if window.IsIconized():
+            window.Iconize(False)
+        window.Raise()
+        window.SetFocus()
+
+    def announce_time(self) -> None:
+        self.app.announce_time(style=self.app.config.get("announcement_style", "simple"))
+        if self.app.main_window:
+            self.app.main_window.set_status_from_app("Announced current time")
+
+    def test_chime(self) -> None:
+        if self.app.play_test_sound() and self.app.main_window:
+            self.app.main_window.set_status_from_app("Test chime played from tray")
+
+    def open_settings(self) -> None:
+        self.show_main_window()
+        if self.app.main_window:
+            self.app.main_window.open_settings_dialog()
+
+    def exit_application(self) -> None:
+        self.app.request_exit()
+
+
+class SystemTrayIcon(wx.adv.TaskBarIcon):
+    """Accessible text-menu system tray icon."""
+
+    def __init__(self, app: AccessiClockApp):
+        super().__init__()
+        self.action_handler = TrayActionHandler(app)
+        self._icon = self._create_icon()
+        self.SetIcon(self._icon, "AccessiClock")
+
+        self.Bind(wx.adv.EVT_TASKBAR_LEFT_DOWN, self._on_left_click)
+        self.Bind(wx.adv.EVT_TASKBAR_LEFT_DCLICK, self._on_left_click)
+        self.Bind(wx.adv.EVT_TASKBAR_RIGHT_DOWN, self._on_right_click)
+
+    def _create_icon(self) -> wx.Icon:
+        icon = wx.Icon()
+        bitmap = wx.Bitmap(16, 16)
+        dc = wx.MemoryDC(bitmap)
+        dc.SetBackground(wx.Brush(wx.Colour(35, 35, 35)))
+        dc.Clear()
+        dc.SetTextForeground(wx.WHITE)
+        dc.DrawText("A", 3, 0)
+        dc.SelectObject(wx.NullBitmap)
+        icon.CopyFromBitmap(bitmap)
+        return icon
+
+    def CreatePopupMenu(self) -> wx.Menu:
+        menu = wx.Menu()
+        show_item = menu.Append(wx.ID_ANY, TRAY_MENU_LABELS[0])
+        announce_item = menu.Append(wx.ID_ANY, TRAY_MENU_LABELS[1])
+        test_item = menu.Append(wx.ID_ANY, TRAY_MENU_LABELS[2])
+        settings_item = menu.Append(wx.ID_ANY, TRAY_MENU_LABELS[3])
+        menu.AppendSeparator()
+        exit_item = menu.Append(wx.ID_ANY, TRAY_MENU_LABELS[4])
+
+        self.Bind(wx.EVT_MENU, lambda _event: self.action_handler.show_main_window(), show_item)
+        self.Bind(wx.EVT_MENU, lambda _event: self.action_handler.announce_time(), announce_item)
+        self.Bind(wx.EVT_MENU, lambda _event: self.action_handler.test_chime(), test_item)
+        self.Bind(wx.EVT_MENU, lambda _event: self.action_handler.open_settings(), settings_item)
+        self.Bind(wx.EVT_MENU, lambda _event: self.action_handler.exit_application(), exit_item)
+        return menu
+
+    def update_tooltip(self, text: str) -> None:
+        self.SetIcon(self._icon, text[:127] or "AccessiClock")
+
+    def _on_left_click(self, event: wx.adv.TaskBarIconEvent) -> None:
+        self.action_handler.show_main_window()
+
+    def _on_right_click(self, event: wx.adv.TaskBarIconEvent) -> None:
+        self.PopupMenu(self.CreatePopupMenu())
+
+    def cleanup(self) -> None:
+        try:
+            self.RemoveIcon()
+        except Exception:
+            logger.debug("Unable to remove tray icon", exc_info=True)
+        self.Destroy()
+

--- a/tests/core/test_logging_scaffold.py
+++ b/tests/core/test_logging_scaffold.py
@@ -1,0 +1,13 @@
+import logging
+from pathlib import Path
+
+from accessiclock.core.logging_setup import configure_logging
+
+
+def test_configure_logging_creates_log_file(tmp_path: Path):
+    log_file = configure_logging(tmp_path)
+
+    logging.getLogger("accessiclock.test").info("hello log")
+
+    assert log_file.exists()
+    assert "hello log" in log_file.read_text(encoding="utf-8")

--- a/tests/core/test_settings_scaffold.py
+++ b/tests/core/test_settings_scaffold.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from accessiclock.core.settings import AppSettings, load_settings, save_settings
+
+
+def test_load_settings_defaults_for_missing_file(tmp_path: Path):
+    settings = load_settings(tmp_path / "missing.json")
+    assert settings == AppSettings()
+
+
+def test_load_settings_clamps_volume(tmp_path: Path):
+    config_file = tmp_path / "config.json"
+    config_file.write_text('{"volume": 999, "clock": "digital"}', encoding="utf-8")
+
+    settings = load_settings(config_file)
+    assert settings.volume == 100
+    assert settings.clock == "digital"
+
+
+def test_save_and_load_round_trip(tmp_path: Path):
+    config_file = tmp_path / "nested" / "config.json"
+    expected = AppSettings(volume=25, clock="westminster", chime_half_hour=True)
+
+    save_settings(config_file, expected)
+    loaded = load_settings(config_file)
+
+    assert loaded == expected

--- a/tests/core/test_settings_scaffold.py
+++ b/tests/core/test_settings_scaffold.py
@@ -17,9 +17,50 @@ def test_load_settings_clamps_volume(tmp_path: Path):
     assert settings.clock == "digital"
 
 
+def test_load_settings_reads_clock_chime_options(tmp_path: Path):
+    config_file = tmp_path / "config.json"
+    config_file.write_text(
+        (
+            '{"chime_style": "grandfather", "hour_count_chimes": true, '
+            '"minute_tick": true, "alarm_enabled": true, "alarm_time": "07:30", '
+            '"alarm_sound_enabled": false, "alarm_spoken_text": "Wake up"}'
+        ),
+        encoding="utf-8",
+    )
+
+    settings = load_settings(config_file)
+
+    assert settings.chime_style == "grandfather"
+    assert settings.hour_count_chimes is True
+    assert settings.minute_tick is True
+    assert settings.alarm_enabled is True
+    assert settings.alarm_time == "07:30"
+    assert settings.alarm_sound_enabled is False
+    assert settings.alarm_spoken_text == "Wake up"
+
+
+def test_load_settings_rejects_unknown_chime_style(tmp_path: Path):
+    config_file = tmp_path / "config.json"
+    config_file.write_text('{"chime_style": "mystery"}', encoding="utf-8")
+
+    settings = load_settings(config_file)
+
+    assert settings.chime_style == "classic"
+
+
 def test_save_and_load_round_trip(tmp_path: Path):
     config_file = tmp_path / "nested" / "config.json"
-    expected = AppSettings(volume=25, clock="westminster", chime_half_hour=True)
+    expected = AppSettings(
+        volume=25,
+        clock="westminster",
+        chime_half_hour=True,
+        chime_style="grandfather",
+        hour_count_chimes=True,
+        minute_tick=True,
+        alarm_enabled=True,
+        alarm_time="06:45",
+        alarm_spoken_text="Coffee is ready",
+    )
 
     save_settings(config_file, expected)
     loaded = load_settings(config_file)

--- a/tests/core/test_settings_scaffold.py
+++ b/tests/core/test_settings_scaffold.py
@@ -39,6 +39,37 @@ def test_load_settings_reads_clock_chime_options(tmp_path: Path):
     assert settings.alarm_spoken_text == "Wake up"
 
 
+def test_load_settings_reads_tray_hotkey_and_audio_device_options(tmp_path: Path):
+    config_file = tmp_path / "config.json"
+    config_file.write_text(
+        (
+            '{"minimize_to_tray": true, "global_hotkeys_enabled": true, '
+            '"speak_time_hotkey": "Ctrl+Alt+T", "audio_device_name": "Speakers"}'
+        ),
+        encoding="utf-8",
+    )
+
+    settings = load_settings(config_file)
+
+    assert settings.minimize_to_tray is True
+    assert settings.global_hotkeys_enabled is True
+    assert settings.speak_time_hotkey == "Ctrl+Alt+T"
+    assert settings.audio_device_name == "Speakers"
+
+
+def test_load_settings_rejects_blank_hotkey_and_normalizes_audio_device(tmp_path: Path):
+    config_file = tmp_path / "config.json"
+    config_file.write_text(
+        '{"speak_time_hotkey": " ", "audio_device_name": ""}',
+        encoding="utf-8",
+    )
+
+    settings = load_settings(config_file)
+
+    assert settings.speak_time_hotkey == "Ctrl+Alt+T"
+    assert settings.audio_device_name == ""
+
+
 def test_load_settings_rejects_unknown_chime_style(tmp_path: Path):
     config_file = tmp_path / "config.json"
     config_file.write_text('{"chime_style": "mystery"}', encoding="utf-8")
@@ -60,6 +91,10 @@ def test_save_and_load_round_trip(tmp_path: Path):
         alarm_enabled=True,
         alarm_time="06:45",
         alarm_spoken_text="Coffee is ready",
+        minimize_to_tray=True,
+        global_hotkeys_enabled=True,
+        speak_time_hotkey="Ctrl+Alt+T",
+        audio_device_name="Headphones",
     )
 
     save_settings(config_file, expected)

--- a/tests/core/test_shortcuts_scaffold.py
+++ b/tests/core/test_shortcuts_scaffold.py
@@ -1,0 +1,14 @@
+from accessiclock.core.shortcuts import build_shortcut_help, default_shortcuts
+
+
+def test_default_shortcuts_contains_core_actions():
+    names = [shortcut.action for shortcut in default_shortcuts()]
+    assert "Test chime" in names
+    assert "Announce current time" in names
+
+
+def test_build_shortcut_help_is_readable_text():
+    help_text = build_shortcut_help()
+    assert "F5" in help_text
+    assert "Ctrl+," in help_text
+    assert "|" in help_text

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,7 +2,9 @@
 
 import json
 import tempfile
+from datetime import time
 from pathlib import Path
+from unittest.mock import MagicMock
 
 
 class TestConfigLoading:
@@ -153,3 +155,59 @@ class TestAppIntegration:
         """Audio player should be importable."""
         from accessiclock.audio.player import AudioPlayer
         assert AudioPlayer is not None
+
+
+class TestAppChimePlayback:
+    """Test app chime and alarm orchestration without starting wx."""
+
+    def test_play_chime_sequence_uses_audio_player_sequence_for_multiple_sounds(self, temp_dir):
+        """Multiple scheduled sounds should be delegated as one ordered sequence."""
+        from accessiclock.app import AccessiClockApp
+        from accessiclock.services.clock_pack_loader import ClockPackLoader
+
+        clock_dir = temp_dir / "clocks" / "test"
+        clock_dir.mkdir(parents=True)
+        for name in ["hour.wav", "tick.wav"]:
+            (clock_dir / name).touch()
+        (clock_dir / "clock.json").write_text(
+            json.dumps(
+                {
+                    "name": "Test",
+                    "version": "1.0",
+                    "sounds": {"hour": "hour.wav", "tick": "tick.wav"},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        app = AccessiClockApp.__new__(AccessiClockApp)
+        app.audio_player = MagicMock()
+        app.audio_player.play_sound_sequence.return_value = True
+        app.clock_pack_loader = ClockPackLoader(temp_dir / "clocks")
+        app.clock_pack_loader.discover_packs()
+        app.selected_clock = "test"
+
+        assert app.play_chime_sequence(["tick", "hour", "hour"]) is True
+        app.audio_player.play_sound_sequence.assert_called_once()
+        played = app.audio_player.play_sound_sequence.call_args.args[0]
+        assert played == [
+            str(clock_dir / "tick.wav"),
+            str(clock_dir / "hour.wav"),
+            str(clock_dir / "hour.wav"),
+        ]
+
+    def test_check_and_trigger_alarm_speaks_configured_text(self):
+        """A due alarm should play sound when available and speak configured text."""
+        from accessiclock.app import AccessiClockApp
+        from accessiclock.services.clock_service import ClockService
+
+        app = AccessiClockApp.__new__(AccessiClockApp)
+        app.clock_service = ClockService()
+        app.clock_service.set_alarm(time(7, 30), spoken_text="Wake up", sound_enabled=True)
+        app.play_chime = MagicMock(return_value=True)
+        app.tts_engine = MagicMock()
+
+        assert app.check_and_trigger_alarm(time(7, 30, 0)) is True
+
+        app.play_chime.assert_called_once_with("alarm")
+        app.tts_engine.speak.assert_called_once_with("Wake up")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -156,6 +156,59 @@ class TestAppIntegration:
         from accessiclock.audio.player import AudioPlayer
         assert AudioPlayer is not None
 
+    def test_save_config_persists_tray_hotkey_and_audio_device_settings(self, temp_dir):
+        from accessiclock.app import AccessiClockApp
+        from accessiclock.core.settings import load_settings
+
+        class FakePaths:
+            config_file = temp_dir / "config.json"
+
+        app = AccessiClockApp.__new__(AccessiClockApp)
+        app.paths = FakePaths()
+        app.settings = load_settings(app.paths.config_file)
+        app.config = app.settings.to_dict()
+        app.clock_service = None
+        app.current_volume = 50
+        app.selected_clock = "default"
+        app.chime_hourly = True
+        app.chime_half_hour = False
+        app.chime_quarter_hour = False
+        app.chime_style = "classic"
+        app.hour_count_chimes = False
+        app.minute_tick = False
+        app.quiet_hours_enabled = False
+        app.quiet_start = "22:00"
+        app.quiet_end = "07:00"
+        app.alarm_enabled = False
+        app.alarm_time = "07:00"
+        app.alarm_sound_enabled = True
+        app.alarm_spoken_text = "Time to get up"
+        app.minimize_to_tray = True
+        app.global_hotkeys_enabled = True
+        app.speak_time_hotkey = "Ctrl+Alt+T"
+        app.audio_device_name = "Speakers"
+
+        app.save_config()
+
+        loaded = load_settings(app.paths.config_file)
+        assert loaded.minimize_to_tray is True
+        assert loaded.global_hotkeys_enabled is True
+        assert loaded.speak_time_hotkey == "Ctrl+Alt+T"
+        assert loaded.audio_device_name == "Speakers"
+
+    def test_set_audio_device_keeps_previous_device_on_failure(self):
+        from accessiclock.app import AccessiClockApp
+
+        app = AccessiClockApp.__new__(AccessiClockApp)
+        app.audio_device_name = "Headphones"
+        app.audio_player = MagicMock()
+        app.audio_player.set_output_device.side_effect = RuntimeError("device missing")
+        app.save_config = MagicMock()
+
+        assert app.set_audio_device("Speakers") is False
+        assert app.audio_device_name == "Headphones"
+        app.save_config.assert_not_called()
+
 
 class TestAppChimePlayback:
     """Test app chime and alarm orchestration without starting wx."""

--- a/tests/test_audio_player.py
+++ b/tests/test_audio_player.py
@@ -128,6 +128,108 @@ class TestVolumeControl:
         assert player._convert_volume_to_decimal(50) == 0.5
         assert player._convert_volume_to_decimal(100) == 1.0
 
+
+class TestAudioDeviceSelection:
+    """Test sound_lib output device selection helpers."""
+
+    def test_list_output_devices_returns_default_for_fallback_backend(self):
+        import accessiclock.audio.player as player_module
+        from accessiclock.audio.player import AudioPlayer
+
+        original_use = player_module._use_sound_lib
+        try:
+            player_module._use_sound_lib = False
+            player = AudioPlayer.__new__(AudioPlayer)
+            player._current_stream = None
+            player._volume = 50
+            player._audio_output = None
+            player._audio_device_name = ""
+
+            assert player.list_output_devices() == ["Default system device"]
+        finally:
+            player_module._use_sound_lib = original_use
+
+    def test_list_output_devices_includes_sound_lib_devices(self):
+        import accessiclock.audio.player as player_module
+        from accessiclock.audio.player import AudioPlayer
+
+        original_use = player_module._use_sound_lib
+        try:
+            player_module._use_sound_lib = True
+            player = AudioPlayer.__new__(AudioPlayer)
+            player._current_stream = None
+            player._volume = 50
+            player._audio_output = None
+            player._audio_device_name = ""
+
+            mock_output_module = MagicMock()
+            mock_output_module.Output.get_device_names.return_value = ["Default", "Speakers"]
+            with patch.dict("sys.modules", {"sound_lib.output": mock_output_module}):
+                assert player.list_output_devices() == [
+                    "Default system device",
+                    "Speakers",
+                ]
+        finally:
+            player_module._use_sound_lib = original_use
+
+    def test_set_output_device_reinitializes_sound_lib_output(self):
+        import accessiclock.audio.player as player_module
+        from accessiclock.audio.player import AudioPlayer
+
+        original_use = player_module._use_sound_lib
+        original_init = player_module._bass_initialized
+        try:
+            player_module._use_sound_lib = True
+            player_module._bass_initialized = True
+            player = AudioPlayer.__new__(AudioPlayer)
+            player._current_stream = None
+            player._volume = 50
+            old_output = MagicMock()
+            player._audio_output = old_output
+            player._audio_device_name = ""
+
+            new_output = MagicMock()
+            new_output.find_user_provided_device.return_value = 2
+            mock_output_module = MagicMock()
+            mock_output_module.Output.return_value = new_output
+            with patch.dict("sys.modules", {"sound_lib.output": mock_output_module}):
+                player.set_output_device("Speakers")
+
+            old_output.free.assert_called_once()
+            mock_output_module.Output.assert_called_once()
+            new_output.find_user_provided_device.assert_called_once_with("Speakers")
+            new_output.set_device.assert_called_once_with(2)
+            assert player.get_output_device_name() == "Speakers"
+        finally:
+            player_module._use_sound_lib = original_use
+            player_module._bass_initialized = original_init
+
+    def test_set_output_device_default_uses_default_sound_lib_output(self):
+        import accessiclock.audio.player as player_module
+        from accessiclock.audio.player import AudioPlayer
+
+        original_use = player_module._use_sound_lib
+        original_init = player_module._bass_initialized
+        try:
+            player_module._use_sound_lib = True
+            player_module._bass_initialized = False
+            player = AudioPlayer.__new__(AudioPlayer)
+            player._current_stream = None
+            player._volume = 50
+            player._audio_output = None
+            player._audio_device_name = "Speakers"
+
+            mock_output_module = MagicMock()
+            with patch.dict("sys.modules", {"sound_lib.output": mock_output_module}):
+                player.set_output_device("")
+
+            mock_output_module.Output.assert_called_once_with()
+            assert player.get_output_device_name() == ""
+            assert player_module._bass_initialized is True
+        finally:
+            player_module._use_sound_lib = original_use
+            player_module._bass_initialized = original_init
+
     def test_set_volume_updates_playing_stream(self):
         """set_volume should update volume on currently playing stream."""
         import accessiclock.audio.player as player_module

--- a/tests/test_audio_player.py
+++ b/tests/test_audio_player.py
@@ -337,6 +337,68 @@ class TestPlaySound:
             Path(temp_path).unlink(missing_ok=True)
 
 
+class TestPlaySoundSequence:
+    """Test ordered sound sequence playback."""
+
+    def test_play_sound_sequence_returns_false_for_empty_sequence(self):
+        """Empty sound sequences should be ignored."""
+        with patch("accessiclock.audio.player._use_sound_lib", False):
+            from accessiclock.audio.player import AudioPlayer
+
+            player = AudioPlayer()
+            assert player.play_sound_sequence([]) is False
+
+    def test_play_sound_sequence_validates_all_files(self):
+        """Missing files in a sequence should fail before a worker is started."""
+        with patch("accessiclock.audio.player._use_sound_lib", False):
+            from accessiclock.audio.player import AudioPlayer
+
+            player = AudioPlayer()
+            with pytest.raises(FileNotFoundError):
+                player.play_sound_sequence(["/nonexistent/chime.wav"])
+
+    def test_sequence_worker_uses_sound_lib_blocking(self):
+        """Sequence worker should play each file with sound_lib in blocking mode."""
+        import accessiclock.audio.player as player_module
+        from accessiclock.audio.player import AudioPlayer
+
+        original_use = player_module._use_sound_lib
+        try:
+            player_module._use_sound_lib = True
+            player = AudioPlayer.__new__(AudioPlayer)
+            player._volume = 50
+            player._current_stream = None
+            player._play_with_sound_lib = MagicMock()
+
+            paths = [Path("one.wav"), Path("two.wav")]
+            player._play_sequence_worker(paths)
+
+            assert player._play_with_sound_lib.call_count == 2
+            assert player._play_with_sound_lib.call_args_list[0].kwargs["block"] is True
+        finally:
+            player_module._use_sound_lib = original_use
+
+    def test_sequence_worker_uses_fallback_blocking(self):
+        """Sequence worker should use the fallback synchronously when sound_lib is unavailable."""
+        import accessiclock.audio.player as player_module
+        from accessiclock.audio.player import AudioPlayer
+
+        original_use = player_module._use_sound_lib
+        try:
+            player_module._use_sound_lib = False
+            player = AudioPlayer.__new__(AudioPlayer)
+            player._volume = 50
+            player._current_stream = None
+            player._play_with_fallback_blocking = MagicMock()
+
+            paths = [Path("one.wav"), Path("two.wav")]
+            player._play_sequence_worker(paths)
+
+            assert player._play_with_fallback_blocking.call_count == 2
+        finally:
+            player_module._use_sound_lib = original_use
+
+
 class TestIsPlaying:
     """Test is_playing method."""
 

--- a/tests/test_clock_pack.py
+++ b/tests/test_clock_pack.py
@@ -228,6 +228,19 @@ class TestClockPackManifest:
 class TestClockPackValidation:
     """Test clock pack validation."""
 
+    def test_bundled_clock_packs_reference_existing_sounds(self):
+        """Bundled clock pack manifests should not point at missing audio files."""
+        from accessiclock.paths import Paths
+        from accessiclock.services.clock_pack_loader import ClockPackLoader
+
+        loader = ClockPackLoader(Paths().clocks_dir)
+        packs = loader.discover_packs()
+
+        assert packs
+        for pack_info in packs.values():
+            is_valid, errors = loader.validate_pack(pack_info)
+            assert is_valid, f"{pack_info.pack_id} has invalid sound files: {errors}"
+
     def test_validate_sounds_exist(self):
         """Should validate that referenced sound files exist."""
         from accessiclock.services.clock_pack_loader import ClockPackLoader

--- a/tests/test_clock_service.py
+++ b/tests/test_clock_service.py
@@ -117,6 +117,129 @@ class TestChimeScheduling:
         test_time = time(15, 30, 0)
         assert service.should_chime_now(test_time) == "quarter_hour"
 
+    def test_classic_chime_sequence_keeps_single_hour_chime(self):
+        """Classic style should preserve the existing one-sound hourly behavior."""
+        from accessiclock.services.clock_service import ClockService
+
+        service = ClockService()
+        service.chime_style = "classic"
+        service.chime_hourly = True
+
+        assert service.get_chime_sequence(time(15, 0, 0)) == ["hour"]
+
+    def test_grandfather_hour_count_repeats_hour_sound(self):
+        """Grandfather style can count the current hour with repeated hour sounds."""
+        from accessiclock.services.clock_service import ClockService
+
+        service = ClockService()
+        service.chime_style = "grandfather"
+        service.hour_count_chimes = True
+        service.chime_hourly = True
+
+        assert service.get_chime_sequence(time(15, 0, 0)) == ["hour", "hour", "hour"]
+
+    def test_grandfather_quarter_chimes_count_quarter_position(self):
+        """Grandfather quarter-hour style should play one, two, or three quarter sounds."""
+        from accessiclock.services.clock_service import ClockService
+
+        service = ClockService()
+        service.chime_style = "grandfather"
+        service.chime_quarter_hour = True
+        service.chime_half_hour = False
+
+        assert service.get_chime_sequence(time(15, 15, 0)) == ["quarter_hour"]
+        assert service.get_chime_sequence(time(15, 30, 0)) == ["quarter_hour", "quarter_hour"]
+        assert service.get_chime_sequence(time(15, 45, 0)) == [
+            "quarter_hour",
+            "quarter_hour",
+            "quarter_hour",
+        ]
+
+    def test_minute_tick_can_precede_chime_sequence(self):
+        """Optional minute tick should play before interval chimes when both are enabled."""
+        from accessiclock.services.clock_service import ClockService
+
+        service = ClockService()
+        service.minute_tick = True
+        service.chime_hourly = True
+
+        assert service.get_chime_sequence(time(15, 0, 0)) == ["tick", "hour"]
+
+    def test_minute_tick_plays_on_non_chime_minutes(self):
+        """Optional minute tick should be able to sound on ordinary minutes."""
+        from accessiclock.services.clock_service import ClockService
+
+        service = ClockService()
+        service.minute_tick = True
+
+        assert service.get_chime_sequence(time(15, 23, 0)) == ["tick"]
+
+    def test_quiet_hours_silence_tick_and_chime_sequence(self):
+        """Quiet hours should silence all scheduled tick and chime sounds."""
+        from accessiclock.services.clock_service import ClockService
+
+        service = ClockService()
+        service.minute_tick = True
+        service.chime_hourly = True
+        service.set_quiet_hours(time(22, 0), time(7, 0))
+
+        assert service.get_chime_sequence(time(23, 0, 0)) == []
+
+    def test_chime_sequence_not_repeated_same_minute_after_marked(self):
+        """Generated chime sequences should respect the existing duplicate guard."""
+        from accessiclock.services.clock_service import ClockService
+
+        service = ClockService()
+        service.minute_tick = True
+        service.chime_hourly = True
+
+        test_time = time(15, 0, 0)
+        assert service.get_chime_sequence(test_time) == ["tick", "hour"]
+        service.mark_chimed(test_time)
+        assert service.get_chime_sequence(time(15, 0, 30)) == []
+
+
+class TestAlarmScheduling:
+    """Test alarm scheduling, sound, and spoken text behavior."""
+
+    def test_alarm_due_uses_sound_and_spoken_text(self):
+        """A due alarm should expose both its sound and spoken message."""
+        from accessiclock.services.clock_service import ClockService
+
+        service = ClockService()
+        service.set_alarm(time(7, 30), spoken_text="Time to get up", sound_enabled=True)
+
+        alarm = service.get_due_alarm(time(7, 30, 0))
+
+        assert alarm is not None
+        assert alarm.sound_name == "alarm"
+        assert alarm.spoken_text == "Time to get up"
+
+    def test_alarm_ignores_quiet_hours(self):
+        """Quiet hours should not suppress explicit alarms."""
+        from accessiclock.services.clock_service import ClockService
+
+        service = ClockService()
+        service.set_quiet_hours(time(22, 0), time(8, 0))
+        service.set_alarm(time(7, 30), spoken_text="Wake up", sound_enabled=False)
+
+        alarm = service.get_due_alarm(time(7, 30, 0))
+
+        assert alarm is not None
+        assert alarm.sound_name is None
+        assert alarm.spoken_text == "Wake up"
+
+    def test_alarm_not_repeated_same_minute_after_marked(self):
+        """A due alarm should not retrigger after it is marked handled."""
+        from accessiclock.services.clock_service import ClockService
+
+        service = ClockService()
+        service.set_alarm(time(7, 30), spoken_text="Wake up")
+
+        assert service.get_due_alarm(time(7, 30, 0)) is not None
+        service.mark_alarmed(time(7, 30, 0))
+        assert service.get_due_alarm(time(7, 30, 30)) is None
+
 
 class TestChimeTracking:
     """Test that chimes don't repeat within the same minute."""

--- a/tests/test_global_hotkeys.py
+++ b/tests/test_global_hotkeys.py
@@ -1,0 +1,66 @@
+from unittest.mock import MagicMock
+
+
+class FakeWx:
+    MOD_CONTROL = 0x0002
+    MOD_ALT = 0x0001
+    WXK_F8 = 344
+    EVT_HOTKEY = object()
+
+
+def test_parse_hotkey_supports_ctrl_alt_letter():
+    from accessiclock.ui.global_hotkeys import parse_hotkey
+
+    parsed = parse_hotkey("Ctrl+Alt+T", wx_module=FakeWx)
+
+    assert parsed is not None
+    assert parsed.modifiers == FakeWx.MOD_CONTROL | FakeWx.MOD_ALT
+    assert parsed.keycode == ord("T")
+
+
+def test_parse_hotkey_supports_function_key():
+    from accessiclock.ui.global_hotkeys import parse_hotkey
+
+    parsed = parse_hotkey("Ctrl+Alt+F8", wx_module=FakeWx)
+
+    assert parsed is not None
+    assert parsed.keycode == FakeWx.WXK_F8
+
+
+def test_parse_hotkey_rejects_blank_text():
+    from accessiclock.ui.global_hotkeys import parse_hotkey
+
+    assert parse_hotkey("", wx_module=FakeWx) is None
+
+
+def test_global_hotkey_manager_registers_and_dispatches():
+    from accessiclock.ui.global_hotkeys import GlobalHotkeyManager
+
+    frame = MagicMock()
+    frame.RegisterHotKey.return_value = True
+    callback = MagicMock()
+    manager = GlobalHotkeyManager(frame, wx_module=FakeWx)
+
+    assert manager.register("Ctrl+Alt+T", callback) is True
+    frame.RegisterHotKey.assert_called_once()
+    frame.Bind.assert_called_once_with(FakeWx.EVT_HOTKEY, manager._on_hotkey)
+
+    event = MagicMock()
+    event.GetId.return_value = manager._hotkey_id
+    manager._on_hotkey(event)
+
+    callback.assert_called_once()
+
+
+def test_global_hotkey_manager_cleans_up_registered_hotkey():
+    from accessiclock.ui.global_hotkeys import GlobalHotkeyManager
+
+    frame = MagicMock()
+    frame.RegisterHotKey.return_value = True
+    manager = GlobalHotkeyManager(frame, wx_module=FakeWx)
+    manager.register("Ctrl+Alt+T", MagicMock())
+
+    manager.unregister()
+
+    frame.UnregisterHotKey.assert_called_once_with(manager._hotkey_id)
+

--- a/tests/test_system_tray.py
+++ b/tests/test_system_tray.py
@@ -1,0 +1,40 @@
+from unittest.mock import MagicMock
+
+
+def test_tray_menu_labels_are_textual_and_accessible():
+    from accessiclock.ui.system_tray import TRAY_MENU_LABELS
+
+    assert TRAY_MENU_LABELS == [
+        "Show AccessiClock",
+        "Announce Time",
+        "Test Chime",
+        "Settings...",
+        "Exit AccessiClock",
+    ]
+    assert all(label.strip() and "&" not in label for label in TRAY_MENU_LABELS)
+
+
+def test_tray_action_methods_delegate_to_app_and_window():
+    from accessiclock.ui.system_tray import TrayActionHandler
+
+    app = MagicMock()
+    window = MagicMock()
+    app.main_window = window
+    handler = TrayActionHandler(app)
+
+    handler.show_main_window()
+    window.Show.assert_called_once_with(True)
+    window.Raise.assert_called_once()
+
+    handler.announce_time()
+    app.announce_time.assert_called_once()
+
+    handler.test_chime()
+    app.play_test_sound.assert_called_once()
+
+    handler.open_settings()
+    window.open_settings_dialog.assert_called_once()
+
+    handler.exit_application()
+    app.request_exit.assert_called_once()
+

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,4922 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version >= '3.11' and python_full_version < '3.15'",
+    "python_full_version < '3.11'",
+]
+
+[[package]]
+name = "accessiclock"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "attrs" },
+    { name = "httpx" },
+    { name = "playsound3" },
+    { name = "python-dateutil" },
+    { name = "pyttsx3" },
+    { name = "sound-lib" },
+    { name = "wxpython" },
+]
+
+[package.optional-dependencies]
+ai = [
+    { name = "elevenlabs" },
+    { name = "openai" },
+]
+build = [
+    { name = "pillow" },
+    { name = "pyinstaller" },
+]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+    { name = "ruff" },
+]
+
+[package.dev-dependencies]
+ai = [
+    { name = "elevenlabs" },
+    { name = "openai" },
+]
+build = [
+    { name = "pillow" },
+    { name = "pyinstaller" },
+]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "attrs", specifier = ">=22.2.0" },
+    { name = "elevenlabs", marker = "extra == 'ai'", specifier = ">=0.2.0" },
+    { name = "httpx", specifier = ">=0.20.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "openai", marker = "extra == 'ai'", specifier = ">=1.0.0" },
+    { name = "pillow", marker = "extra == 'build'", specifier = ">=10.0.0" },
+    { name = "playsound3" },
+    { name = "pyinstaller", marker = "extra == 'build'", specifier = ">=6.0.0" },
+    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-cov", marker = "extra == 'dev'" },
+    { name = "pytest-mock", marker = "extra == 'dev'" },
+    { name = "python-dateutil" },
+    { name = "pyttsx3" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.0" },
+    { name = "sound-lib", git = "https://github.com/accessibleapps/sound_lib.git" },
+    { name = "wxpython", specifier = ">=4.2.0" },
+]
+provides-extras = ["dev", "build", "ai"]
+
+[package.metadata.requires-dev]
+ai = [
+    { name = "elevenlabs", specifier = ">=0.2.0" },
+    { name = "openai", specifier = ">=1.0.0" },
+]
+build = [
+    { name = "pillow", specifier = ">=10.0.0" },
+    { name = "pyinstaller", specifier = ">=6.0.0" },
+]
+dev = [
+    { name = "mypy", specifier = ">=1.0.0" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+    { name = "ruff", specifier = ">=0.9.0" },
+]
+
+[[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9", size = 123506, upload-time = "2026-06-15T22:00:47.595Z" },
+]
+
+[[package]]
+name = "ast-serialize"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/9d/09e27731bd5864a9ce04e3244074e674bb8936bf62b45e0357248717adac/ast_serialize-0.5.0.tar.gz", hash = "sha256:5880091bfe6f4f986f22866375c2e884843e7a0b6343ae41aeea659613d879b6", size = 61157, upload-time = "2026-05-17T17:48:29.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/9a/13dde51ba9e15f8b97957ab7cb0120d0e381524d651c6bd630b9c359227f/ast_serialize-0.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8f5c14f169eb0972c0c21bada5358b23d6047c76583b005234f865b11f1fa00a", size = 1183520, upload-time = "2026-05-17T17:47:30.831Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/5a7f0a9fe68944f536632a5af84676739c7d2582be42deb082634bf3a754/ast_serialize-0.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7d1a2de9de5be04652f0ed60738356ef94f66db37924a9499fffe98dc491aa0b", size = 1175779, upload-time = "2026-05-17T17:47:32.551Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/81/0bb853e76e4f6e9a1855d569003c59e19ffac45f7079d91505d1bb212f92/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be5173fb66f9b49026d9d5a2ff0fc7c7009077107c0eb285b2d60fdf1fe10bd1", size = 1233750, upload-time = "2026-05-17T17:47:34.731Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d3/4cf705beeccc08754d0bbda99aefff26110e209b9a07ac8a6b60eec48531/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8015cd071ac1339924ee2b8098c93e00e155f30a16f40ec9816fcf84f4753f6", size = 1235942, upload-time = "2026-05-17T17:47:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c8/ee097e437ea27dd2b8b227865c875492b585650a5802a22d82b304c8201b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5499e8797edff2a9186aa313ed382c6b422e798e9332d9953badcee6e69a88f2", size = 1442517, upload-time = "2026-05-17T17:47:38.17Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/bd/68063442838f1ba68ec72b5436430bc75b3bb17a1a3c3063f09b0c05ae2b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6848f2a093fb5548751a9a09bff8fcd229e2bbeb0e3331f391b6ae6d26cd9903", size = 1254081, upload-time = "2026-05-17T17:47:39.826Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e2/1e520793bc6a4e4524a6ab022391e827825eaa0c3811828bfdc6852eca26/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:832d4c998e0b091fd60a6d6bceee535483c4d490de9ba85003af835225719261", size = 1259910, upload-time = "2026-05-17T17:47:41.369Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e1/49b60f467979979cfe6913b43948ff25bca971ad0591d181812f163a988e/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:16db7c62ec0b8efe1d7afd283a388d8f74f2605d56032e5a37747d2de8dba027", size = 1250678, upload-time = "2026-05-17T17:47:43.702Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ba/66ab9555de6275677566f6574e5ef6c29cb185ea866f643bc06f8280a8ee/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:baf5eb061eb5bccade4128ad42da33787d72f6013809cd1b590376ece8b3c937", size = 1301603, upload-time = "2026-05-17T17:47:46.256Z" },
+    { url = "https://files.pythonhosted.org/packages/66/42/6aca9b9abc710014b2be9059689e5dd1679339e78f567ffb4d255a9e2050/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:104e4a35bd7c124173c41760ef9aaea17ddb3f86c65cb643671d59afbe3ee94c", size = 1410332, upload-time = "2026-05-17T17:47:47.899Z" },
+    { url = "https://files.pythonhosted.org/packages/47/68/2f76594432a22581ecf878b5e75a9b8601c24b2241cf0bbeb1e21fcf370c/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:36be371028fc1675acb38a331bde160dbab7ff907fdf00b67eb6911aa106951b", size = 1509979, upload-time = "2026-05-17T17:47:50.942Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ac/a93c9b58292653f6c595752f677a08e608f903b710594909e9231a389b3b/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:061ee58bdb52341c8201a6df41182a977736bae3b7ded87ca7176ca25a8a47ab", size = 1505002, upload-time = "2026-05-17T17:47:54.093Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2e/b278f68c497ee2f1d1576cbbef8db5281cd4a5f2db040537592ac9c8862e/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b15219e9cdc9f53f6f4cb51c009203507228226148c05c5e8fe451c28b435eb3", size = 1456231, upload-time = "2026-05-17T17:47:56.311Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/419be1c566a4c504cd8fd60ce2f84e790f295495c0f327cfaeadf3d51012/ast_serialize-0.5.0-cp314-cp314t-win32.whl", hash = "sha256:842d1c004bb466c7df036f95fabef789570541922b10976b12f5592a69cf0b38", size = 1058668, upload-time = "2026-05-17T17:47:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/03/6f/c9d4d549295ed05111aeb8853232d1afd9d0a179fddb01eeffbb3a4a6842/ast_serialize-0.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b0c06d760909b095cc466356dfccd05a1c7233a6ca191c020dca2c6a6f16c24c", size = 1101075, upload-time = "2026-05-17T17:48:00.35Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/8e/d00c5ab30c58222e07d62956fca86c59d91b9ad32997e633c38b526623a3/ast_serialize-0.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:787baedb0262cc49e8ce37cc15c00ae818e46a165a3b36f5e21ed174998104cb", size = 1075347, upload-time = "2026-05-17T17:48:01.753Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9e/dc2530acb3a60dc6e46d65abf27d1d9f86721694757906a148d90a6860de/ast_serialize-0.5.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0668aa9459cfa8c9c49ddd2163ebcf43088ba045ef7492af6fe22e0098303101", size = 1191380, upload-time = "2026-05-17T17:48:03.738Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0a/bd3d18a582f273d6c843d16bb9e22e9e16365ff7991e92f18f798e9f1224/ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bf683d6363edf2b39eed6b6d4fe22d34b6203867a67e27134d9e2a2680c4bc4a", size = 1183879, upload-time = "2026-05-17T17:48:05.463Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/1f919100f8620887af58fcc381c61a1f218cdf89c6e155f87b213e61010a/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc22cf0c9be65e71cf88fda130af60d61eb4a79370ad4cfe7900d48a4aa2211", size = 1244529, upload-time = "2026-05-17T17:48:07.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ca/6376559dcce707cdbc1d0d9a13c8d3baaaa501e949ce0ebdc4230cd881aa/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f66173891548c9f2726bf27957b41cabce12fa679dc6da505ddbde4d4b3b31cf", size = 1240560, upload-time = "2026-05-17T17:48:08.46Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b2/a620e206b5aeb7efbf2710336df57d457cffbb3991076bbcc1147ef9abd4/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e42d729ef2be96a14efbad355093284739e3670ece3e534f82cc8832790911d9", size = 1451172, upload-time = "2026-05-17T17:48:09.922Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/e0/4ad5c04c24a40481b2935ce9a0ccdb6023dc8b667167d06ae530cc3512f2/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b725026bafa801dbd7310eb13a75f0a2e370e7e51b2cb225f9d21fcfadf919ee", size = 1265072, upload-time = "2026-05-17T17:48:11.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/71/4d1d479aa56d0101c40e17720c3d6ac2af7269ea0487a80b18e7bfd1a5b7/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b54f60c1d78767a53b67eaa663f0dfac3afe606aa07f1301572f588b73d64809", size = 1270488, upload-time = "2026-05-17T17:48:13.575Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4f/0de1bbe06f6edef9fde4ed12ca8e7b3ec7e6e2bd4e672c5af487f7957665/ast_serialize-0.5.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:27d51654fc240a1e87e742d353d98eb45b75f62f129086b3596ab53df2ac2a43", size = 1260702, upload-time = "2026-05-17T17:48:15.141Z" },
+    { url = "https://files.pythonhosted.org/packages/75/61/e00872439cfdddcc3c1b6cdaa6e5d904ba8e26a18807c67c4e14409d0ca8/ast_serialize-0.5.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c36237c46dd1674542f2109740ea5ea485a169bf1431939ada0434e17934", size = 1311182, upload-time = "2026-05-17T17:48:16.779Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8e/699a5b955f7926956c95e9e1d74132acad73c2fe7a426f94da89123c20aa/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1943db345233cc7194a470f13afa9c59772c0b123dea0c9414c4d4ca54369759", size = 1421410, upload-time = "2026-05-17T17:48:18.527Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ae/d5b7626874478997adc7a29ab28accf21e596fb590c944290401dfd0b29e/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:df1c00022cbbcb064bfaa505aa9c9295362443ce5dacb459d1331d3da353f887", size = 1516587, upload-time = "2026-05-17T17:48:20.133Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ce/b59e02a82d9c4244d64cde502e0b00e83e38816abe19155ceb5437402c7f/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cae65289fc456fde04af979a2be09302ef5d8ab92ef23e596d6746dc267ada27", size = 1515171, upload-time = "2026-05-17T17:48:21.921Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/38/d8d90042747d05aa08d4efcf1c99035a5f670a6bf4c214d31644392afbca/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:239a4c354e8d676e9d94631d1d4a64edc6b266f86ff3a5a80aedd344f342c01d", size = 1464668, upload-time = "2026-05-17T17:48:23.544Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/51/5b840c4df7334104cecffa28f23904fe81ca89ca223d2450e288de39fd3c/ast_serialize-0.5.0-cp39-abi3-win32.whl", hash = "sha256:143a4ef63285a075871908fda3672dc21864b83a8ec3ee12304aa3e4c5387b9a", size = 1068311, upload-time = "2026-05-17T17:48:25.027Z" },
+    { url = "https://files.pythonhosted.org/packages/41/11/ca5672c7d491825bc4cd6702dea106a6b60d928707712ec257c7833ae476/ast_serialize-0.5.0-cp39-abi3-win_amd64.whl", hash = "sha256:cf25572c526add400f26a4750dc6ce0c3bb93fc1f75e7ae0cad4ce4f2cd5c590", size = 1108931, upload-time = "2026-05-17T17:48:26.591Z" },
+    { url = "https://files.pythonhosted.org/packages/45/19/cc8bd127d28a43da249aa955cfd164cf8fd534e79e42cea96c4854d72fd0/ast_serialize-0.5.0-cp39-abi3-win_arm64.whl", hash = "sha256:92a31c9c20d25a076edaeec76b128a3535d74a24f340b9a8a7e96c9b86dc9642", size = 1081181, upload-time = "2026-05-17T17:48:28.122Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d", size = 315182, upload-time = "2026-04-02T09:25:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8", size = 209329, upload-time = "2026-04-02T09:25:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/01fa81c5ca6141024d89a8fc15968002b71da7f825dd14113207113fabbd/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790", size = 231230, upload-time = "2026-04-02T09:25:44.281Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/7b991776844dfa058017e600e6e55ff01984a063290ca5622c0b63162f68/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc", size = 225890, upload-time = "2026-04-02T09:25:45.475Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393", size = 216930, upload-time = "2026-04-02T09:25:46.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ab/b18f0ab31cdd7b3ddb8bb76c4a414aeb8160c9810fdf1bc62f269a539d87/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153", size = 202109, upload-time = "2026-04-02T09:25:48.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e5/7e9440768a06dfb3075936490cb82dbf0ee20a133bf0dd8551fa096914ec/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af", size = 214684, upload-time = "2026-04-02T09:25:49.245Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34", size = 212785, upload-time = "2026-04-02T09:25:50.671Z" },
+    { url = "https://files.pythonhosted.org/packages/66/cd/6e9889c648e72c0ab2e5967528bb83508f354d706637bc7097190c874e13/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1", size = 203055, upload-time = "2026-04-02T09:25:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/7a951d6a08aefb7eb8e1b54cdfb580b1365afdd9dd484dc4bee9e5d8f258/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752", size = 232502, upload-time = "2026-04-02T09:25:53.388Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/abcf2d83bf8e0a1286df55cd0dc1d49af0da4282aa77e986df343e7de124/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53", size = 214295, upload-time = "2026-04-02T09:25:54.765Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/7d4cd7ed54be99973a0dc176032cba5cb1f258082c31fa6df35cff46acfc/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616", size = 227145, upload-time = "2026-04-02T09:25:55.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a", size = 218884, upload-time = "2026-04-02T09:25:57.074Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/2e8b7f8915ed5c9ef13aa828d82738e33888c485b65ebf744d615040c7ea/charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374", size = 148343, upload-time = "2026-04-02T09:25:58.199Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943", size = 159174, upload-time = "2026-04-02T09:25:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/feb40dca40dbb21e0a908801782d9288c64fc8d8e562c2098e9994c8c21b/charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008", size = 147805, upload-time = "2026-04-02T09:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "comtypes"
+version = "1.4.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/2a/65274c13327f637ec13af8d39f2cf579d9ebe7a0e683696b5f05236d2805/comtypes-1.4.16.tar.gz", hash = "sha256:cd66d1add01265cface4df51ba1e31cd1657e04463c281c802e737e79e1ba93c", size = 260252, upload-time = "2026-03-02T23:11:42.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/7c/0eb685107290b6221c03c46d39214a4e42a124189691cb83ae3228257f46/comtypes-1.4.16-py3-none-any.whl", hash = "sha256:e18d85179ff12955524c5a8c3bc09cb3c0d890f1da4d7123d14244c7b78f84c8", size = 296230, upload-time = "2026-03-02T23:11:41.049Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/69/0d2ef01ff4b8fcecd4cba920d11e92fa4f96ae412441d3b56a90a258e69b/coverage-7.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3e3680291c4a1d0dadfa84a2c459576a4af5133abb617905714339a0c73138cf", size = 219722, upload-time = "2026-05-26T20:38:14.002Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ae/9afdeaa31b9d9ce98124b6abf8bb49119bf71aecae04f8567c189d91299f/coverage-7.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a5274669f37f2343635a347b91a60777621341ab3378e9c6ac9335eee704bddf", size = 220240, upload-time = "2026-05-26T20:38:17.424Z" },
+    { url = "https://files.pythonhosted.org/packages/51/69/c998589871df7ea7dba865cc5ee32b5a3e1d47ba6c68ef91104c7c46fa5e/coverage-7.14.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cfe5a5fec635799ef33428f1e5e61bafa45a92a96190ba731561ba558ccc214d", size = 246981, upload-time = "2026-05-26T20:38:19.266Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/10/1c7d04c13040dac531d21b712bbe08f902e6dd9b58f5d77875c4d030f8f2/coverage-7.14.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:62a9f70b52e0b5a95cfef4a5c5641b06983cadc5e538a3feeb5c00211f523ac2", size = 248812, upload-time = "2026-05-26T20:38:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/65/2a38a4607ef27cadcfbcee034dba5830ae2569f90144a0f4c7dbf47d30b0/coverage-7.14.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c18ebc343e15be53049b3a2dce38fe82d58f37e20ab9094b3a39c0aa4f6bb47", size = 250675, upload-time = "2026-05-26T20:38:22.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a2/a446ed9752a4a59b79e0fb6cbb319f6facb2183045c0725462625e66f87e/coverage-7.14.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b84ffdf877644e7096aa936991efeed873f7f3df57b9cd001312b7668ab08550", size = 252590, upload-time = "2026-05-26T20:38:23.63Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/fd/e81fbd7ba752365546e9842b1cbdaad3d6919d2a522c590aef16a281ec5e/coverage-7.14.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e854312c4103f2ad4c0dc023b69b77ebfd2c89db5f86c4c94dc2353f9a92167e", size = 247691, upload-time = "2026-05-26T20:38:25.057Z" },
+    { url = "https://files.pythonhosted.org/packages/53/35/f3c26fdaae9ea937d154ca4d372e5ea0a4167ff70d36c6074ac2eacb2f83/coverage-7.14.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c643734307300234fafa36bf2a040a7235f8f177ea1fd6ec1423aea6fb7b929f", size = 248716, upload-time = "2026-05-26T20:38:26.406Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/14/940b6c49551fd343e8507ee2b0ba7af5d0aa04ed5bf768285cb7c72a9884/coverage-7.14.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:84ac9499e48700399a5dd0ea7085b5091961fec52c68d66b4ec0d3cf7f4441b1", size = 246721, upload-time = "2026-05-26T20:38:28.282Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2c/40fc0634186c28292a662dff578866b3913983d6c375a3c2a74020938719/coverage-7.14.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7f02d09f70776579b926d889a4c9c235070a1f47c40458aeaca563fae5acfdb5", size = 250533, upload-time = "2026-05-26T20:38:29.753Z" },
+    { url = "https://files.pythonhosted.org/packages/de/e3/2c26bf1e811f9df991ff2a9bdddebdd13ee0665d564df7d05979f9146297/coverage-7.14.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ce66d8e46da2bb5ee313a745cbd2e391d319176c1f7a9451bfcd3a2fb920859b", size = 246990, upload-time = "2026-05-26T20:38:31.516Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b0/060260ef56bd92363ebdce0c7095ce422b06e69aae71828efeca473ab1ca/coverage-7.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c912c259304cfb5ee584481cfb7ce1ff932b4d61e6c9140b8f19cb7b5ed82332", size = 247593, upload-time = "2026-05-26T20:38:33.065Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f3/501502046efeb0d6d94b5ca54941d95f1184183dd6bdb7f283985783bb4a/coverage-7.14.1-cp310-cp310-win32.whl", hash = "sha256:1238cb94638e610e972c60dac68e813f868dc7d6e982535270558443058d9d59", size = 222330, upload-time = "2026-05-26T20:38:35.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5d/1bf99f2c558f128faf7906817ccbdb576ba815d3b41ce2ac1719b70a3663/coverage-7.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:fc459e5d73be2d6332fcfe8dbf3d8994671fe33c700f4565988ecfa511547253", size = 223261, upload-time = "2026-05-26T20:38:37.196Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d7/477ad149490e6cb849f28abea1dabb9c823cea72e7500c81b4240ce619c0/coverage-7.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:478b5bcd63c2e1357c5c7e16c070690df7b07f676b1c114d7b93e533c664309f", size = 219848, upload-time = "2026-05-26T20:38:38.715Z" },
+    { url = "https://files.pythonhosted.org/packages/91/82/a5eb47257c50601bb7b9a9d2857c67b7a3a85ad74180eb2c98bb1fbe0ce5/coverage-7.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a24a81f9715ee42ef59a316cc11611c98fe23920f7c81861315c9f3ff4a230f4", size = 220354, upload-time = "2026-05-26T20:38:40.232Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8b/78419b5391a5cb706b6544390507e469d83ffc9a8248b02c4011aceb9365/coverage-7.14.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:196a13319ad88d6d8ef5ab489ec4f44ddde2143c0c7d5b27786f6c3ffd56a7e1", size = 250771, upload-time = "2026-05-26T20:38:41.782Z" },
+    { url = "https://files.pythonhosted.org/packages/77/63/e77aaacd491182210d639636b7a8bba23ffffa9b82aa3762da9431855fa9/coverage-7.14.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3d452fd08b5c72c5167c93e6867b5c08500bd40f2a21e1e854a500550b6cc36f", size = 252683, upload-time = "2026-05-26T20:38:43.305Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/a022e3cfbec2ac241640003cb3a817e161d9c7f5aa9b49173756cdc03204/coverage-7.14.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23bf7fa51ac02e07fc7c96849b82946da47ae862dc8f86d183b2a4864fc38129", size = 254791, upload-time = "2026-05-26T20:38:45.361Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d6/967e408aca4c1ceb88cb0cc677169110ae7f5995fb5eaf5fb1f5a1bb8f5d/coverage-7.14.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcaa50684dcaadfa599ac48f81103c756d791cfd85c97203d2217c593d48b860", size = 256748, upload-time = "2026-05-26T20:38:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/be/869188f7fe28638078ec479331ace6dc5f7b40b7153eb616f47ab79404d8/coverage-7.14.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4ea1c034f95c9b056e856b794630b17f9fa3d57e4800ff1e503d3be0f9c9078c", size = 250907, upload-time = "2026-05-26T20:38:48.493Z" },
+    { url = "https://files.pythonhosted.org/packages/07/aa/adb7d3b4278d690e68703abcd76ab1b948242e3668d921711551b78f9ddb/coverage-7.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c7e057326434e441306226fbeb5d1aaf14a2637efe97ba668306635835f32ad7", size = 252483, upload-time = "2026-05-26T20:38:50.074Z" },
+    { url = "https://files.pythonhosted.org/packages/43/61/331c74103c62dcb0c4b9b3a0de9a61aca016208b0a90f109592a9f9ecc28/coverage-7.14.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:59baf88468dbc8d63b1887afd92bda52e40bb1561696e5819670601403810cec", size = 250545, upload-time = "2026-05-26T20:38:51.613Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b6/c5dae3c104d89be04828f61810e6b3473825482e4c288cc4ed04553e08ae/coverage-7.14.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d34d75f892b3ab73ba11cab5442cce7b3e168fd64162b16f0e1e0d09c508edef", size = 254310, upload-time = "2026-05-26T20:38:53.503Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a1/2b9d5863e3b83c01ad8199e3c597802fbb3a9dc90b058885804c20296d31/coverage-7.14.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3a56abc20a472baf0304c455721bc601477440d28ecfde8a03dde79ede07e0df", size = 250266, upload-time = "2026-05-26T20:38:55.414Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5e/0e511fbdb269359be26fe678a1c3fa1f2aa2a01573cc3f54268c8d6d4797/coverage-7.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6a3cb83d1552c0cd1b4906655b6a33fd4a8473229633a901c6b73bf86914dee9", size = 251174, upload-time = "2026-05-26T20:38:57.141Z" },
+    { url = "https://files.pythonhosted.org/packages/85/10/e55307b622b3dd9671cb321824502dc10f93e72f2802b9946159a8edadeb/coverage-7.14.1-cp311-cp311-win32.whl", hash = "sha256:10274a1fbeb8ec5d72966e17bb198a3104257aca4ac09d98667c5f8aca8c8548", size = 222354, upload-time = "2026-05-26T20:38:58.727Z" },
+    { url = "https://files.pythonhosted.org/packages/71/cf/107421693cfb71e4f1ca5bf70443f64d4161878068d07a3e51c7ad21d17b/coverage-7.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:87ebdf787d4888e3f3f2d523eadc6e18c6d18c6d0eb173801a189641627fb37e", size = 223290, upload-time = "2026-05-26T20:39:00.413Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/1d/3e3644585eb29e9dafefb19555078529a4d7cce12bd21929664eea989277/coverage-7.14.1-cp311-cp311-win_arm64.whl", hash = "sha256:dd34767fa19848d35659ffc0a75314f58c7af3f1cd87ec521e8292a1238398a3", size = 221953, upload-time = "2026-05-26T20:39:02.159Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c", size = 220379, upload-time = "2026-05-26T20:39:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/de/72/de048c4a25e13bce59ac6a339351c10bdf2515e07459afcdaf04dc3143a2/coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b", size = 251888, upload-time = "2026-05-26T20:39:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6", size = 254624, upload-time = "2026-05-26T20:39:09.037Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ed/7b25642496e8170b6bac14adce00537c6e5fa2d586159401a4de3e8b49e6/coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37", size = 255739, upload-time = "2026-05-26T20:39:10.889Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a2/abd210b8c4e29c24e4624916db97bb519097a91034aaeb767f937e7da794/coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad", size = 257998, upload-time = "2026-05-26T20:39:12.722Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/24/7c50beed3792fe62f6ce0545c6686ce83379719e2c0276179333d97eae92/coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84", size = 252296, upload-time = "2026-05-26T20:39:14.259Z" },
+    { url = "https://files.pythonhosted.org/packages/15/05/0f874628ebcbfc77ead559ff210281ef06a97db08481832e7dd39274a135/coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54", size = 253658, upload-time = "2026-05-26T20:39:15.923Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6f/ca6ad067364b337ef997802115e7ecad2abd2248b05471464b0dea02b4d4/coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7", size = 251803, upload-time = "2026-05-26T20:39:17.537Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/30/b9b4d377cd9f40baf228068f5a81faf8450c6228503011bd499708483a50/coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9", size = 255873, upload-time = "2026-05-26T20:39:19.414Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/21/7c721a9e5e6bb88547d30a787aefb97512d3f54c1324c7488d9b3743f7f9/coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02", size = 251372, upload-time = "2026-05-26T20:39:21.169Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f8ae5a2200130e1503cd7661a6cd3b2b7bacef98277fbf3571fb13f8b766/coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a", size = 253245, upload-time = "2026-05-26T20:39:23.097Z" },
+    { url = "https://files.pythonhosted.org/packages/34/62/70a9024672a5f6910517d9628c52c9afbdd3cf8f46426af52bb148a56fff/coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1", size = 222567, upload-time = "2026-05-26T20:39:24.868Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/8b7cd386839b039ebe1855733b9f9449a8dec5d79564018234f185a7fa70/coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e", size = 223372, upload-time = "2026-05-26T20:39:26.603Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ba/b44d472022f620d289d95fa830143235c0c36461c6f2437ea8d51e5481ed/coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a", size = 221989, upload-time = "2026-05-26T20:39:28.242Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9e/5f6d56327c62b185225d145191c607e07515294a0aa6338e58805cd4a5ac/coverage-7.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793", size = 220044, upload-time = "2026-05-26T20:39:29.902Z" },
+    { url = "https://files.pythonhosted.org/packages/75/92/e82aca356744cbbc0f77a0b623e38918c1872361963413a3bab5d0340393/coverage-7.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d", size = 220412, upload-time = "2026-05-26T20:39:31.561Z" },
+    { url = "https://files.pythonhosted.org/packages/27/c9/385bde0bf7ed0f4bf3a7ee5367060a86b5d218718cfd6fb943c0f836b34f/coverage-7.14.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247", size = 251412, upload-time = "2026-05-26T20:39:33.337Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/23faf6a2343a0d17f960a4bd56c43bc7eb4cf312f774dd6ceebd82c7d8fc/coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d", size = 254008, upload-time = "2026-05-26T20:39:35.009Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/36f4aa9ca8a815e6036156e80706a67828bb97bd826948244f6996dda957/coverage-7.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f0cfc27c539f07cf5c0a4cfe211d0b6cae039f8f40526dbaa71944e64b50a7b", size = 255241, upload-time = "2026-05-26T20:39:36.71Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/79/95266316352f90f6b1c6736bb413302edfde2453fb32422d3911642691b3/coverage-7.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:221c70f316241a78e77e607c227cefc8808d4e08f28d99c04f35694690e940be", size = 257373, upload-time = "2026-05-26T20:39:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/9c/58316d1f66c488b5fca8a0eb3e98348807813efa8a0d0833b9021be27488/coverage-7.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da028256b04ec30e5e0114b6f76172938c313991f0a2d3d894271315cf5d5e43", size = 251635, upload-time = "2026-05-26T20:39:40.268Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5a/ca2398a568e16fed7bb713e84ba3603a7164fb65779abe645c565ec890d5/coverage-7.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76a085d7005236a767e3426148b2c407e53ad61695c562f8a81da2d373324901", size = 253373, upload-time = "2026-05-26T20:39:42.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2c/0396562c32deaebe7be51d865b3a41e9a87d7561acafe1a28f53b07e019a/coverage-7.14.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b553d04b5e778a8e56d57eb134aff42a92718ecba45e79c4764ecfa40efd92ff", size = 251341, upload-time = "2026-05-26T20:39:43.907Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/8f/a94f9221184c9cae1ee115820e3798e48b6b17777a9f19e46fb9a0c8dc74/coverage-7.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:46f714d2fb8ae2f4f29f23ada7f1e79b759fff5a70f94a1dac23af204c3ec9e4", size = 255497, upload-time = "2026-05-26T20:39:46.166Z" },
+    { url = "https://files.pythonhosted.org/packages/71/69/505d70e47db1eaebcd002c39759707621ef184cd6b1ae084d9f41293f323/coverage-7.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1896f5e19ff3f0431c7ce2172adc54890fd97f86b59ced8ca1649145d9ffe35d", size = 251159, upload-time = "2026-05-26T20:39:48.03Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/aa/58681c383aa33a9d2ed40a02d7a22fbf780d1fa4d575396365777828198c/coverage-7.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:62fd185ef9df3c33d1c8178c5af105f762afbad96038de9a4ae100aa6297ca33", size = 252934, upload-time = "2026-05-26T20:39:49.872Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fd/11c928cd6bdffc7074bb5965c173d9ebf517fb00205e1da524b98d29ef92/coverage-7.14.1-cp313-cp313-win32.whl", hash = "sha256:ab4af6352741a604c431c6072fce5bee33bf0f20dc7a56618d6bf6bb89e9810c", size = 222584, upload-time = "2026-05-26T20:39:51.68Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/92/fb416fc26d340dcba19518c418d6048e913186e17243982c5e435e41fa7a/coverage-7.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:7af486dabe8954d03b087f0021540897afe084f04e16ff5579e08cc46f871416", size = 223394, upload-time = "2026-05-26T20:39:53.472Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c6/02d56e3867972f77d5036de924643f26c056e848f00452cafb4dbc3c29b4/coverage-7.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:2224f89ffd0c5605ccce1ed7a584da162bc7c55f601ab1c946bc9de31a486b42", size = 222015, upload-time = "2026-05-26T20:39:55.374Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9e/fcc77914050df73f7662fa1f00902774c79c075a8388ab334074574bf77e/coverage-7.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de286598cc65d2b489411174b1faec2f5a7775fb3201fd925db2a76b4030f37d", size = 220733, upload-time = "2026-05-26T20:39:57.189Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/67/2963cbdaf5cbadec44efa3a1e39eaa1f02df4079585f05387607a221e126/coverage-7.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:042c46ded7c288aeb07cf14a28b6c1e10b78fcba40171c3fa1e939377eeef0b5", size = 221086, upload-time = "2026-05-26T20:39:59.019Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/8701645574e11881f2f47d8930f98bc48b5d43b25eb5b4430dfc4a2f9f48/coverage-7.14.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4ddbe407477f04c45115d1a4e5bc480f753553b534d338d4c3358b1cdd0ea52", size = 262381, upload-time = "2026-05-26T20:40:00.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/28/7a64d73598263e0c5abd5084211a8474488d31b3c552ff531c719dfcff62/coverage-7.14.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d13e6725992e2d2fd7d81d4f5241952d13740121dfd501da09201be39b2c003a", size = 264458, upload-time = "2026-05-26T20:40:02.506Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/d8/4969179db9f7eb4df218e69540adf829d1c835f59452513d065d15446802/coverage-7.14.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f747dc8edcfe740130f28f32f3995e955494285717e86ee25af51db2219df08a", size = 266884, upload-time = "2026-05-26T20:40:04.421Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/78/a45d5794dbc9bafd97afc96a4377c86c7820d78b6cf51b89bc1d4e919275/coverage-7.14.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced2f09ef276fd58611a1ef502164ad266d2b75174e5a40cabbdb4033f9f6cf2", size = 268022, upload-time = "2026-05-26T20:40:06.298Z" },
+    { url = "https://files.pythonhosted.org/packages/21/cb/4f5e354e9e3e67af96bd4e57113e6db6b22298c7168b13eec408a549903d/coverage-7.14.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b84800013769a78ccb9ef4659402e26d06867e337b61ec365f77ad008adea80e", size = 261631, upload-time = "2026-05-26T20:40:08.226Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/49/eced49af4cb996d5d8b7e94e736175c513e4facd3398507b89892b4326d8/coverage-7.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ea8cd6ca0ee9f616aaef3afc6882e32c2cbf18b00d96313ffd76af650574034d", size = 264443, upload-time = "2026-05-26T20:40:10.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d8/5603a88a7c5913a6b54f6cb1a8c46f7b39cbb30f27cd3f492908da09b2d7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:aa5e304a873fabddc11e484e9b6b738bd38bd7bed17b09aa84eecf5332e8b8bb", size = 262069, upload-time = "2026-05-26T20:40:11.999Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/59/2ae3cb79da554a06c8619d6c88ea19dd1e4aed4b834b6a83bb1fa243bdc5/coverage-7.14.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5a1c5215be81035e629d5bc756650634d0bf31991038db7a0eccb90f025ce16d", size = 265780, upload-time = "2026-05-26T20:40:13.858Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5f/b130c1dc999031f2648bd25317fbce505ad8d5562079b4ed81e736a84967/coverage-7.14.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:79058c47dae6788504b5effb319961bcd72d7240551464b91d474bc0ed186d69", size = 260970, upload-time = "2026-05-26T20:40:16.142Z" },
+    { url = "https://files.pythonhosted.org/packages/87/d1/ec13ccddeb48ec963bdfa72a11224bac2584bd045ba13beca82f8113e9c7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:370c5afae3fa0658e11694a32b24c2778f6bc2d17718121f94ee185e69f26b54", size = 263157, upload-time = "2026-05-26T20:40:18.382Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c2/cd91ead503045161092d3845f7bb95ea2f25131ce96d3e314dd835d91b9c/coverage-7.14.1-cp313-cp313t-win32.whl", hash = "sha256:3758dd0a7f1fa57365ef2e781df0f0731d38b6e3772259d13dae4bd8a958d4b1", size = 223259, upload-time = "2026-05-26T20:40:20.381Z" },
+    { url = "https://files.pythonhosted.org/packages/71/9f/1e28d97e6bd2c76b07f38b7c02870f1371255ff6717f54eca578fcbbdd0e/coverage-7.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:6ff665fb023a77386fe11685190cee1f60a7d635994a30d9b0a061533d470fce", size = 224320, upload-time = "2026-05-26T20:40:22.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e0/d936e908f0e1efa55e52b91e01b52f1055cef5e1ab2718493390ed8e2fb8/coverage-7.14.1-cp313-cp313t-win_arm64.whl", hash = "sha256:17a5a241e5997621a956a7f402a7433ef4221e5152809b785bec79e2323799f1", size = 222577, upload-time = "2026-05-26T20:40:24.894Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/34/fc2f101b151af3799a101f0550b0454aa008afdc0add677394ec4aa8ea10/coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee", size = 220091, upload-time = "2026-05-26T20:40:27.249Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a7/1ebae2ab5b961b5c79bb09fe7b3ac99edb190d8be4a8c510b2cf66f46468/coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500", size = 220421, upload-time = "2026-05-26T20:40:30.084Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/90/92aca9cf0acc95123c96cd1eb1f08917897a7f5dee01e15738922971ec31/coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906", size = 251466, upload-time = "2026-05-26T20:40:32.542Z" },
+    { url = "https://files.pythonhosted.org/packages/26/2b/78048cbe3b999f6cbf9cc0d90abba6a88a3e0863a8c1c6cbc762f3f8802f/coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42", size = 253973, upload-time = "2026-05-26T20:40:34.473Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/21/c2e33b29d1cfde484a19d437afc343c6cd30b08d78cbbf9f5aff14e57b2b/coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8", size = 255318, upload-time = "2026-05-26T20:40:38.154Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ee/aad2f108d63b769121005302f16bf66db8625c88ceaba466942e09a2607e/coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851", size = 257633, upload-time = "2026-05-26T20:40:40.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f8/11a2c29b4fd76d9849f81d0bb812ec0017a9396df3217214e38934a8c837/coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034", size = 251488, upload-time = "2026-05-26T20:40:42.631Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/9a5820de4b8ac2b71d85e3b5fb49108d7469c665f0e2ad0dd7569023e305/coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c", size = 253329, upload-time = "2026-05-26T20:40:45.208Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ff/f33e4823667e27548e8fd8df44217515303f9808d0ff29817db56f87d990/coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36", size = 251291, upload-time = "2026-05-26T20:40:47.502Z" },
+    { url = "https://files.pythonhosted.org/packages/68/9b/489db0ebb209054766b90a9014a45f6d26eb724c02ec21311c3733b5a644/coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5", size = 255564, upload-time = "2026-05-26T20:40:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b5/16bc2d4c2409b23c7737edb68c83bc89e345f378050549fe1d75ac7d34d5/coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4", size = 251107, upload-time = "2026-05-26T20:40:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/0c/2629997469a00cd069d588a41c9dc887610f2775ae89d250c4791e65272a/coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d", size = 252764, upload-time = "2026-05-26T20:40:54.267Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ee/f78d63c8f079e0d7211c7e2401fa17e311514534ba61bae03e4b287ce4ab/coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee", size = 222837, upload-time = "2026-05-26T20:40:56.496Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/be539854f93a70dfbeec69117f33ec70dc42ff0b65b5b07ab8d40d04228e/coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7", size = 223650, upload-time = "2026-05-26T20:40:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9e/24e2842fef40f35ac82ba3a7719c8023d011bf3bf652d0675316a9d088a1/coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343", size = 222218, upload-time = "2026-05-26T20:41:00.321Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1d/ac0a9df5fe31c1e8bdd658074905fc12844a05c1a7e3fdb8417e97c31e23/coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1", size = 220822, upload-time = "2026-05-26T20:41:02.281Z" },
+    { url = "https://files.pythonhosted.org/packages/32/cf/f964fd9aff20323f9f1a726c97135f8a76bcd87b92dad141a456a43f3c64/coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b", size = 221084, upload-time = "2026-05-26T20:41:04.593Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5e/7e5ef2aba844de2b80d678619fcf0841b42e3f37f16411226f3fe4c1016f/coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474", size = 262454, upload-time = "2026-05-26T20:41:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/64/62/75809bded87015cc4935524218a2a8ed8dd1a8498bfed30a2f4f7a4b4d34/coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86", size = 264578, upload-time = "2026-05-26T20:41:08.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/42/d33392dc14633525012d2d504fa1a33b05538bf535f5c1d64675e5754b78/coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e", size = 266981, upload-time = "2026-05-26T20:41:10.824Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/49/0157c4428c2aca7f1e09d5565930586fd5ae36f1655f08b0daa7cf1fcae1/coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65", size = 268112, upload-time = "2026-05-26T20:41:12.966Z" },
+    { url = "https://files.pythonhosted.org/packages/96/26/86b9ce71f4092b1ed325ce1421698081df1286b833400b6836912834d6e0/coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e", size = 261558, upload-time = "2026-05-26T20:41:15Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4c/c311210c5472cf5401d8422b0d7812cdd520f24417673afabda6c323faca/coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8", size = 264447, upload-time = "2026-05-26T20:41:17.369Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/71/59513f8710ed3e6b0ac0a050a5b7e977bb9c9e880354863b5d00d8809256/coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07", size = 262048, upload-time = "2026-05-26T20:41:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/bceed32dc494f5bbf50f775cd2e78ca814953942b5ea28d3c1c3ac316f14/coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de", size = 265781, upload-time = "2026-05-26T20:41:21.559Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c5/9348fe40dbfd4991aaf78df2c6c3098bfb2cc834d1fd362a64b4efef855a/coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890", size = 260896, upload-time = "2026-05-26T20:41:23.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/92/1ea0f03929da7cf87206b1fa24f4c8e9c158be0455481af29ec0a1f3503f/coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd", size = 263214, upload-time = "2026-05-26T20:41:25.419Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a9/b2493c054c0e01a643266742ab45e15744e60743f9260cd930c7142b1124/coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e", size = 223624, upload-time = "2026-05-26T20:41:27.795Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/bd/3e1e6a57fccd2d7c83fcdf338e93ba98eb85c6e877dd34731ac585375490/coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c", size = 224728, upload-time = "2026-05-26T20:41:30.098Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d7/31066cf1d2f0c6c797fce911bcfa01dd35642dc6da992a950256097c5860/coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af", size = 222752, upload-time = "2026-05-26T20:41:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "elevenlabs"
+version = "2.53.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/5f1afc8d3649b303e6a0f1c317f37062694be4dd95daec99d73581ceee54/elevenlabs-2.53.0.tar.gz", hash = "sha256:4681561f12a72baffc451f5d9d14b915dffe7e3d9b007917a1b077859bc63866", size = 646150, upload-time = "2026-06-15T09:33:10.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/ab/56c99ee7701ab4c2c587637a32b2f9b0afbfe3373069c02ecf524f752e16/elevenlabs-2.53.0-py3-none-any.whl", hash = "sha256:c1cb3bce2134ddc42375de77d88a8154c92bef497593ece2634b23e616ef057e", size = 1752582, upload-time = "2026-06-15T09:33:08.258Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/da/76a2c7e510ba15fe323d9509c223ab272da79ea59f54488f4a78da6426db/jiter-0.15.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:edebcf7d1f601199084bb6e844d7dc67e03e04f6ac786b0332d616635c4ff7a4", size = 310849, upload-time = "2026-05-19T10:06:51.944Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/8e/827be942883a4dc0862c48626ff41af3320b1902d136a0bf4b9041f2c567/jiter-0.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9f924585cdacf631cd382b657966847bb537bf9ed0a6f9b991da5f05a631480f", size = 314991, upload-time = "2026-05-19T10:06:53.522Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/38/be2832be361ba1b9517c76f46d30b64e985be1dd43c974f4c3a4b1844436/jiter-0.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abbf258599526ad0326fe51e252e24f2bd6f24f1852681b4b78feda3808f1d18", size = 340843, upload-time = "2026-05-19T10:06:55.071Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d8/90f01fb83c0c7ba509303ec93e32a308fbfa167d264860b01c0fd0dbbd06/jiter-0.15.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7c468136b8bd6bb18c8786e4236a1fa27362f24cb23450ba0cb204ab379b8e6f", size = 365116, upload-time = "2026-05-19T10:06:56.893Z" },
+    { url = "https://files.pythonhosted.org/packages/91/38/94593d34f8c67a0b6f6cbc027f016ffa9780b3a858a7a86f6fd7a15bcc1e/jiter-0.15.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05906b93d72f03339e6bb7cf8dc10ebda64a0266126eed6beba79e20abcf5fd4", size = 457970, upload-time = "2026-05-19T10:06:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/df/04/d79962dd49d00c97e2a9b4cacea1947904d02135936960351f9a96d4c1a6/jiter-0.15.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:30ce785d2adb8e32c3f7741442370a74834ec4c01f3c48f0750227a0b4ef27d6", size = 375744, upload-time = "2026-05-19T10:07:00.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/2e/5d37abe2be0e819c21e2338bebd410e481763ce526a9138c8c3652fa0123/jiter-0.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fd73e3da91a0a722d67165e849ce2cdc10de0e0d48738c142be8c6c5f310f4c", size = 349609, upload-time = "2026-05-19T10:07:01.829Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/90/98768ad2ed90c1fda15d64157de2dfbf73c1c074d4b1bfaca915480bc7cf/jiter-0.15.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:ceb8fc27d38793f9c97149be8302720c5b22e5c195a37bf2c45dc36c4600a512", size = 354366, upload-time = "2026-05-19T10:07:03.587Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c4/fbfb806209f1fe4b7dccdfb07bc62bb044300734a945b06fd64db446ef6a/jiter-0.15.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d726e3ceeb337191324b49de298142f27c3ad10886341555d1d5315b5f252c6a", size = 393519, upload-time = "2026-05-19T10:07:05.08Z" },
+    { url = "https://files.pythonhosted.org/packages/37/1c/b9c257cd70cb453b6d10f3ebf0402cdb11669ab455389096f09839670290/jiter-0.15.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2c8aea7781d2a372227871de4e1a1332aa96f5a89fd76c5e835dafdbad102887", size = 519952, upload-time = "2026-05-19T10:07:06.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/1a/aa85027db7ab15829c12feebbc33b404f53fc399bd559d85fd0d6365ff0d/jiter-0.15.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cf4bd113a69c0a740e27cb962ce10630c36d2b8f59d759a651b955ee9d18a823", size = 550770, upload-time = "2026-05-19T10:07:08.228Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/54/8c3f65c8a5687925e84708f19d63f7f37d28e2b86a48d951702ad94424d8/jiter-0.15.0-cp310-cp310-win32.whl", hash = "sha256:d92a5cd21fdb083931d546c207aa29633787c5dc5b02daab2d32b843f88a2c53", size = 209303, upload-time = "2026-05-19T10:07:10.006Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/0528a1eb9f42dd2d8228a0711458628f35924d131f623eaebc35fd23d3d4/jiter-0.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:e58585a58209d72691ce2d62a9147445f5a87beb0bde97fde284c96ae392a3d1", size = 200404, upload-time = "2026-05-19T10:07:11.426Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/13/daa722f5765c393576f466378f9dfd29d77c9bed939e0688f96afa3601ea/jiter-0.15.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0f862193b8696249d22ec433e85fd2ab0ad9596bc3e45e6c0bc55e8aeba97be2", size = 310899, upload-time = "2026-05-19T10:07:12.89Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/82/2d2551829b082f4b6d82b9f939b031fb808a10aab1ec0664f82e150bb9a2/jiter-0.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1303d4d68a9b051ea90502402063ecf3807da00ad2affa19ca1ae3b90b3c5f67", size = 314963, upload-time = "2026-05-19T10:07:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0a/8b1a51466f7fe9f31dbe4bc7e0ca848674f9825e0f737b929b97e8c60aa7/jiter-0.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:392b8ab019e5502d08aff85c6272209c24bc2cbe706ea82a56368f524236614a", size = 341730, upload-time = "2026-05-19T10:07:15.869Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/2a/e71dea19822e2e404e83992a08c1d6b9b617bb944f28c9c2fbd85d02c91e/jiter-0.15.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:773b6eb282ce11ee19f05f6b2d4404fa308e5bbd353b0b80a0262caad6db2cd7", size = 366214, upload-time = "2026-05-19T10:07:17.259Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/97e1fa539d124a509a00ab7f669289d1c1d236ecabf12948a18f16c91082/jiter-0.15.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d2c0c44d569ce0f2850f5c926f8caeb5f245fbc84475aeb36efccc2103e6dbd", size = 459527, upload-time = "2026-05-19T10:07:18.741Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7a/4a68d331aef8cf2e2393c14a3aacb635c62aa86071b0229899fb5baaa907/jiter-0.15.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:032396229564bca02440396bd327710719f724f5e7b7e9f7a8eb3faa4a2c2281", size = 375451, upload-time = "2026-05-19T10:07:20.208Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/1c445c2b6f0e30a274dc8082e0c3c7825411cce80d726bccd697c98cc8d3/jiter-0.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3d37768fce7f88dd2a8c6091f2325dea27d30d30d5c6e7a1c0f0af77723b708", size = 349428, upload-time = "2026-05-19T10:07:22.372Z" },
+    { url = "https://files.pythonhosted.org/packages/00/94/e20d38984fc17a636371bffd2ae0f698124fdc8e75ef969cd2da6ba7cea7/jiter-0.15.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:2c9cb907439d20bd0c7d7565ca01ee52234203208433749bae5b516907526928", size = 355405, upload-time = "2026-05-19T10:07:23.916Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fa/4d09f814779d0ea80a28ed8e4c6662ec9a4a8ecef0ac52190ebac6262d14/jiter-0.15.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9100ddbec09741cc66feb0fc6773f8bdbd0e3c345689368f260082ff85dcc0cd", size = 393688, upload-time = "2026-05-19T10:07:25.854Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9d/8eb5d4fb8bf7e93a75964a5da71a75c67c864baf7fa3f98598187b3c7e57/jiter-0.15.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ae1b0d82ac2d987f9ea512b1c9adfcc71a28de3dea3a6039b54d76cffda9901e", size = 520853, upload-time = "2026-05-19T10:07:27.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2c/5e07874e59e623a943a0acf1552a80d05b70f31b402287a8fc6d7ec634c7/jiter-0.15.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8020c99ec13a7db2b6f96cbe82ef4721c88b426a4892f27478044af0284615ef", size = 551016, upload-time = "2026-05-19T10:07:28.846Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/d2d34422143474cadc15b60d482b1c35683dbc5c63c24346ddd0df09bcaf/jiter-0.15.0-cp311-cp311-win32.whl", hash = "sha256:42bfb257930800cf43e7c62c832402c704ab60797c992faf88d20e903eac8f32", size = 209518, upload-time = "2026-05-19T10:07:30.431Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/7d/52778b930e5cc3e52a37d950b1c10494244308b4329b25a0ff0d88303a81/jiter-0.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:860a74063284a2ae9bfedd694f299cc2c68e2696c5f3d440cc9d18bb81b9dd04", size = 200565, upload-time = "2026-05-19T10:07:32.125Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4f/d9b4067feb69b3fa6eb0488e1b59e2ad5b463fe39f59e527eab2aca00bb0/jiter-0.15.0-cp311-cp311-win_arm64.whl", hash = "sha256:37a10c377ce3a4a85f4a67f28b7afe093154cde77eaf248a72e856aa08b4d865", size = 195488, upload-time = "2026-05-19T10:07:33.846Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793, upload-time = "2026-05-19T10:07:35.25Z" },
+    { url = "https://files.pythonhosted.org/packages/01/84/c01099b59a285a1ebba64ae93f62bfa036675340fd1b0045ae65890a0442/jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c9004af7c8d67cce7f1aae1026fb55607f4aa600710d08ede3a3ce4aeefe7e0", size = 309570, upload-time = "2026-05-19T10:07:36.919Z" },
+    { url = "https://files.pythonhosted.org/packages/58/64/8fb7f9d45bb98190355454cd04dad8d8f27223d6bd52f83af07f637168a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c210f8b35dc6f30aafd4b4365ca89b9d1189f21ab49b8e68fa6322a847aef138", size = 336783, upload-time = "2026-05-19T10:07:38.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b6/f5739011d009b3a30f6a53c5240979030ba29ae46a8c67e3a15759f7c37d/jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61", size = 363555, upload-time = "2026-05-19T10:07:40.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/12/98a9d9f766665e8a3b6252454e17cb0c464606a28cf2fa09399b003345fa/jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687", size = 452255, upload-time = "2026-05-19T10:07:42.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d5/60f972840f79c5e7544fce567c56f1e4e50468f996baba3e78d823dd62a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879", size = 373559, upload-time = "2026-05-19T10:07:44.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d", size = 346055, upload-time = "2026-05-19T10:07:46.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/63/4d2749d8d54d230bad9b3a6b0d00cc28c6ff6b2fdffc26a8ccf76cc5a974/jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb", size = 351406, upload-time = "2026-05-19T10:07:47.855Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b9/9965b990035d8773328e0a8c8b457a87bf2b19f6c4126d9d99296be5d16a/jiter-0.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ae901f3a55bfafdde31d289590fa25e3245735a2b1e8c7cc15871710a002871", size = 389357, upload-time = "2026-05-19T10:07:49.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/55/9ddf903deda1413e87fed792f416b7123daee5b8efbad6a202a7421c36a5/jiter-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f0b271b462769543716f92d3a4f90527df6ef5ed05ee95ec4137f513e21e1b77", size = 517263, upload-time = "2026-05-19T10:07:51.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/76/a0c40ad064d3a20a4fde231e35d56e9a01ce82164278180e82d5daf85469/jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d", size = 548646, upload-time = "2026-05-19T10:07:53.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4f/eca9b954942916ba2f453891b8593ab444cd872396fe66a3936616f236f3/jiter-0.15.0-cp312-cp312-win32.whl", hash = "sha256:c2f6bb8b5216ab9e7873bc08b5d7bef2b8abbb578a3069bf1cd14a45d71d771d", size = 206427, upload-time = "2026-05-19T10:07:55.307Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/8ead82a87495149542748e828d153fd232a512a22c83b02c4815c1a9c7d8/jiter-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:40b2c7e92c44a84d748d21706c68dc6ff8161d80b59c99d774721a0d2317d7c7", size = 197300, upload-time = "2026-05-19T10:07:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e4/9b8a78fb2d894471bc344e37f1949bdd784bd914d031dba0ba3a40c71dd7/jiter-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:cc0bc345cf2df9d1c00ac443f50d543c1ccfa8b0422cb85b1ab70d681c0b255b", size = 192702, upload-time = "2026-05-19T10:07:58.307Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f4/f708c900ecee41b2025ef8413d5351e5649eb2125c506f6720cc69b06f5c/jiter-0.15.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c11465f97e2abf45a014b83b730222f8f1c5335e802c7055a67d50de6f1f4e3", size = 307829, upload-time = "2026-05-19T10:07:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/db537c0949e83668c38481d426b9f2fd5ab758c4ee53a811dd0a510626a0/jiter-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e7b1776f0797956c509e123d0952d10d293a9492dea9f288ab9570ec01d1a5", size = 308445, upload-time = "2026-05-19T10:08:01.184Z" },
+    { url = "https://files.pythonhosted.org/packages/37/38/ea0e13b18c30ef951da0d47d39e7fa9edb82a93a62990ffbd7cea9b622d4/jiter-0.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351a341c2105aa430b7047e30f1bf7975f6313b00165d3fc07be2edaf741f279", size = 336181, upload-time = "2026-05-19T10:08:02.688Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fc/2303901b16c4ba05865588990a420c0b4156270b44379c20931544a1d962/jiter-0.15.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ab395feec8d249ec4044e228e98a7033f043426a265df439dc3698823f0a4e4", size = 362985, upload-time = "2026-05-19T10:08:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/11bace093c52e7d4d26c8e606ccd7ae8c972189622469ec0d9e28161e28b/jiter-0.15.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2a438005b6f22d0273413484d6094d7c2c5d10ec1b3a3bf128e0d1d3ba53258", size = 453292, upload-time = "2026-05-19T10:08:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/22/db/987f2f086ca4d7a6582eb4ccd513f9b26b42d9e4243a087609a3137a8fc7/jiter-0.15.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f18f85e4218d1b40f000f42a92239a7a61a902cd42c65e6c360dbd17dcb20894", size = 373501, upload-time = "2026-05-19T10:08:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/89fbcabb2739b7a5b8dc959a1b6c5761f6484f5fed3486854b3c789bb1de/jiter-0.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1aa62e277fc1cbd80e6deacae6f4d983b41b3d7728e0645c5d741a6149bba45", size = 344683, upload-time = "2026-05-19T10:08:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/6cca7692e7dddfec6d8d76c54dc97f2af2a41df4ac0674b999df1f09a5f3/jiter-0.15.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:6550fa135c7deb8ead6af49ed7ff648532ea8334a1447fe34a36315ef79c5c29", size = 350892, upload-time = "2026-05-19T10:08:11.352Z" },
+    { url = "https://files.pythonhosted.org/packages/39/14/0338d6190cb8e6d22e677ab1d4eabd4117f67cca70c54cd04b82ff64e068/jiter-0.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:066f8f33f18b2419cd8213b2436fa7fbc9c499f315971cfa3ce1f9820c001b1b", size = 388723, upload-time = "2026-05-19T10:08:12.912Z" },
+    { url = "https://files.pythonhosted.org/packages/90/31/cc19f4a1bdb6afb09ce6a2f2615aa8d44d994eba0d8e6105ed1af920e736/jiter-0.15.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:75e8a04e91432dde9f1838373cf93d23726c79d3e908d319acf0e796f85592e7", size = 516648, upload-time = "2026-05-19T10:08:14.808Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9f/833c541512cd091b63c10c0381973dfe11bc7a503a818c16384417e0c81e/jiter-0.15.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a97261f1fccb8e50ecd2890a96e46efdc3f57c80a197324c6777827231eca712", size = 547382, upload-time = "2026-05-19T10:08:16.927Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/11/e7b70e91f90bc4477e8eee9e8a5f7cf3cb41b4525d6394dc98a714eb8f7f/jiter-0.15.0-cp313-cp313-win32.whl", hash = "sha256:c77496cb10bd7549690fbbab3e5ec05857b83e49276f4a9423a766ddd2afcd4c", size = 205845, upload-time = "2026-05-19T10:08:18.401Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/5c20d9ad6f02c493e4023e5d2d09e1c1f15fe2753c9102c544aff068a88e/jiter-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b15741f501469009ae0ae90b7147958a664a7dede40aa7ff174a8a4645f546d0", size = 196842, upload-time = "2026-05-19T10:08:20.131Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/11/1eb400ef248e8c925fd883fbe325daf5e42cd1b0d308539dd332bd4f7ffc/jiter-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d6a60072b44c3c2b797a7ddcbcbbf2b34ea3cfd4721580fbfd2a09d9d9b84ba", size = 192212, upload-time = "2026-05-19T10:08:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/60/2fd8d7c79da8acf9b7b277c7616847773779356b92acfc9bb158452174da/jiter-0.15.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ef1fd24d9413f6209e00d3d5a453e67acfe004a25cc6c8e8484faed4311ab9e8", size = 315065, upload-time = "2026-05-19T10:08:23.218Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f4/008fb7d65e8ac2abf00811651a661e025c4ba80bbc6f378450384ddd3aed/jiter-0.15.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144f8e72cb53dab146347b91cceac01f5481237f2b93b4a339a1ee8f8878b67c", size = 339444, upload-time = "2026-05-19T10:08:24.701Z" },
+    { url = "https://files.pythonhosted.org/packages/00/55/90b0c7b9c6896c0f2a591dd36d36b71d22e09674bfef178fa03ba3f81499/jiter-0.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:553fcac2ef2cb990877f9fc0833b8b629a3e6a5670b6b5fd58219b41a653ddc4", size = 347779, upload-time = "2026-05-19T10:08:26.408Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/69666cec5000fd57734c118437394516c749ae8dbeea9fb66d6fef9c4775/jiter-0.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:774f93f65031856bf14ad9f59bdcab8b8cad501e5ceabd51ba3525f76937a25b", size = 200395, upload-time = "2026-05-19T10:08:28.055Z" },
+    { url = "https://files.pythonhosted.org/packages/39/04/a6aa62cd27e8149b0d28df5561f10f6cceaf7935a9ccf3f1c5a05f9a0cd8/jiter-0.15.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f1e1754960f38ec40613a07e5e372df67acb3b890fb383b6fb3de3e49ddbf3c7", size = 190516, upload-time = "2026-05-19T10:08:29.35Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/079f350ebf7859d081de30aa890f9e3be68516f754f3ba32366ffff4dcee/jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49", size = 308884, upload-time = "2026-05-19T10:08:31.667Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4e/a2c30a7f69b48c03b20935d647479106fe932f6e63f75faf53937197e05d/jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86", size = 310028, upload-time = "2026-05-19T10:08:33.304Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/2e7cdfd3cf8ca967be38c48f5cf474d79f089efaf559a40f15984a77ae69/jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f", size = 337485, upload-time = "2026-05-19T10:08:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/11/15a1aa28b120b8ee5b4f1fb894c125046225f09847738bd64233d3b84883/jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e", size = 364223, upload-time = "2026-05-19T10:08:36.694Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/f442e8af5f3d0dcf47b39e83a0efd9ee45ea946aa6d04625dc3181eae3b6/jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6", size = 456387, upload-time = "2026-05-19T10:08:38.143Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f4/37f2d2c9f64f49af7da652ed7532bb5a2372e588e6927c3fdd76f911db65/jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9", size = 374461, upload-time = "2026-05-19T10:08:39.869Z" },
+    { url = "https://files.pythonhosted.org/packages/60/28/edcfbbbf0cb15436f36664a8908a0df47ab9006298d4cd937dc08ea932d6/jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c", size = 345924, upload-time = "2026-05-19T10:08:41.668Z" },
+    { url = "https://files.pythonhosted.org/packages/47/13/89fba6398dab7f202b7278c4b4aac122399d2c0183971c4a57a3b7088df5/jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd", size = 352283, upload-time = "2026-05-19T10:08:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/da/0f6af8cef2c565a1ab44d970f268c43ccaa72707386ea6388e6fe2b6cd26/jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89", size = 389985, upload-time = "2026-05-19T10:08:44.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/b9cb7d6d29e24ee14910266157d2a279d7a8f60ee0df7fa840882976ba64/jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554", size = 517695, upload-time = "2026-05-19T10:08:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5e/6d1bda880723aae0ad86b4b763f044362448efe31e3e819635d41cb03451/jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a", size = 548868, upload-time = "2026-05-19T10:08:48.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/72/7de501cf38dcacaf35098796f3a50e0f2e338baba18a58946c618544b809/jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec", size = 206380, upload-time = "2026-05-19T10:08:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a9/e19addf4b0c1bdce52c6da12351e6bc42c340c45e7c09e2158e46d293ccc/jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558", size = 197687, upload-time = "2026-05-19T10:08:51.088Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c9/776b1db01db25fc6c1d58d1979a37b0a9fe787e5f5b1d062d2eaacb77923/jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866", size = 192571, upload-time = "2026-05-19T10:08:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f6/45bb4670bacf300fd2c7abadbfb3af376e5f1b6ae75fd9bc069891d15870/jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d", size = 317151, upload-time = "2026-05-19T10:08:53.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/ed635ad5acd7b73e454283083bbb7c8205ad10e88b0d9d7d793b09fe8226/jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6", size = 341243, upload-time = "2026-05-19T10:08:55.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/db/3ff4176b817b8ea33879e71e13d8bc2b0d481a7ed3fe9e080f333d415c16/jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995", size = 363629, upload-time = "2026-05-19T10:08:56.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/24/5f8270e0ba9c883582f96f722f8a0b58015c7ce1f8c6d4571cf394e99b6b/jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8", size = 456198, upload-time = "2026-05-19T10:08:58.618Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5b/76fc02b0b5c54c3d18c60653156e2f76fde1816f9b4722db68d6ee2c897e/jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5", size = 373710, upload-time = "2026-05-19T10:09:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/52/4310821b0ea9277994d3e1f49fc6a4b34e4800caebacb2c0af81da59a454/jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b", size = 349901, upload-time = "2026-05-19T10:09:01.621Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fe/67648c35b3594fba8854ac64cc8a826d8bcd18324bbdb53d77697c60b6ef/jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8", size = 352438, upload-time = "2026-05-19T10:09:03.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/0a1879d07ad6b3e025a2750027363452ced93c2d16d1c9d4b153ffd51c91/jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec", size = 388152, upload-time = "2026-05-19T10:09:04.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/78/46c6f6b56ba85c90021f4afd72ed42f691f8f84daacb5fe27277070e3858/jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e", size = 517707, upload-time = "2026-05-19T10:09:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cb/720662d4c88fcad606e826fef5424365527ba43ce4868a479aed8f8c507e/jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5", size = 548241, upload-time = "2026-05-19T10:09:08.093Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950, upload-time = "2026-05-19T10:09:09.616Z" },
+    { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055, upload-time = "2026-05-19T10:09:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244, upload-time = "2026-05-19T10:09:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/43/1fc62172aa98b50a7de9a25554060db510f85c89cfbed0dfe13e1907a139/jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:411fa4dfa5a7ae3d11491027ffb9beadec3996010a986862db70d91abba1c750", size = 305585, upload-time = "2026-05-19T10:09:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c4/dd58fcd9e2df83666e5c1c1347bef58ce919cd8efc3ffa38aeea62ce493b/jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:2b0074e2f56eb2dacca1689760fd2852a068f85a0547a157b82cb4cafeb6768b", size = 306936, upload-time = "2026-05-19T10:09:37.435Z" },
+    { url = "https://files.pythonhosted.org/packages/39/86/b695e16f1180c07f43ea98e73ecd21cf63fa2e1b0c1103739013784d11ae/jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:913d02d29c9606643418d9ccfc3b72492ab25a6bf7889934e09a3490f8d3438b", size = 342453, upload-time = "2026-05-19T10:09:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/34/56/55d76614af37fe3f22a3347d1e410d2a15da581997cb2da499a625000bb5/jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b15d3ec9b0449c40e85319bdb4caa8b77ab526e74f5532ed94bec15e2f66822c", size = 345606, upload-time = "2026-05-19T10:09:40.727Z" },
+    { url = "https://files.pythonhosted.org/packages/73/38/505941b2b092fd5bbbd60a52a880db1173f1690ae6751bed3af1c9ddcb4e/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:631f13a3d04e97d4e083993b10f4b99530e3a10d953e2eb5e196b7dc7f812ce0", size = 303769, upload-time = "2026-05-19T10:09:42.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/95/a06692b29e77473f286e1ec1f426d3ca44d7b5843be8ad21d7a5f3fcdcc0/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45", size = 305128, upload-time = "2026-05-19T10:09:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/7270d7ad41d6061a25b950c6bf91d638bd9aacb113200a8c8d57a055fd67/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c", size = 340459, upload-time = "2026-05-19T10:09:45.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469, upload-time = "2026-05-19T10:09:46.864Z" },
+]
+
+[[package]]
+name = "libloader"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/dd/58864bd93f74cd227996cec701713e27f6a57b1c189747cfefc9c9c2e00e/libloader-1.4.3.tar.gz", hash = "sha256:9c56b1ee2e866e314c35d1095d1e3b99c1c762e89a27bf26c98bd65d58f4e182", size = 6165, upload-time = "2026-01-14T03:18:21.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/cb/dac60d530791146d52e2dab3a16531963d03899ea37eec77cc03ea8c281d/libloader-1.4.3-py3-none-any.whl", hash = "sha256:4cfd541496bed79a2b5f72c316e16312ce1dd72fab6ed837801aa5e53299d6da", size = 6190, upload-time = "2026-01-14T03:18:20.84Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1", size = 200139, upload-time = "2026-05-10T18:17:25.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/10/37fd9e9ba96cb0bd742dfb20fc3d082e54bdbec759d7300df927f360ef07/librt-0.11.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6e94ebfcfa2d5e9926d6c3b9aa4617ffc42a845b4321fb84021b872358c82a0f", size = 141706, upload-time = "2026-05-10T18:15:16.129Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/72/1b1466f358e4a0b728051f69bc27e67b432c6eaa2e05b88db49d3785ae0d/librt-0.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ae627397a2f351560440d872d6f7c8dbb4072e57868e7b2fc5b8b430fe489d45", size = 142605, upload-time = "2026-05-10T18:15:18.148Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/85/ed26dd2f6bc9a0baf48306433e579e8d354d70b2bcb78134ed950a5d0e1e/librt-0.11.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc329359321b67d24efdf4bc69012b0597001649544db662c001db5a0184794c", size = 476555, upload-time = "2026-05-10T18:15:19.569Z" },
+    { url = "https://files.pythonhosted.org/packages/66/fe/11891191c0e0a3fd617724e891f6e67a71a7658974a892b9a9a97fdb2977/librt-0.11.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:7e82e642ab0f7608ce2fe53d76ca2280a9ee33a1b06556142c7c6fe80a86fc33", size = 468434, upload-time = "2026-05-10T18:15:20.87Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/50/5ec949d7f9ce1a07af903aa3e13abb98b717923bdead6e719b2f824ccc07/librt-0.11.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:88145c15c67731d54283d135b03244028c750cc9edc334a96a4f5950ebdb2884", size = 496918, upload-time = "2026-05-10T18:15:22.616Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/c4/177336c7524e34875a38bf668e88b193a6723a4eb4045d07f74df6e1506c/librt-0.11.0-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d36a51b3d93320b686588e27123f4995804dbf1bce81df78c02fc3c6eea9280", size = 490334, upload-time = "2026-05-10T18:15:24.2Z" },
+    { url = "https://files.pythonhosted.org/packages/13/1f/da3112f7569eda3b49f9a2629bae1fe059812b6085df16c885f6454dff49/librt-0.11.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d00f3ac06a2a8b246327f11e186a53a100a4d5c7ed52346367e5ec751d51586c", size = 511287, upload-time = "2026-05-10T18:15:26.226Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/94/03fec301522e172d105581431223be56b27594ff46440ebfbb658a3735d5/librt-0.11.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:461bbceede621f1ffb8839755f8663e886087ee7af16294cab7fb4d782c62eeb", size = 517202, upload-time = "2026-05-10T18:15:27.965Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/6e/339f6e5a7b413ce014f1917a756dae630fe59cc99f34153205b1cb540901/librt-0.11.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0cad8a4d6a8ff03c9b76f9414caccd78e7cfbc8a2e12fa334d8e1d9932753783", size = 497517, upload-time = "2026-05-10T18:15:29.614Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/43/acdd5ce317cb46e8253ca9bfbdb8b12e68a24d745949336a7f3d5fb79ba0/librt-0.11.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f37aa505b3cf60701562eddb32df74b12a9e380c207fd8b06dd157a943ac7ea0", size = 538878, upload-time = "2026-05-10T18:15:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b5/7a25bb12e3172839f647f196b3e988318b7bb1ca7501732a225c4dce2ec0/librt-0.11.0-cp310-cp310-win32.whl", hash = "sha256:94663a21534637f0e787ec2a2a756022df6e5b7b2335a5cdd7d8e33d68a2af89", size = 100070, upload-time = "2026-05-10T18:15:32.551Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0d/ebbcf4d77999c02c937b05d2b90ff4cd4dcc7e9a365ba132329ac1fe7a0f/librt-0.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:dec7db73758c2b54953fd8b7fe348c45188fe26b39ee18446196edd08453a5d4", size = 117918, upload-time = "2026-05-10T18:15:33.678Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/87/2bf31fe17587b29e3f93ec31421e2b1e1c3e349b8bf6c7c313dbad1d5340/librt-0.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:93d95bd45b7d58343d8b90d904450a545144eec19a002511163426f8ab1fae29", size = 141092, upload-time = "2026-05-10T18:15:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/08/5c5bf772920b7ebac6e32bc91a643e0ab3870199c0b542356d3baa83970a/librt-0.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ee278c769a713638cdacd4c0436d72156e75df3ebc0166ab2b9dc43acc386c9", size = 142035, upload-time = "2026-05-10T18:15:36.242Z" },
+    { url = "https://files.pythonhosted.org/packages/06/20/662a03d254e5b000d838e8b345d83303ddb768c080fd488e40634c0fa66b/librt-0.11.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f230cb1cbc9faaa616f9a678f530ebcf186e414b6bcbd88b960e4ba1b92428d5", size = 475022, upload-time = "2026-05-10T18:15:37.56Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f3/aa81523e45184c6ec23dc7f63263362ec55f80a09d424c012359ecbe7e35/librt-0.11.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5d63c855d86938d9de93e265c9bd8c705b51ec494de5738340ee93767a686e4b", size = 467273, upload-time = "2026-05-10T18:15:39.182Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/6f/59c74b560ca8853834d5501d589c8a2519f4184f273a085ffd0f37a1cc47/librt-0.11.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:993f028be9e96a08d31df3479ac80d99be374d17f3b78e4796b3fd3c913d4e89", size = 497083, upload-time = "2026-05-10T18:15:40.634Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/7b/5aa4d2c9600a719401160bf7055417df0b2a47439b9d88286ce45e56b65f/librt-0.11.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:258d73a0aa66a055e65b2e4d1b8cdb23b9d132c5bb915d9547d804fcaed116cc", size = 489139, upload-time = "2026-05-10T18:15:41.934Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/31/9143803d7da6856a69153785768c4936864430eec0fd9461c3ea527d9922/librt-0.11.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0827efe7854718f04aaddf6496e96960a956e676fe1d0f04eb41511fd8ad06d5", size = 508442, upload-time = "2026-05-10T18:15:43.206Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5a/bce08184488426bda4ccc2c4964ac048c8f68ae89bd7120082eef4233cfd/librt-0.11.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7753e57d6e12d019c0d8786f1c09c709f4c3fcc57c3887b24e36e6c06ec938b7", size = 514230, upload-time = "2026-05-10T18:15:44.761Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/bb5e213d254b7505a0e658da199d8ab719086632ce09eef311ab27976523/librt-0.11.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:11bd19822431cc21af9f27374e7ae2e58103c7d98bda823536a6c47f6bb2bb3d", size = 494231, upload-time = "2026-05-10T18:15:46.308Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/fb/541cdad5b1ab1300398c74c4c9a497b88e5074c21b1244c8f49731d3a284/librt-0.11.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:22bdf239b219d3993761a148ffa134b19e52e9989c84f845d5d7b71d70a17412", size = 537585, upload-time = "2026-05-10T18:15:47.629Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f2/464bb69295c320cb06bddb4f14a4ec67934ee14b2bffb12b19fb7ab287ba/librt-0.11.0-cp311-cp311-win32.whl", hash = "sha256:46c60b61e308eb535fbd6fa622b1ee1bb2815691c1ad9c98bf7b84952ec3bc8d", size = 100509, upload-time = "2026-05-10T18:15:49.157Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e7/a17ee1788f9e4fbf548c19f4afa07c92089b9e24fef6cb2410863781ef4c/librt-0.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:902e546ff044f579ff1c953ff5fce97b636fe9e3943996b2177710c6ef076f73", size = 118628, upload-time = "2026-05-10T18:15:50.345Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/6c766214f9f9903bcfcfbef97d807af8d8f5aa3502d247858ab17582d212/librt-0.11.0-cp311-cp311-win_arm64.whl", hash = "sha256:65ac3bc20f78aa0ee5ae84baa68917f89fef4af63e941084dd019a0d0e749f0c", size = 103122, upload-time = "2026-05-10T18:15:52.068Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d0/07c77e067f0838949b43bd89232c29d72efebb9d2801a9750184eb706b71/librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46", size = 144147, upload-time = "2026-05-10T18:15:53.227Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/24/8493538fa4f62f982686398a5b8f68008138a75086abdea19ade64bf4255/librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40071fc5fe0ce8daa6de616702314a01e1250711682b0523d6ab8d4525910cb3", size = 143614, upload-time = "2026-05-10T18:15:54.657Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1e/f8bad050810d9171f34a1648ed910e56814c2ba61639f2bd53c6377ae24b/librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67", size = 485538, upload-time = "2026-05-10T18:15:56.117Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/fe/3594ebfbaf03084ba4b120c9ba5c3183fd938a48725e9bbe6ff0a5159ad8/librt-0.11.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:cca6644054e78746d8d4ef238681f9c34ff8b584fe6b988ecebb8db3b15e622a", size = 479623, upload-time = "2026-05-10T18:15:57.544Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/da/5d1876984b3746c85dbd219dbfcb73c85f54ee263fd32e5b2a632ec14571/librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a", size = 513082, upload-time = "2026-05-10T18:15:58.805Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6e/55bdf5d5ca00c3e18430690bf2c953d8d3ffd3c337418173d33dec985dc9/librt-0.11.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0d1029d7e1ae1a7e647ed6fb5df8c4ce2dffefb7a9f5fd1376a4554d96dac09f", size = 508105, upload-time = "2026-05-10T18:16:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/f1f23a7c595ee90ece4d35c851e5d104b1311a887ed1b4ac4c35bbd13da8/librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bc3ce6b33c5828d9e80592011a5c584cb2ce86edbc4088405f70da47dc1d1b3b", size = 522268, upload-time = "2026-05-10T18:16:01.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/5720f5697a7f54b78b3aefbe20df3a48cedcff1276618c4aa481177942ed/librt-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:936c5995f3514a42111f20099397d8177c79b4d7e70961e396c6f5a0a3566766", size = 527348, upload-time = "2026-05-10T18:16:03.496Z" },
+    { url = "https://files.pythonhosted.org/packages/50/db/b4a47c6f91db4ff76348a0b3dd0cc65e090a078b765a810a62ff9434c3d3/librt-0.11.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9bc0ca6ad9381cbe8e4aa6e5726e4c80c78115a6e9723c599ed1d73e092bc49d", size = 516294, upload-time = "2026-05-10T18:16:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/58/9384b2f4eb1ed1d273d40948a7c5c4b2360213b402ef3be4641c06299f9c/librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:070aa8c26c0a74774317a72df8851facc7f0f012a5b406557ac56992d92e1ec8", size = 553608, upload-time = "2026-05-10T18:16:06.839Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7b/5aa8848a7c6a9278c79375146da1812e695754ceec5f005e6043461a7315/librt-0.11.0-cp312-cp312-win32.whl", hash = "sha256:6bf14feb84b05ae945277395451998c89c54d0def4070eb5c08de544930b245a", size = 101879, upload-time = "2026-05-10T18:16:08.103Z" },
+    { url = "https://files.pythonhosted.org/packages/37/33/8a745436944947575b584231750a41417de1a38cf6a2e9251d1065651c09/librt-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:75672f0bc524ede266287d532d7923dbce94c7514ad07627bac3d0c6d92cc4d9", size = 119831, upload-time = "2026-05-10T18:16:09.174Z" },
+    { url = "https://files.pythonhosted.org/packages/59/67/a6739ac96e28b7855808bdb0370e250606104a859750d209e5a0716fe7ab/librt-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:2f10cf143e4a9bb0f4f5af568a00df94a2d69ef41c2579584454bb0fe5cc642c", size = 103470, upload-time = "2026-05-10T18:16:10.369Z" },
+    { url = "https://files.pythonhosted.org/packages/82/61/e59168d4d0bf2bf90f4f0caf7a001bfc60254c3af4586013b04dc3ef517b/librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78dc31f7fdfe9c9d0eb0e8f42d139db230e826415bbcabd9f0e9faaaee909894", size = 144119, upload-time = "2026-05-10T18:16:11.771Z" },
+    { url = "https://files.pythonhosted.org/packages/61/fd/caa1d60b12f7dd79ccea23054e06eeaebe266a5f52c40a6b651069200ce5/librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c", size = 143565, upload-time = "2026-05-10T18:16:13.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/dc744f5c2b4978d48db970be29f22716d3413d28b14ad99740817315cf2c/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea", size = 485395, upload-time = "2026-05-10T18:16:14.729Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/21/7f8e97a1e4dae952a5a95948f6f8507a173bc1e669f54340bba6ca1ca31b/librt-0.11.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a9010e2ed5b3a9e158c5fd966b3ab7e834bb3d3aacc8f66c91dd4b57a3799230", size = 479383, upload-time = "2026-05-10T18:16:16.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2", size = 513010, upload-time = "2026-05-10T18:16:17.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/43/0b5708af2bd30a46400e72ba6bdaa8f066f15fb9a688527e34220e8d6c06/librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3", size = 508433, upload-time = "2026-05-10T18:16:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/50/356187247d09013490481033183b3532b58acf8028bcb34b2b56a375c9b2/librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21", size = 522595, upload-time = "2026-05-10T18:16:20.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e7/c6ac4240899c7f3248079d5a9900debe0dadb3fdeaf856684c987105ba47/librt-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:83d3e1f72bd42f6c5c0b7daec530c3f829bd02db42c70b8ddf0c2d90a2459930", size = 527255, upload-time = "2026-05-10T18:16:22.352Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b5/a81322dbeedeeaf9c1ee6f001734d28a09d8383ac9e6779bc24bbd0743c6/librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be", size = 516847, upload-time = "2026-05-10T18:16:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/66/6e6323787d592b55204a42595ff1102da5115601b53a7e9ddebc889a6da5/librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e", size = 553920, upload-time = "2026-05-10T18:16:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/21/623f8ca230857102066d9ca8c6c1734995908c4d0d1bee7bb2ef0021cb33/librt-0.11.0-cp313-cp313-win32.whl", hash = "sha256:78fddc31cd4d3caa897ad5d31f856b1faadc9474021ad6cb182b9018793e254e", size = 101898, upload-time = "2026-05-10T18:16:26.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1d/b4ebd44dd723f768469007515cb92251e0ae286c94c140f374801140fa74/librt-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47", size = 119812, upload-time = "2026-05-10T18:16:27.859Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e4/b2f4ca7965ca373b491cdb4bc25cdb30c1649ca81a8782056a83850292a9/librt-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:96f044bb325fd9cf1a723015638c219e9143f0dfbc0ca54c565df2b7fc748b44", size = 103448, upload-time = "2026-05-10T18:16:29.066Z" },
+    { url = "https://files.pythonhosted.org/packages/29/eb/dbce197da4e227779e56b5735f2decc3eb36e55a1cdbf1bd65d6639d76c1/librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd", size = 143345, upload-time = "2026-05-10T18:16:30.674Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/254bebd0c11c8ba684018efb8006ff22e466abce445215cca6c778e7d9de/librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4", size = 143131, upload-time = "2026-05-10T18:16:32.037Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3f/f77d6122d21ac7bf6ae8a7dfced1bd2a7ac545d3273ebdcaf8042f6d619f/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8", size = 477024, upload-time = "2026-05-10T18:16:33.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0a/2c996dadebaa7d9bbbd43ef2d4f3e66b6da545f838a41694ef6172cebec8/librt-0.11.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0dc56b1f8d06e60db362cc3fdae206681817f86ce4725d34511473487f12a34b", size = 474221, upload-time = "2026-05-10T18:16:34.864Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7e/f5d92af8486b8272c23b3e686b46ff72d89c8169585eb61eef01a2ac7147/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175", size = 505174, upload-time = "2026-05-10T18:16:36.705Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/cb0734fe86398eb33193ab753b7326255c74cac5eb09e76b9b16536e7adb/librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03", size = 497216, upload-time = "2026-05-10T18:16:38.418Z" },
+    { url = "https://files.pythonhosted.org/packages/18/06/094820f91558b66e29943c0ec41c9914f460f48dd51fc503c3101e10842d/librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c", size = 513921, upload-time = "2026-05-10T18:16:39.848Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c2/00de9018871a282f530cacb457d5ec0428f6ac7e6fedde9aff7468d9fb04/librt-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f9743fc99135d5f78d2454435615f6dec0473ca507c26ce9d92b10b562a280d3", size = 520850, upload-time = "2026-05-10T18:16:41.471Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9d/64631832348fd1834fb3a61b996434edddaaf25a31d03b0a76273159d2cf/librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96", size = 504237, upload-time = "2026-05-10T18:16:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/ae5525eb16edc827a044e7bb8777a455ff95d4bca9379e7e6bddd7383647/librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe", size = 546261, upload-time = "2026-05-10T18:16:44.408Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/09/adce371f27ca039411da9659f7430fcc2ba6cd0c7b3e4467a0f091be7fa9/librt-0.11.0-cp314-cp314-win32.whl", hash = "sha256:d2277a05f6dcb9fd13db9566aac4fabd68c3ea1ea46ee5567d4eef8efa495a2f", size = 96965, upload-time = "2026-05-10T18:16:46.039Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ee/8ac720d98548f173c7ce2e632a7ca94673f74cacd5c8162a84af5b35958a/librt-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7", size = 115151, upload-time = "2026-05-10T18:16:47.133Z" },
+    { url = "https://files.pythonhosted.org/packages/94/20/c900cf14efeb09b6bef2b2dff20779f73464b97fd58d1c6bccc379588ae3/librt-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aea3caa317752e3a466fa8af45d91ee0ea8c7fdd96e42b0a8dd9b76a7931eba1", size = 98850, upload-time = "2026-05-10T18:16:48.597Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/71/944bfe4b64e12abffcd3c15e1cce07f72f3d55655083786285f4dedeb532/librt-0.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d1b36540d7aaf9b9101b3a6f376c8d8e9f7a9aec93ed05918f2c69d493ffef72", size = 151138, upload-time = "2026-05-10T18:16:49.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/10/99e64a5c86989357fda078c8143c533389585f6473b7439172dd8f3b3b2d/librt-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:efbb343ab2ce3540f4ecbe6315d677ed70f37cd9a72b1e58066c918ca83acbaa", size = 151976, upload-time = "2026-05-10T18:16:51.062Z" },
+    { url = "https://files.pythonhosted.org/packages/21/31/5072ad880946d83e5ea4147d6d018c78eefce85b77819b19bdd0ee229435/librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548", size = 557927, upload-time = "2026-05-10T18:16:52.632Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8d/70b5fb7cfbab60edbe7381614ab985da58e144fbf465c86d44c95f43cdca/librt-0.11.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f5fb36b8c6c63fdcbb1d526d94c0d1331610d43f4118cc1beb4efef4f3faacb2", size = 539698, upload-time = "2026-05-10T18:16:53.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a3/ba3495a0b3edbd24a4cae0d1d3c64f39a9fc45d06e812101289b50c1a619/librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f", size = 577162, upload-time = "2026-05-10T18:16:55.589Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/db/36e25fb81f99937ff1b96612a1dc9fd66f039cb9cc3aee12c01fac31aab9/librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51", size = 566494, upload-time = "2026-05-10T18:16:56.975Z" },
+    { url = "https://files.pythonhosted.org/packages/33/0d/3f622b47f0b013eeb9cf4cc07ae9bfe378d832a4eec998b2b209fe84244d/librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2", size = 596858, upload-time = "2026-05-10T18:16:58.374Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/02/71b90bc93039c46a2000651f6ad60122b114c8f54c4ad306e0e96f5b75ad/librt-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f8e3e8056dd674e279741485e2e512d6e9a751c7455809d0114e6ebf8d781085", size = 590318, upload-time = "2026-05-10T18:16:59.676Z" },
+    { url = "https://files.pythonhosted.org/packages/04/04/418cb3f75621e2b761fb1ab0f017f4d70a1a72a6e7c74ee4f7e8d198c2f3/librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3", size = 575115, upload-time = "2026-05-10T18:17:01.007Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2c/5a2183ac58dd911f26b5d7e7d7d8f1d87fcecdddd99d6c12169a258ff62c/librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd", size = 617918, upload-time = "2026-05-10T18:17:02.682Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/da/dbe4dfc01ac226fb0504fad035f4d69f3202f3502e20e68537631daddd96/lxml-6.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:09dd5b7075dc2f7709654a46543ba1ea3c2e217b2ed8fbd413a8a945a0f40f60", size = 8541124, upload-time = "2026-05-18T19:17:11.589Z" },
+    { url = "https://files.pythonhosted.org/packages/78/20/f7095ed9fc2c025f9cfe71cc6ec9f1feb05624edc1812423b5f1aecf3d4b/lxml-6.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f6ac4ef4d82dff54670227a69c67782ae0b811b5cf6b17954f1e8f7502fc0d1d", size = 4602783, upload-time = "2026-05-18T19:17:20.888Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/a4/65c63ca98bd129f6cff7b8c2fa48953ab058cc6005b541354e7dd54d8000/lxml-6.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:556e94a63c9b04716f8e4de2abb65775061f846e89331b6c5be79183a24f98ea", size = 5002687, upload-time = "2026-05-18T19:17:01.738Z" },
+    { url = "https://files.pythonhosted.org/packages/96/1d/ab7a5c4b5a394d98a94e2d0fc67bab8297597426770dd4978370fbdaf531/lxml-6.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c6bf403fbb3b3e348a561a5f4f0b9961835657981c802a1df03653eef8a9074", size = 5155099, upload-time = "2026-05-18T19:17:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b1/07603bfeeb891a2596d5c2a68f7d2f70f7d11c841ebe391412c69c2857b0/lxml-6.1.1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1dde6131244bba38a17c745836ba190bc753fd73c9291666287fd0a3fa3dcf30", size = 5057225, upload-time = "2026-05-18T19:17:08.117Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/16/cb391ee4b90186fa16d9ebcbe3ea96c71b8da3b0686386c8dcbcc3c67d44/lxml-6.1.1-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98fc784c2c1440667aeedf8465bdfe10208acf0ead656a2c68627299f546b315", size = 5287643, upload-time = "2026-05-18T19:17:11.507Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d6/b619717f918fd76747448fdbaee0e769edbc70e659b5b5d0112b7020b7a3/lxml-6.1.1-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:add8cf6ddf9a65116119a28ece0f7886e30af27ba724a7594305f1d1b58a92a1", size = 5412445, upload-time = "2026-05-18T19:17:22.182Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/80/12bc5390ac0a3edeb579d9535e5049a5dda663438728e179d52fb319c33a/lxml-6.1.1-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:cf9d57306d848218f3601fee7601fab1a327c942d56e2e97610583cb4dd74206", size = 4770864, upload-time = "2026-05-18T19:17:26.851Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/59/6500c09da3137f54f020e908d81cfc5ee3e8888e908fd380207afad7c2e6/lxml-6.1.1-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:88136950da4d13c318bde414ce10219931937851327f44328f2df4d2c4614067", size = 5359594, upload-time = "2026-05-18T19:17:32.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9b/f64b4cc6b7ebcf75d95af3cde934d254b5f2f10d4163928d838d86b6eb48/lxml-6.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cecdd5dfdc87b1fd87dbf81d4b037a544f47f4c744200a67013771682d67686a", size = 5107713, upload-time = "2026-05-18T19:17:04.402Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/c7388ad5d3a72315d2832dc1458cbf4f2af7f2b990b606ff4876efd04511/lxml-6.1.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:cd312b9692e831d2ffcad61eab31d91d4b4655a962e61de8fb410472cbcd37aa", size = 4803973, upload-time = "2026-05-18T19:17:06.545Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/22/76197f0bbf165f0b9e75be59be4997e5259cde973f12f098c1b54c7f5d60/lxml-6.1.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:5b7328b46d49fc9477d91ae8f6d55340347d827b7734ba3ea33faae0efef1383", size = 5349925, upload-time = "2026-05-18T19:17:09.743Z" },
+    { url = "https://files.pythonhosted.org/packages/24/52/d2a0cfeccb9bcdc47c7ee05cdae5d69b48c9acf20997790a6338bb0d0b3b/lxml-6.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37a58976370f36d9329d118ad0b953c5aeb9119ac9c6a4e258942a225d0573a1", size = 5309825, upload-time = "2026-05-18T19:17:13.831Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4a/b30944266776c2f49749ef2445aa7e78898194134b80ad776386f61b56ae/lxml-6.1.1-cp310-cp310-win32.whl", hash = "sha256:cea3f4c1af79af13cdb2da0c028111d8f8522d4f22a000c82385535f24e5cf3a", size = 3598402, upload-time = "2026-05-18T19:17:08.21Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/97/33691c66a4d7ec1a5a98e7c909a5b83ee45c7f7ba4cf92b1c4cf26e98079/lxml-6.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:3abf332af33a74288675d936fe861fd4344da0dd6622193fbc4f2bfbb35536b5", size = 4021295, upload-time = "2026-05-18T19:17:28.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/5f/26a4dd0e12b9456ff7b12a21af5b491eb6629680d1edd73f4140fd386bcf/lxml-6.1.1-cp310-cp310-win_arm64.whl", hash = "sha256:8dadbe5b217ff35b6a8d16610dd710219b59b76d13f0e3f0d9f36786206e4485", size = 3667717, upload-time = "2026-05-19T19:22:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b0/83f481780d1548750b8ce2ec824073deef2f452d9cd1a6faff8507e3d16d/lxml-6.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:53b7d2b7a10b1c35c0a5e21e9224accf60c1bbfba523990732e521b2b73adef2", size = 8526461, upload-time = "2026-05-18T19:17:25.862Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/30fa0f808002c7329397bfbb24e306789c0b29f04aa5842c07b174b4216f/lxml-6.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ff3f333630ab480244a1bff72043e511a91eb22e7595dead8653ee5612dd8f3d", size = 4595375, upload-time = "2026-05-18T19:17:34.555Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/d2/edb71cf0e561581a7c5eb2626244320eb04e9f8ce6d563184fd668b45073/lxml-6.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a4bbea04c97f6d78a48e3fbc1cb9116d2780b1b39e03a23f6eb9b603fd61f510", size = 4923654, upload-time = "2026-05-18T19:17:42.917Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/77/1bc7eeb0de4577d783fb625aa092cc9357883bba35845a3666bf1259f3dc/lxml-6.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db1d75f6617a49c1c01bc7023713e0ff59ab32c9579ae62a7674c0e34f3b0b0a", size = 5067921, upload-time = "2026-05-18T19:17:49.175Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/3c/c0690d74bd2bc17bc03b5b0d093569ead597dd0bfa088bf99eef8c24e19c/lxml-6.1.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a12689be69a28ddaa0ab99a5a1137da2afd5f8f16df7b5680b66f616d3eda1d", size = 5002456, upload-time = "2026-05-18T19:17:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8d/d1b3271af0c0f1e27e8472a849e4d2c65bc7766884b9ad2da9e76e145c88/lxml-6.1.1-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b73c339ae29b90fd2d06e58ebd555a751bde9cd6bbd36cc0281b9a2c94e9d8", size = 5202776, upload-time = "2026-05-18T19:18:08.924Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/45/689824ffb237fd10125ad273f32b28ff04dc6203c2822c85ff65a93df65e/lxml-6.1.1-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:752d3bbfe874715ccd0aec7f88d7fc623c0f1fd7aa7b3238a084e017bad2a009", size = 5329945, upload-time = "2026-05-18T19:18:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/c0/ef73af53767e958fd87d437c170f272e2f6e6c0f854939f133a895f1e711/lxml-6.1.1-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:6b1761fbf9ec984e2e9d9c589ef5f5fd684b7c19f92aadd567a26c5224958db6", size = 4659237, upload-time = "2026-05-18T19:18:18.657Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5e/e1158e40397585e91cb0472374a1f63d0926a1ddeaa92f13d1a1ffe306d5/lxml-6.1.1-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d680fbcb768404c601ecb43519ecd8461f6954cb11c06a78962f666832ccfca8", size = 5265904, upload-time = "2026-05-18T19:18:24.883Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/16/8687e5d1400ed1c0bc41dace232ebb7553952b618ea1f2e5fb6e2cfbbe23/lxml-6.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:162af1091cd785f2f27e62d3547ae9bc58ec5c86dd314d67021fd02463708d83", size = 5045225, upload-time = "2026-05-18T19:17:20.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/18/d877bd1ae2e5ffdfd4836565aba350db31feb2f2656d6ce70316ed66a05e/lxml-6.1.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e9308ff8241c532df3f3e570f9a5aeed6c853f888512ba4b75638d7c11c95ef6", size = 4712721, upload-time = "2026-05-18T19:17:40.512Z" },
+    { url = "https://files.pythonhosted.org/packages/44/4d/1f44fd1d770b10dacbf6b5c6e520f4d6e0708744930f719dc04e67cab981/lxml-6.1.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5f6994074ebae6ffb04447268e37dc16edc304f9859cf91acb86e0af6c1b395c", size = 5252549, upload-time = "2026-05-18T19:17:51.236Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5d/1d66b84f850089254c230ef6ea6b267a5a54e2e179a5d960036a05d501d7/lxml-6.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80c2dfadb855da477cf73373ad29a333535dedb9b12bad02c9814c8e2b43bf08", size = 5226877, upload-time = "2026-05-18T19:18:00.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/00/84c4b5302d42a2d0184f38d538c8a197f33b52a50bd4f7bcfe990bce3036/lxml-6.1.1-cp311-cp311-win32.whl", hash = "sha256:30a89d3ac8faec007453fb541f3f46807eeec88edd5826f6e3fe001752a2c621", size = 3594072, upload-time = "2026-05-18T19:17:12.714Z" },
+    { url = "https://files.pythonhosted.org/packages/61/9d/2e2f7d876349f45e0f3e29f72da311668853d59b58d473a2dea4f0160135/lxml-6.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:abbefa31eee84842140f67acef1c828e28bba8bbf0c3bc6e5492a9af88152c28", size = 4025469, upload-time = "2026-05-18T19:17:50.566Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/570e6390e4110331e6208b2ba83d1482cc9146808ee118b22824a34c1070/lxml-6.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:dcb292aa7fe485ceff7af4f92e46c5af397daec5dff64871a528f0fc47a3cc5b", size = 3667640, upload-time = "2026-05-19T19:22:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7", size = 8570821, upload-time = "2026-05-18T19:17:42.068Z" },
+    { url = "https://files.pythonhosted.org/packages/22/00/ff3009c88e65de8011630acf8ab5a09cb2becd2aaf47fba2f3449f6224e9/lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1", size = 4624252, upload-time = "2026-05-18T19:17:47.897Z" },
+    { url = "https://files.pythonhosted.org/packages/42/95/bb63f0fd62e554fe078e1fb3c8fe9083c14ddc7ad7fa178d10e57e071ac7/lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc", size = 4930746, upload-time = "2026-05-18T19:18:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723, upload-time = "2026-05-18T19:18:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383", size = 5005557, upload-time = "2026-05-18T19:18:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036, upload-time = "2026-05-18T19:18:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367, upload-time = "2026-05-18T19:18:49.217Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/8555d40948b09ce86f1bd0c68a7ac31d07b1929f92cc1b074006c97ef2d2/lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740", size = 5350171, upload-time = "2026-05-18T19:18:52.779Z" },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874, upload-time = "2026-05-18T19:18:55.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492, upload-time = "2026-05-18T19:19:01.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/5fcf7eb9904b80086aa47dcf0027de07b1bb990afad2e6823144c368ae04/lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635", size = 5048232, upload-time = "2026-05-18T19:18:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023, upload-time = "2026-05-18T19:18:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773, upload-time = "2026-05-18T19:18:23.223Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088, upload-time = "2026-05-18T19:18:31.433Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995, upload-time = "2026-05-18T19:18:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/6772e1a4b513fc50a8d931f19edde0e13ae6918510a1e13ff67864f3e5ed/lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a", size = 3596382, upload-time = "2026-05-18T19:17:18.37Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/45198e9624762af2dfd2cb8782598477ceb29f6e59caab560388ae1f4ec1/lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77", size = 3997255, upload-time = "2026-05-18T19:17:56.781Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a9/7a54b6834088d9ae528a7b780584ba6a39a9457b0ac330479f20ffbc9449/lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f", size = 3659610, upload-time = "2026-05-19T19:22:50.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/32/86a3f0f724a3a402d4627937a7fc27b160e45e7012b4adf47f6e1e844511/lxml-6.1.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:31033dc34636ea6b7d5cc11b1ddbda78a14de858ba9d3e1ed4b69a3085bc521e", size = 3930127, upload-time = "2026-05-18T19:19:02.27Z" },
+    { url = "https://files.pythonhosted.org/packages/40/44/d832e82af08723761556d004b1d04d281c09f9a8cecd7d3148548c9941a3/lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3893c14c4b6ac5b2d54ba8cf03e99fe5104e592de491f19bd6b82756c09f8004", size = 4210769, upload-time = "2026-05-18T19:20:41.427Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/39/0dc5949f759ed7d951e0bb8c2f2d9d7aca1908d22352fa84a8afd2ea54af/lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c07da4cebf6889f03ebac8d238f62318e29f495de0aa18a51ea14e61ae907e2e", size = 4318163, upload-time = "2026-05-18T19:20:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/fb/8ab3845fe046ba4cbf74536bcf6801a774b7caf4350de1c5d37f1f0a9e90/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6f0ce10945fab9c4c06ce14e22af9059d1a87493a9af4501a5b0b9187e21cf2", size = 4250945, upload-time = "2026-05-18T19:20:47.385Z" },
+    { url = "https://files.pythonhosted.org/packages/68/1b/7553ab136894374ffae8851ec06f98f511cd8e66246e41b6be059d0a7289/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8844cd288697c6425c9beba919302241e3278871dc6519515e72b04e987abcf", size = 4401664, upload-time = "2026-05-18T19:20:50.489Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a4/441aee36c6f6b249823d20fd91f9be9ab89d7c5a8ae542a4a4ca6d342d56/lxml-6.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:ed21202aec73cda4d55d1ce57b389aadb90ffb044e6cd1080b8347efe1b1ec84", size = 3508989, upload-time = "2026-05-18T19:18:38.158Z" },
+]
+
+[[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/15/cca9d88503549ed6fedeaa1d448cdddd542ee8a490232d732e278036fbf2/mypy-2.1.0.tar.gz", hash = "sha256:81e76ad12c2d804512e9b13240d1588316531bfba07558286078bfbce9613633", size = 3898359, upload-time = "2026-05-11T18:37:36.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/71/d351dca3e9b30da2328ee9d445c88b8388072808ebfbc49eb69d30b67749/mypy-2.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:11a6beb180257a805961aea9ec591bbd0bd17f1e18d35b8456d57aee5bedfedc", size = 14778792, upload-time = "2026-05-11T18:36:23.605Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/45/7d51594b644c17c0bcf74ed8cd5fc33b324276d708e8506f220b70dab9d9/mypy-2.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8ef78c1d306bbf9a8a12f526c44902c9c28dffd6c52c52bf6a72641ce18d3849", size = 13645739, upload-time = "2026-05-11T18:37:22.752Z" },
+    { url = "https://files.pythonhosted.org/packages/65/01/455c31b170e9468265074840bf18863a8482a24103fdaabe4e199392aa5f/mypy-2.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c209a90853081ff01d01ee895cafe10f7db1474e0d95beaeef0f6c1db9119bbd", size = 14074199, upload-time = "2026-05-11T18:35:09.292Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5a/93093f0b29a9e982deafde698f740a2eb2e05886e79ccf0594c7fd5413a3/mypy-2.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47cebf61abde7c088a4e27718a8b13a81655686b2e9c251f5c0915a802248166", size = 14953128, upload-time = "2026-05-11T18:31:57.678Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2f/a196f5331d96170ad3d28f144d2aba690d4b2911381f68d51e489c7ab82a/mypy-2.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d57a90ae5e872138a425ec328edbc9b235d1934c4377881a33ec05b341acc9a8", size = 15249378, upload-time = "2026-05-11T18:33:00.101Z" },
+    { url = "https://files.pythonhosted.org/packages/54/de/94d321cc12da9f71341ac0c270efbed5c725750c7b4c334d957de9a087d9/mypy-2.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:aea7f7a8a55b459c34275fc468ada6ca7c173a5e43a68f5dbe588a563d8a06b8", size = 11060994, upload-time = "2026-05-11T18:33:18.848Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/62/0c27ca55219a7c764a7fb88c7bb2b7b2f9780ade8bbf16bc8ed8400eef6b/mypy-2.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:c989640253f0d76843e9c6c1bbf4bd48c5e85ada61bde4beb37cb3eca035685e", size = 9976743, upload-time = "2026-05-11T18:31:25.554Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a1/639f3024794a2a15899cb90707fe02e044c4412794c39c5769fd3df2e2ef/mypy-2.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a683016b16fe2f572dc04c72be7ee0504ac1605a265d0200f5cea695fb788f41", size = 14691685, upload-time = "2026-05-11T18:33:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/08/9a585dea4325f20d8b80dc78623fa50d1fd2173b710f6237afd6ba6ab39b/mypy-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1a293c534adb55271fef24a26da04b855540a8c13cc07bc5917b9fd2c394f2ca", size = 13555165, upload-time = "2026-05-11T18:32:16.107Z" },
+    { url = "https://files.pythonhosted.org/packages/81/dc/7c42cc9c6cb01e8eb09961f1f738741d3e9c7e9d5c5b30ec69222625cd5f/mypy-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7406f4d048e71e576f5356d317e5b0a9e666dfd966bd99f9d14ca06e1a341538", size = 13994376, upload-time = "2026-05-11T18:32:39.256Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/285946c33bce716e082c11dfeee9ee196eaf1f5042efb3581a31f9f205e4/mypy-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0210d626fc8b31ccc90233754c7bc90e1f43205e85d96387f7db1285b55c398", size = 14864618, upload-time = "2026-05-11T18:34:49.765Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/83/82397f48af6c27e295d57979ded8490c9829040152cf7571b2f026aeb9a0/mypy-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3712c20deed54e814eaaa825603bada8ea1c390670a397c95b98405347acc563", size = 15102063, upload-time = "2026-05-11T18:34:05.855Z" },
+    { url = "https://files.pythonhosted.org/packages/40/68/b02dec39057b88eb03dc0aa854732e26e8361f34f9d0e20c7614967d1eba/mypy-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:fcaa0e479066e31f7cceb6a3bea39cb22b2ff51a6b2f24f193d19179ba17c389", size = 11060564, upload-time = "2026-05-11T18:35:36.494Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a8/ea3dcbef31f99b634f2ee23bb0321cbc8c1b388b76a861eb849f13c347dc/mypy-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:0b1a5260c95aa443083f9ed3592662941951bca3d4ca224a5dc517c38b7cf666", size = 9966983, upload-time = "2026-05-11T18:37:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b1/55861beb5c339b44f9a2ba92df9e2cb1eeb4ae1eee674cdf7772c797778b/mypy-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:244358bf1c0da7722230bce60683d52e8e9fd030554926f15b747a84efb5b3af", size = 14874381, upload-time = "2026-05-11T18:37:31.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b3/b7f770114b7d0ac92d0f76e8d93c2780844a70488a90e91821927850da86/mypy-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4ec7c57657493c7a75534df2751c8ae2cda383c16ecc55d2106c54476b1b16f6", size = 13665501, upload-time = "2026-05-11T18:34:23.063Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f3/8ae2037967e2126689a0c11d99e2b707134a565191e92c60ca2572aec60a/mypy-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8161b6ff4392410023224f0969d17db93e1e154bc3e4ba62598e720723ae211", size = 14045750, upload-time = "2026-05-11T18:31:48.151Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/32/615eb5911859e43d054941b0d0a7d06cfa2870eba86529cf385b052b111c/mypy-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf03e12003084a67395184d3eb8cbd6a489dc3655b5664b28c210a9e2403ab0b", size = 15061630, upload-time = "2026-05-11T18:37:06.898Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/03/4eafbfff8bfab1b87082741eae6e6a624028c984e6708b73bce2a8570c9d/mypy-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:20509760fd791c51579d573153407d226385ec1f8bcce55d730b354f3336bc22", size = 15288831, upload-time = "2026-05-11T18:31:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/919661478e5891a3c96e549c036e467e64563ab85995b10c53c8358e16a3/mypy-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:6753d0c1fdd6b1a23b9e4f283ce80b2153b724adcb2653b20b85a8a28ac6436b", size = 11135228, upload-time = "2026-05-11T18:34:31.23Z" },
+    { url = "https://files.pythonhosted.org/packages/24/0a/6a12b9782ca0831a553192f351679f4548abc9d19a7cc93bb7feb02084c7/mypy-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:98ebb6589bb3b6d0c6f0c459d53ca55b8091fbc13d277c4041c885392e8195e8", size = 10040684, upload-time = "2026-05-11T18:36:48.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/dd/c7191469c777f07689c032a8f7326e393ea34c92d6d76eb7ce5ba57ea66d/mypy-2.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35aac3bb114e03888f535d5eb51b8bafbb3266586b599da1940f9b1be3ec5bd5", size = 14852174, upload-time = "2026-05-11T18:31:38.929Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8c/aed55408879043d72bb9135f4d0d19a02b886dd569631e113e3d2706cb8d/mypy-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8de55a8c861f2a49331f807be98d90caeceeef520bde13d43a160207f8af613e", size = 13651542, upload-time = "2026-05-11T18:36:04.636Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8e/f371a824b1f1fa8ea6e3dbb8703d232977d572be2329554a3bc4d960302f/mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5fdf2941a07434af755837d9880f7d7d25f1dacb1af9dcd4b9b66f2220a3024e", size = 14033929, upload-time = "2026-05-11T18:35:55.742Z" },
+    { url = "https://files.pythonhosted.org/packages/94/21/f54be870d6dd53a82c674407e0f8eed7174b05ec78d42e5abd7b42e84fd5/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285", size = 15039200, upload-time = "2026-05-11T18:33:10.281Z" },
+    { url = "https://files.pythonhosted.org/packages/17/99/bf21748626a40ce59fd29a39386ab46afec88b7bd2f0fa6c3a97c995523f/mypy-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5431d42af987ebd92ba2f71d45c85ed41d8e6ca9f5fd209a69f68f707d2469e5", size = 15272690, upload-time = "2026-05-11T18:32:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d7/9e90d2cf47100bea550ed2bc7b0d4de3a62181d84d5e37da0003e8462637/mypy-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:767fe8c66dc3e01e19e1737d4c38ebefead16125e1b8e58ad421903b376f5c65", size = 11147435, upload-time = "2026-05-11T18:33:56.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/46/e5c449e858798e35ffc90946282a27c62a77be743fe17480e4977374eb91/mypy-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:ecfe70d43775ab99562ab128ce49854a362044c9f894961f68f898c23cb7429d", size = 10035052, upload-time = "2026-05-11T18:32:30.049Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ca/b279a672e874aedd5498ae25f722dacc8aa86bbffb939b3f97cbb1cf6686/mypy-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7354c5a7f69d9345c3d6e69921d57088eea3ddeeb6b20d34c1b3855b02c36ec2", size = 14848422, upload-time = "2026-05-11T18:35:45.984Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e6/3efe56c631d959b9b4454e208b0ac4b7f4f58b404c89f8bec7b49efdfc21/mypy-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:49890d4f76ac9e06ec117f9e09f3174da70a620a0c300953d8595c926e80947f", size = 13677374, upload-time = "2026-05-11T18:36:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7f/8107ea87a44fd1f1b59882442f033c9c3488c127201b1d1d15f1cbd6022e/mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:761be68e023ef5d94678772396a8af1220030f80837a3afd8d0aef3b419666f4", size = 14055743, upload-time = "2026-05-11T18:35:18.361Z" },
+    { url = "https://files.pythonhosted.org/packages/51/4d/b6d34db183133b83761b9199a82d31557cdbb70a380d8c3b3438e11882a3/mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c90345fc182dc363b891350457ec69c35140858538f38b4540845afcc32b1aef", size = 15020937, upload-time = "2026-05-11T18:34:59.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/d7/f08360c691d758acb02f45022c34d98b92892f4ea756644e1000d4b9f3d8/mypy-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b84802e7b5a6daf1f5e15bc9fcd7ddae77be13981ffab037f1c67bb84d67d135", size = 15253371, upload-time = "2026-05-11T18:36:41.081Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1b/09460a13719530a19bce27bd3bc8449e83569dd2ba7faf51c9c3c30c0b61/mypy-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:022c771234936ceac541ebaf836fe9e2abeb3f5e09aff21588fe543ff006fe21", size = 11326429, upload-time = "2026-05-11T18:34:13.526Z" },
+    { url = "https://files.pythonhosted.org/packages/40/62/75dbf0f82f7b6680340efc614af29dd0b3c17b8a4f1cd09b8bd2fd6bc814/mypy-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:498207db725cec88829a6a5c2fc771205fd043719ef98bc49aba8fb9fc4e6d57", size = 10218799, upload-time = "2026-05-11T18:32:23.491Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/66/caca04ed7d972fb6eb6dd1ccd6df1de5c38fae8c5b3dc1c4e8e0d85ee6b9/mypy-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d5e5cad0efeba72b93cd17490cc0d69c5ac9ca132994fe3fb0314808aeeb83e", size = 15923458, upload-time = "2026-05-11T18:35:28.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/52/2d90cbe49d014b13ed7ff337930c30bad35893fe38a1e4641e756bb62191/mypy-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ff715050c127d724fd260a2e666e7747fdd83511c0c47d449d98238970aef780", size = 14757697, upload-time = "2026-05-11T18:36:14.208Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/37/d98f4a14e081b238992d0ed96b6d39c7cc0148c9699eb71eaa68629665ea/mypy-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82208da9e09414d520e912d3e462d454854bed0810b71540bb016dcbca7308fd", size = 15405638, upload-time = "2026-05-11T18:33:48.249Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c2/15c46613b24a84fad2aea1248bf9619b99c2767ae9071fe224c179a0b7d4/mypy-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e79ebc1b904b84f0310dff7469655a9c36c7a68bddb37bdd42b67a332df61d08", size = 16215852, upload-time = "2026-05-11T18:32:50.296Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/90/9c16a57f482c76d25f6379762b56bbf65c711d8158cf271fb2802cfb0640/mypy-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e583edc957cfb0deb142079162ae826f58449b116c1d442f2d91c69d9fced081", size = 16452695, upload-time = "2026-05-11T18:33:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/4c/215a4eeb63cacc5f17f516691ea7285d11e249802b942476bff15922a314/mypy-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b33b6cd332695bba180d55e717a79d3038e479a2c49cc5eb3d53603409b9a5d7", size = 12866622, upload-time = "2026-05-11T18:34:39.945Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/1043e1db5f455ffe4c9ab22747cd8ca2bc492b1e4f4e21b130a44ee2b217/mypy-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:4f910fe825376a7b66ef7ca8c98e5a149e8cd64c19ae71d84047a74ee060d4e6", size = 10610798, upload-time = "2026-05-11T18:36:31.444Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2a/13ca1f292f6db1b98ff495ef3467736b331621c5917cad984b7043e7348d/mypy-2.1.0-py3-none-any.whl", hash = "sha256:a663814603a5c563fb87a4f96fb473eeb30d1f5a4885afcf44f9db000a366289", size = 2693302, upload-time = "2026-05-11T18:31:29.246Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.2.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3e/ed6db5be21ce87955c0cbd3009f2803f59fa08df21b5df06862e2d8e2bdd/numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb", size = 21165245, upload-time = "2025-05-17T21:27:58.555Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c2/4b9221495b2a132cc9d2eb862e21d42a009f5a60e45fc44b00118c174bff/numpy-2.2.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e41fd67c52b86603a91c1a505ebaef50b3314de0213461c7a6e99c9a3beff90", size = 14360048, upload-time = "2025-05-17T21:28:21.406Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/77/dc2fcfc66943c6410e2bf598062f5959372735ffda175b39906d54f02349/numpy-2.2.6-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:37e990a01ae6ec7fe7fa1c26c55ecb672dd98b19c3d0e1d1f326fa13cb38d163", size = 5340542, upload-time = "2025-05-17T21:28:30.931Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4f/1cb5fdc353a5f5cc7feb692db9b8ec2c3d6405453f982435efc52561df58/numpy-2.2.6-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:5a6429d4be8ca66d889b7cf70f536a397dc45ba6faeb5f8c5427935d9592e9cf", size = 6878301, upload-time = "2025-05-17T21:28:41.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/17/96a3acd228cec142fcb8723bd3cc39c2a474f7dcf0a5d16731980bcafa95/numpy-2.2.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efd28d4e9cd7d7a8d39074a4d44c63eda73401580c5c76acda2ce969e0a38e83", size = 14297320, upload-time = "2025-05-17T21:29:02.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/63/3de6a34ad7ad6646ac7d2f55ebc6ad439dbbf9c4370017c50cf403fb19b5/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc7b73d02efb0e18c000e9ad8b83480dfcd5dfd11065997ed4c6747470ae8915", size = 16801050, upload-time = "2025-05-17T21:29:27.675Z" },
+    { url = "https://files.pythonhosted.org/packages/07/b6/89d837eddef52b3d0cec5c6ba0456c1bf1b9ef6a6672fc2b7873c3ec4e2e/numpy-2.2.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:74d4531beb257d2c3f4b261bfb0fc09e0f9ebb8842d82a7b4209415896adc680", size = 15807034, upload-time = "2025-05-17T21:29:51.102Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c8/dc6ae86e3c61cfec1f178e5c9f7858584049b6093f843bca541f94120920/numpy-2.2.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8fc377d995680230e83241d8a96def29f204b5782f371c532579b4f20607a289", size = 18614185, upload-time = "2025-05-17T21:30:18.703Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c5/0064b1b7e7c89137b471ccec1fd2282fceaae0ab3a9550f2568782d80357/numpy-2.2.6-cp310-cp310-win32.whl", hash = "sha256:b093dd74e50a8cba3e873868d9e93a85b78e0daf2e98c6797566ad8044e8363d", size = 6527149, upload-time = "2025-05-17T21:30:29.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/dd/4b822569d6b96c39d1215dbae0582fd99954dcbcf0c1a13c61783feaca3f/numpy-2.2.6-cp310-cp310-win_amd64.whl", hash = "sha256:f0fd6321b839904e15c46e0d257fdd101dd7f530fe03fd6359c1ea63738703f3", size = 12904620, upload-time = "2025-05-17T21:30:48.994Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a8/4f83e2aa666a9fbf56d6118faaaf5f1974d456b1823fda0a176eff722839/numpy-2.2.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f9f1adb22318e121c5c69a09142811a201ef17ab257a1e66ca3025065b7f53ae", size = 21176963, upload-time = "2025-05-17T21:31:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2b/64e1affc7972decb74c9e29e5649fac940514910960ba25cd9af4488b66c/numpy-2.2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c820a93b0255bc360f53eca31a0e676fd1101f673dda8da93454a12e23fc5f7a", size = 14406743, upload-time = "2025-05-17T21:31:41.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9f/0121e375000b5e50ffdd8b25bf78d8e1a5aa4cca3f185d41265198c7b834/numpy-2.2.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3d70692235e759f260c3d837193090014aebdf026dfd167834bcba43e30c2a42", size = 5352616, upload-time = "2025-05-17T21:31:50.072Z" },
+    { url = "https://files.pythonhosted.org/packages/31/0d/b48c405c91693635fbe2dcd7bc84a33a602add5f63286e024d3b6741411c/numpy-2.2.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:481b49095335f8eed42e39e8041327c05b0f6f4780488f61286ed3c01368d491", size = 6889579, upload-time = "2025-05-17T21:32:01.712Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/7f0554d49b565d0171eab6e99001846882000883998e7b7d9f0d98b1f934/numpy-2.2.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b64d8d4d17135e00c8e346e0a738deb17e754230d7e0810ac5012750bbd85a5a", size = 14312005, upload-time = "2025-05-17T21:32:23.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/dd/2238b898e51bd6d389b7389ffb20d7f4c10066d80351187ec8e303a5a475/numpy-2.2.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba10f8411898fc418a521833e014a77d3ca01c15b0c6cdcce6a0d2897e6dbbdf", size = 16821570, upload-time = "2025-05-17T21:32:47.991Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6c/44d0325722cf644f191042bf47eedad61c1e6df2432ed65cbe28509d404e/numpy-2.2.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bd48227a919f1bafbdda0583705e547892342c26fb127219d60a5c36882609d1", size = 15818548, upload-time = "2025-05-17T21:33:11.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/9d/81e8216030ce66be25279098789b665d49ff19eef08bfa8cb96d4957f422/numpy-2.2.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9551a499bf125c1d4f9e250377c1ee2eddd02e01eac6644c080162c0c51778ab", size = 18620521, upload-time = "2025-05-17T21:33:39.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/e19617b9530b031db51b0926eed5345ce8ddc669bb3bc0044b23e275ebe8/numpy-2.2.6-cp311-cp311-win32.whl", hash = "sha256:0678000bb9ac1475cd454c6b8c799206af8107e310843532b04d49649c717a47", size = 6525866, upload-time = "2025-05-17T21:33:50.273Z" },
+    { url = "https://files.pythonhosted.org/packages/31/0a/f354fb7176b81747d870f7991dc763e157a934c717b67b58456bc63da3df/numpy-2.2.6-cp311-cp311-win_amd64.whl", hash = "sha256:e8213002e427c69c45a52bbd94163084025f533a55a59d6f9c5b820774ef3303", size = 12907455, upload-time = "2025-05-17T21:34:09.135Z" },
+    { url = "https://files.pythonhosted.org/packages/82/5d/c00588b6cf18e1da539b45d3598d3557084990dcc4331960c15ee776ee41/numpy-2.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:41c5a21f4a04fa86436124d388f6ed60a9343a6f767fced1a8a71c3fbca038ff", size = 20875348, upload-time = "2025-05-17T21:34:39.648Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ee/560deadcdde6c2f90200450d5938f63a34b37e27ebff162810f716f6a230/numpy-2.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de749064336d37e340f640b05f24e9e3dd678c57318c7289d222a8a2f543e90c", size = 14119362, upload-time = "2025-05-17T21:35:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/65/4baa99f1c53b30adf0acd9a5519078871ddde8d2339dc5a7fde80d9d87da/numpy-2.2.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:894b3a42502226a1cac872f840030665f33326fc3dac8e57c607905773cdcde3", size = 5084103, upload-time = "2025-05-17T21:35:10.622Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/89/e5a34c071a0570cc40c9a54eb472d113eea6d002e9ae12bb3a8407fb912e/numpy-2.2.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:71594f7c51a18e728451bb50cc60a3ce4e6538822731b2933209a1f3614e9282", size = 6625382, upload-time = "2025-05-17T21:35:21.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/35/8c80729f1ff76b3921d5c9487c7ac3de9b2a103b1cd05e905b3090513510/numpy-2.2.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2618db89be1b4e05f7a1a847a9c1c0abd63e63a1607d892dd54668dd92faf87", size = 14018462, upload-time = "2025-05-17T21:35:42.174Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3d/1e1db36cfd41f895d266b103df00ca5b3cbe965184df824dec5c08c6b803/numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd83c01228a688733f1ded5201c678f0c53ecc1006ffbc404db9f7a899ac6249", size = 16527618, upload-time = "2025-05-17T21:36:06.711Z" },
+    { url = "https://files.pythonhosted.org/packages/61/c6/03ed30992602c85aa3cd95b9070a514f8b3c33e31124694438d88809ae36/numpy-2.2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37c0ca431f82cd5fa716eca9506aefcabc247fb27ba69c5062a6d3ade8cf8f49", size = 15505511, upload-time = "2025-05-17T21:36:29.965Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/5761d832a81df431e260719ec45de696414266613c9ee268394dd5ad8236/numpy-2.2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fe27749d33bb772c80dcd84ae7e8df2adc920ae8297400dabec45f0dedb3f6de", size = 18313783, upload-time = "2025-05-17T21:36:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0a/72d5a3527c5ebffcd47bde9162c39fae1f90138c961e5296491ce778e682/numpy-2.2.6-cp312-cp312-win32.whl", hash = "sha256:4eeaae00d789f66c7a25ac5f34b71a7035bb474e679f410e5e1a94deb24cf2d4", size = 6246506, upload-time = "2025-05-17T21:37:07.368Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fa/8c9210162ca1b88529ab76b41ba02d433fd54fecaf6feb70ef9f124683f1/numpy-2.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c1f9540be57940698ed329904db803cf7a402f3fc200bfe599334c9bd84a40b2", size = 12614190, upload-time = "2025-05-17T21:37:26.213Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5c/6657823f4f594f72b5471f1db1ab12e26e890bb2e41897522d134d2a3e81/numpy-2.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0811bb762109d9708cca4d0b13c4f67146e3c3b7cf8d34018c722adb2d957c84", size = 20867828, upload-time = "2025-05-17T21:37:56.699Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9e/14520dc3dadf3c803473bd07e9b2bd1b69bc583cb2497b47000fed2fa92f/numpy-2.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:287cc3162b6f01463ccd86be154f284d0893d2b3ed7292439ea97eafa8170e0b", size = 14143006, upload-time = "2025-05-17T21:38:18.291Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/06/7e96c57d90bebdce9918412087fc22ca9851cceaf5567a45c1f404480e9e/numpy-2.2.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f1372f041402e37e5e633e586f62aa53de2eac8d98cbfb822806ce4bbefcb74d", size = 5076765, upload-time = "2025-05-17T21:38:27.319Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ed/63d920c23b4289fdac96ddbdd6132e9427790977d5457cd132f18e76eae0/numpy-2.2.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:55a4d33fa519660d69614a9fad433be87e5252f4b03850642f88993f7b2ca566", size = 6617736, upload-time = "2025-05-17T21:38:38.141Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c5/e19c8f99d83fd377ec8c7e0cf627a8049746da54afc24ef0a0cb73d5dfb5/numpy-2.2.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f92729c95468a2f4f15e9bb94c432a9229d0d50de67304399627a943201baa2f", size = 14010719, upload-time = "2025-05-17T21:38:58.433Z" },
+    { url = "https://files.pythonhosted.org/packages/19/49/4df9123aafa7b539317bf6d342cb6d227e49f7a35b99c287a6109b13dd93/numpy-2.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bc23a79bfabc5d056d106f9befb8d50c31ced2fbc70eedb8155aec74a45798f", size = 16526072, upload-time = "2025-05-17T21:39:22.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6c/04b5f47f4f32f7c2b0e7260442a8cbcf8168b0e1a41ff1495da42f42a14f/numpy-2.2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3143e4451880bed956e706a3220b4e5cf6172ef05fcc397f6f36a550b1dd868", size = 15503213, upload-time = "2025-05-17T21:39:45.865Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0a/5cd92e352c1307640d5b6fec1b2ffb06cd0dabe7d7b8227f97933d378422/numpy-2.2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4f13750ce79751586ae2eb824ba7e1e8dba64784086c98cdbbcc6a42112ce0d", size = 18316632, upload-time = "2025-05-17T21:40:13.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3b/5cba2b1d88760ef86596ad0f3d484b1cbff7c115ae2429678465057c5155/numpy-2.2.6-cp313-cp313-win32.whl", hash = "sha256:5beb72339d9d4fa36522fc63802f469b13cdbe4fdab4a288f0c441b74272ebfd", size = 6244532, upload-time = "2025-05-17T21:43:46.099Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/3b/d58c12eafcb298d4e6d0d40216866ab15f59e55d148a5658bb3132311fcf/numpy-2.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b0544343a702fa80c95ad5d3d608ea3599dd54d4632df855e4c8d24eb6ecfa1c", size = 12610885, upload-time = "2025-05-17T21:44:05.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/9e/4bf918b818e516322db999ac25d00c75788ddfd2d2ade4fa66f1f38097e1/numpy-2.2.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0bca768cd85ae743b2affdc762d617eddf3bcf8724435498a1e80132d04879e6", size = 20963467, upload-time = "2025-05-17T21:40:44Z" },
+    { url = "https://files.pythonhosted.org/packages/61/66/d2de6b291507517ff2e438e13ff7b1e2cdbdb7cb40b3ed475377aece69f9/numpy-2.2.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fc0c5673685c508a142ca65209b4e79ed6740a4ed6b2267dbba90f34b0b3cfda", size = 14225144, upload-time = "2025-05-17T21:41:05.695Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/25/480387655407ead912e28ba3a820bc69af9adf13bcbe40b299d454ec011f/numpy-2.2.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:5bd4fc3ac8926b3819797a7c0e2631eb889b4118a9898c84f585a54d475b7e40", size = 5200217, upload-time = "2025-05-17T21:41:15.903Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4a/6e313b5108f53dcbf3aca0c0f3e9c92f4c10ce57a0a721851f9785872895/numpy-2.2.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:fee4236c876c4e8369388054d02d0e9bb84821feb1a64dd59e137e6511a551f8", size = 6712014, upload-time = "2025-05-17T21:41:27.321Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/30/172c2d5c4be71fdf476e9de553443cf8e25feddbe185e0bd88b096915bcc/numpy-2.2.6-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1dda9c7e08dc141e0247a5b8f49cf05984955246a327d4c48bda16821947b2f", size = 14077935, upload-time = "2025-05-17T21:41:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fb/9e743f8d4e4d3c710902cf87af3512082ae3d43b945d5d16563f26ec251d/numpy-2.2.6-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f447e6acb680fd307f40d3da4852208af94afdfab89cf850986c3ca00562f4fa", size = 16600122, upload-time = "2025-05-17T21:42:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/12/75/ee20da0e58d3a66f204f38916757e01e33a9737d0b22373b3eb5a27358f9/numpy-2.2.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:389d771b1623ec92636b0786bc4ae56abafad4a4c513d36a55dce14bd9ce8571", size = 15586143, upload-time = "2025-05-17T21:42:37.464Z" },
+    { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1", size = 18385260, upload-time = "2025-05-17T21:43:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff", size = 6377225, upload-time = "2025-05-17T21:43:16.254Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06", size = 12771374, upload-time = "2025-05-17T21:43:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/3b/d94a75f4dbf1ef5d321523ecac21ef23a3cd2ac8b78ae2aac40873590229/numpy-2.2.6-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0b605b275d7bd0c640cad4e5d30fa701a8d59302e127e5f79138ad62762c3e3d", size = 21040391, upload-time = "2025-05-17T21:44:35.948Z" },
+    { url = "https://files.pythonhosted.org/packages/17/f4/09b2fa1b58f0fb4f7c7963a1649c64c4d315752240377ed74d9cd878f7b5/numpy-2.2.6-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:7befc596a7dc9da8a337f79802ee8adb30a552a94f792b9c9d18c840055907db", size = 6786754, upload-time = "2025-05-17T21:44:47.446Z" },
+    { url = "https://files.pythonhosted.org/packages/af/30/feba75f143bdc868a1cc3f44ccfa6c4b9ec522b36458e738cd00f67b573f/numpy-2.2.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce47521a4754c8f4593837384bd3424880629f718d87c5d44f8ed763edd63543", size = 16643476, upload-time = "2025-05-17T21:45:11.871Z" },
+    { url = "https://files.pythonhosted.org/packages/37/48/ac2a9584402fb6c0cd5b5d1a91dcf176b15760130dd386bbafdbfe3640bf/numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00", size = 12812666, upload-time = "2025-05-17T21:45:31.426Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11' and python_full_version < '3.15'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0d/f5957185c0ee2f3e12f78715aa9e3b353fd83633316c8532b38faa37e3f6/numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d", size = 14964111, upload-time = "2026-05-18T23:33:17.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/40/40a40ee0ddf7ceb782c49af278894b686e586d65d8c1889c8b5da01a3d7d/numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8", size = 5469159, upload-time = "2026-05-18T23:33:20.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/f9a8046535cb21deae82f8d03de9617e08882d274fad2539630761888228/numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538", size = 6798936, upload-time = "2026-05-18T23:33:22.987Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a8/6fa8c1a345a8c85dbb21932c447bee07c30a2c2a3f31e369c0a84b300147/numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47", size = 15966692, upload-time = "2026-05-18T23:33:26.62Z" },
+    { url = "https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93", size = 16918164, upload-time = "2026-05-18T23:33:29.955Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/80/3615be3313f7e7696609bc194b9f0101da809df79e859bdb84e0cd043f46/numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8", size = 17322877, upload-time = "2026-05-18T23:33:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/a691e0fe2675e370d0e08ff905adc49a1c8830e8cae03efe4477e92cd55d/numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6", size = 18651487, upload-time = "2026-05-18T23:33:38.217Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a7/9bc1cd626d7bf6869bfedf27b91b6ab5dd607758bf8e959d6fa80c6a59cb/numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8", size = 6233945, upload-time = "2026-05-18T23:33:41.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/7fc6239c12bce7e931463251cca4426c465e1876ba3cc785402ef4dd8f4e/numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147", size = 12608406, upload-time = "2026-05-18T23:33:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/140f85a466595a16382996a1bf06b2b54bcd597488921b0c9daaeeda72af/numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577", size = 10479528, upload-time = "2026-05-18T23:33:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+    { url = "https://files.pythonhosted.org/packages/de/12/b422cc84439adc0d00de605bf4a308890ae5c26f2c71fbd73e5d08fbb0dd/numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662", size = 16847511, upload-time = "2026-05-18T23:36:50.673Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/f481bef68011740f8849418d82db07230e825013f31f4eef5ba5b805316a/numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7", size = 14889064, upload-time = "2026-05-18T23:36:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/57/42ed575c10ced8af951d426bc4e1f8aff16fd851db33f067036215a7f860/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f", size = 5394157, upload-time = "2026-05-18T23:36:57.194Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/f66cc724fcc36c1e364c67f51ae9146090b8b584f27d58b97fdae3edd737/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c", size = 6708728, upload-time = "2026-05-18T23:36:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/36/4c926a91554483977608951360c18c2e911592785eb87a6437813f6123f7/openai-2.41.1.tar.gz", hash = "sha256:23d617a0432457ad844973bee8f540be9da90894f7c5686852d2d365da058f57", size = 783584, upload-time = "2026-06-10T16:10:37.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/74/925d7b3892927e9804aaf58d374a45dc28e4420ff90e992272b77286343e/openai-2.41.1-py3-none-any.whl", hash = "sha256:a939565f350cb7443cb843b801b88c716ac8024b492fb94ca269d5f6b1bbefd6", size = 1353380, upload-time = "2026-06-10T16:10:35.756Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/aa/d0b28e1c811cd4d5f5c2bfe2e022292bd255ae5744a3b9ac7d6c8f72dd75/pillow-12.2.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:a4e8f36e677d3336f35089648c8955c51c6d386a13cf6ee9c189c5f5bd713a9f", size = 5354355, upload-time = "2026-04-01T14:42:15.402Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8e/1d5b39b8ae2bd7650d0c7b6abb9602d16043ead9ebbfef4bc4047454da2a/pillow-12.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e589959f10d9824d39b350472b92f0ce3b443c0a3442ebf41c40cb8361c5b97", size = 4695871, upload-time = "2026-04-01T14:42:18.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c5/dcb7a6ca6b7d3be41a76958e90018d56c8462166b3ef223150360850c8da/pillow-12.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a52edc8bfff4429aaabdf4d9ee0daadbbf8562364f940937b941f87a4290f5ff", size = 6269734, upload-time = "2026-04-01T14:42:20.608Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f1/aa1bb13b2f4eba914e9637893c73f2af8e48d7d4023b9d3750d4c5eb2d0c/pillow-12.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:975385f4776fafde056abb318f612ef6285b10a1f12b8570f3647ad0d74b48ec", size = 8076080, upload-time = "2026-04-01T14:42:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/2a/8c79d6a53169937784604a8ae8d77e45888c41537f7f6f65ed1f407fe66d/pillow-12.2.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd9c0c7a0c681a347b3194c500cb1e6ca9cab053ea4d82a5cf45b6b754560136", size = 6382236, upload-time = "2026-04-01T14:42:25.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/42/bbcb6051030e1e421d103ce7a8ecadf837aa2f39b8f82ef1a8d37c3d4ebc/pillow-12.2.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:88d387ff40b3ff7c274947ed3125dedf5262ec6919d83946753b5f3d7c67ea4c", size = 7070220, upload-time = "2026-04-01T14:42:28.68Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e1/c2a7d6dd8cfa6b231227da096fd2d58754bab3603b9d73bf609d3c18b64f/pillow-12.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:51c4167c34b0d8ba05b547a3bb23578d0ba17b80a5593f93bd8ecb123dd336a3", size = 6493124, upload-time = "2026-04-01T14:42:31.579Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/41/7c8617da5d32e1d2f026e509484fdb6f3ad7efaef1749a0c1928adbb099e/pillow-12.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:34c0d99ecccea270c04882cb3b86e7b57296079c9a4aff88cb3b33563d95afaa", size = 7194324, upload-time = "2026-04-01T14:42:34.615Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/de/a777627e19fd6d62f84070ee1521adde5eeda4855b5cf60fe0b149118bca/pillow-12.2.0-cp310-cp310-win32.whl", hash = "sha256:b85f66ae9eb53e860a873b858b789217ba505e5e405a24b85c0464822fe88032", size = 6376363, upload-time = "2026-04-01T14:42:37.19Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/34/fc4cb5204896465842767b96d250c08410f01f2f28afc43b257de842eed5/pillow-12.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:673aa32138f3e7531ccdbca7b3901dba9b70940a19ccecc6a37c77d5fdeb05b5", size = 7083523, upload-time = "2026-04-01T14:42:39.62Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/a0/32852d36bc7709f14dc3f64f929a275e958ad8c19a6deba9610d458e28b3/pillow-12.2.0-cp310-cp310-win_arm64.whl", hash = "sha256:3e080565d8d7c671db5802eedfb438e5565ffa40115216eabb8cd52d0ecce024", size = 2463318, upload-time = "2026-04-01T14:42:42.063Z" },
+    { url = "https://files.pythonhosted.org/packages/68/e1/748f5663efe6edcfc4e74b2b93edfb9b8b99b67f21a854c3ae416500a2d9/pillow-12.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:8be29e59487a79f173507c30ddf57e733a357f67881430449bb32614075a40ab", size = 5354347, upload-time = "2026-04-01T14:42:44.255Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a1/d5ff69e747374c33a3b53b9f98cca7889fce1fd03d79cdc4e1bccc6c5a87/pillow-12.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71cde9a1e1551df7d34a25462fc60325e8a11a82cc2e2f54578e5e9a1e153d65", size = 4695873, upload-time = "2026-04-01T14:42:46.452Z" },
+    { url = "https://files.pythonhosted.org/packages/df/21/e3fbdf54408a973c7f7f89a23b2cb97a7ef30c61ab4142af31eee6aebc88/pillow-12.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f490f9368b6fc026f021db16d7ec2fbf7d89e2edb42e8ec09d2c60505f5729c7", size = 6280168, upload-time = "2026-04-01T14:42:49.228Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f1/00b7278c7dd52b17ad4329153748f87b6756ec195ff786c2bdf12518337d/pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8bd7903a5f2a4545f6fd5935c90058b89d30045568985a71c79f5fd6edf9b91e", size = 8088188, upload-time = "2026-04-01T14:42:51.735Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cf/220a5994ef1b10e70e85748b75649d77d506499352be135a4989c957b701/pillow-12.2.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3997232e10d2920a68d25191392e3a4487d8183039e1c74c2297f00ed1c50705", size = 6394401, upload-time = "2026-04-01T14:42:54.343Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/bd/e51a61b1054f09437acfbc2ff9106c30d1eb76bc1453d428399946781253/pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e74473c875d78b8e9d5da2a70f7099549f9eb37ded4e2f6a463e60125bccd176", size = 7079655, upload-time = "2026-04-01T14:42:56.954Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3d/45132c57d5fb4b5744567c3817026480ac7fc3ce5d4c47902bc0e7f6f853/pillow-12.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:56a3f9c60a13133a98ecff6197af34d7824de9b7b38c3654861a725c970c197b", size = 6503105, upload-time = "2026-04-01T14:42:59.847Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/2e/9df2fc1e82097b1df3dce58dc43286aa01068e918c07574711fcc53e6fb4/pillow-12.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90e6f81de50ad6b534cab6e5aef77ff6e37722b2f5d908686f4a5c9eba17a909", size = 7203402, upload-time = "2026-04-01T14:43:02.664Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2e/2941e42858ebb67e50ae741473de81c2984e6eff7b397017623c676e2e8d/pillow-12.2.0-cp311-cp311-win32.whl", hash = "sha256:8c984051042858021a54926eb597d6ee3012393ce9c181814115df4c60b9a808", size = 6378149, upload-time = "2026-04-01T14:43:05.274Z" },
+    { url = "https://files.pythonhosted.org/packages/69/42/836b6f3cd7f3e5fa10a1f1a5420447c17966044c8fbf589cc0452d5502db/pillow-12.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:6e6b2a0c538fc200b38ff9eb6628228b77908c319a005815f2dde585a0664b60", size = 7082626, upload-time = "2026-04-01T14:43:08.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/88/549194b5d6f1f494b485e493edc6693c0a16f4ada488e5bd974ed1f42fad/pillow-12.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:9a8a34cc89c67a65ea7437ce257cea81a9dad65b29805f3ecee8c8fe8ff25ffe", size = 2463531, upload-time = "2026-04-01T14:43:10.743Z" },
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b7/2437044fb910f499610356d1352e3423753c98e34f915252aafecc64889f/pillow-12.2.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538bd5e05efec03ae613fd89c4ce0368ecd2ba239cc25b9f9be7ed426b0af1f", size = 5273969, upload-time = "2026-04-01T14:45:55.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f4/8316e31de11b780f4ac08ef3654a75555e624a98db1056ecb2122d008d5a/pillow-12.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:394167b21da716608eac917c60aa9b969421b5dcbbe02ae7f013e7b85811c69d", size = 4659674, upload-time = "2026-04-01T14:45:58.093Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/37/664fca7201f8bb2aa1d20e2c3d5564a62e6ae5111741966c8319ca802361/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5d04bfa02cc2d23b497d1e90a0f927070043f6cbf303e738300532379a4b4e0f", size = 5288479, upload-time = "2026-04-01T14:46:01.141Z" },
+    { url = "https://files.pythonhosted.org/packages/49/62/5b0ed78fce87346be7a5cfcfaaad91f6a1f98c26f86bdbafa2066c647ef6/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0c838a5125cee37e68edec915651521191cef1e6aa336b855f495766e77a366e", size = 7032230, upload-time = "2026-04-01T14:46:03.874Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404, upload-time = "2026-04-01T14:46:06.33Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946, upload-time = "2026-04-01T14:46:11.734Z" },
+]
+
+[[package]]
+name = "platform-utils"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/35/1388d9d259b53c4359d79f85afb0cac9ac40efdd8dee360ae18c220d226d/platform_utils-1.6.2.tar.gz", hash = "sha256:649bce9741c2cc99ab8065dc677f16faeb039ed2904a602c89aded8da14cd2c9", size = 14938, upload-time = "2026-01-16T04:11:23.365Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/b0/005ec9008a0fd6c06e789cd8bd73b97b1aadae84b1dfc6ebd15b071ea71d/platform_utils-1.6.2-py3-none-any.whl", hash = "sha256:a040c646eb64152ab8598b6d4997eb857c49d32d0ca115f38920bd006befd195", size = 10200, upload-time = "2026-01-16T04:11:22.014Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "playsound3"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/93/39f2296a69fe2c70dcc9b9724147ffc9d7f676f67eb3cbad3baa725ae32d/playsound3-3.3.1.tar.gz", hash = "sha256:3f0eb87d5ff2061d07663c4b010b8e7d66c274344712b01d561a0a73447ef41d", size = 608340, upload-time = "2026-01-22T18:05:55.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/9d/8b97af915bd8a9e2b17b08bb9d62d45cce5c00a28a64b08324bb5895145b/playsound3-3.3.1-py3-none-any.whl", hash = "sha256:8e606115c3630762a7136579ceb25fbf725768a31f7d0bfc2883154d8c50205d", size = 9697, upload-time = "2026-01-22T18:05:53.783Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/08/f1ba952f1c8ae5581c70fa9c6da89f247b83e3dd8c09c035d5d7931fc23d/pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4", size = 2113146, upload-time = "2026-05-06T13:37:36.537Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5", size = 1949769, upload-time = "2026-05-06T13:37:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ba/bfb1d928fd5b49e1258935ff104ae356e9fd89384a55bf9f847e9193ad40/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb63e0198ca18aad131c089b9204c23079c3afa95487e561f4c522d519e55aba", size = 1974958, upload-time = "2026-05-06T13:37:28.611Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/74/76223bfb117b64af743c9b6670d1364516f5c0604f96b48f3272f6af6cc6/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f47286a97f0bc9b8859519809077b91b2cefe4ae47fcbf5e466a009c1c5d742b", size = 2042118, upload-time = "2026-05-06T13:36:55.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7b/848732968bc8f48f3187542f08358b9d842db564147b256669426ebb1652/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:905a0ed8ea6f2d61c1738835f99b699348d7857379083e5fc497fa0c967a407c", size = 2222876, upload-time = "2026-05-06T13:38:25.455Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2f/e90b63ee2e14bd8d3db8f705a6d75d64e6ee1b7c2c8833747ce706e1e0ce/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea793e075b70290d89d8142074262885d3f7da19634845135751bd6344f73b50", size = 2286703, upload-time = "2026-05-06T13:37:53.304Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/1e/acc4d70f88a0a277e4a1fa77ebb985ceabaf900430f875bf9338e11c9420/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395aebd9183f9d112f569aeb5b2214d1a10a33bec8456447f7fbdfa51d38d4cd", size = 2092042, upload-time = "2026-05-06T13:38:46.981Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/da/0a422b57bf8504102bf3c4ccea9c41bab5a5cee6a54650acf8faf67f5a24/pydantic_core-2.46.4-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b078afbc25f3a1436c7a1d2cd3e322497ee99615ba97c563566fdf46aff1ee01", size = 2117231, upload-time = "2026-05-06T13:39:23.146Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2a/2ac13c3af305843e23c5078c53d135656b3f05a2fd78cb7bbbb12e97b473/pydantic_core-2.46.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f747929cf940cddb5b3668a390056ddd5ba2e5010615ea2dcf4f9c4f3ab8791d", size = 2168388, upload-time = "2026-05-06T13:40:08.06Z" },
+    { url = "https://files.pythonhosted.org/packages/72/04/2beacf7e1607e93eefe4aed1b4709f079b905fb77530179d4f7c71745f22/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:daa27d92c36f24388fe3ad306b174781c747627f134452e4f128ea00ce1fe8c4", size = 2184769, upload-time = "2026-05-06T13:38:13.901Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/29/d2b9fd9f539133548eaf622c06a4ce176cb46ac59f32d0359c4abc0de047/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:19e51f073cd3df251856a8a4189fbdf1de4012c3ebacfb1884f94f1eb406079f", size = 2319312, upload-time = "2026-05-06T13:39:08.24Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/0f7a5b85fec6075bea96e3ef9187de38fccced0de92c1e7feda8d5cc7bb9/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c1747f85cee84c26985853c6f3d9bd3e75da5212912443fa111c113b9c246f39", size = 2361817, upload-time = "2026-05-06T13:38:43.2Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a4/73363fec545fd3ec025490bdda2743c56d0dd5b6266b1a53bbe9e4265375/pydantic_core-2.46.4-cp310-cp310-win32.whl", hash = "sha256:2f84c03c8607173d16b5a854ec68a2f9079ae03237a54fb506d13af47e1d018d", size = 1987085, upload-time = "2026-05-06T13:39:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/01/aa/62f082da2c91fac1c234bc9ee0066257ce83f0604abd72e4c9d5991f2d84/pydantic_core-2.46.4-cp310-cp310-win_amd64.whl", hash = "sha256:8358a950c8909158e3df31538a7e4edc2d7265a7c54b47f0864d9e5bae9dcebf", size = 2074311, upload-time = "2026-05-06T13:39:59.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyinstaller"
+version = "6.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/4d/ec706c3fcf39e26888c35b39615ff4d5865d184069666c47492cff1fbe50/pyinstaller-6.21.0.tar.gz", hash = "sha256:bb9fab705983e393a2d1cac77d6972513057ad800215fd861dc15ff5272e98fd", size = 4061519, upload-time = "2026-06-13T14:15:06.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/4a/53cf98bf66daed012dc9cd78c8203f19a675d696f2fc12afcf8c5049a0e0/pyinstaller-6.21.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:327d132389f37912609e01be62810cf96b5aa95b613903e4b8692e0d12fb0eda", size = 1052350, upload-time = "2026-06-13T14:13:55.88Z" },
+    { url = "https://files.pythonhosted.org/packages/30/83/b591295c352ef464c50b4c6ffff1c4f771d875c9e833f578d1b9f564f6b3/pyinstaller-6.21.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7071d4b094d5b40deeef5fa3d3b98a1b846087f7562b49209663d5f9281fe251", size = 748477, upload-time = "2026-06-13T14:14:00.327Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8f/88fff4e403873b1e22286911350e75ff00db014aa08e57045da9d4328993/pyinstaller-6.21.0-py3-none-manylinux2014_i686.whl", hash = "sha256:6b6374d652107dd4a2eeece903ff82bb4045bb5e1006c5a158a6dcdbefe84bf2", size = 760877, upload-time = "2026-06-13T14:14:04.836Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/13/f0e48fbdfd1d05d948157121cea8b1b823dcb89efe6934b71fdd8bdb3f0f/pyinstaller-6.21.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:4e3108b3f02384560da70e39b8bf22b0ad597d02bd68a40d76ea91c1cfa00cad", size = 759194, upload-time = "2026-06-13T14:14:10.61Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d5/ea7878cf9924ed30d946d8288777424e6d069d94f5bde56b4d0890069664/pyinstaller-6.21.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:697532279f535ad572bda613db4f821540e235c7854ca6da4d3bf0373f4415ee", size = 754979, upload-time = "2026-06-13T14:14:15.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/09/51b8905714b733bac66dbc041a7821372d70d888d273ae474c4037d4202d/pyinstaller-6.21.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:605169523a6b5ace39f13dfbff21add9f2bc43df99c7daf9394fefb2c45e8b6f", size = 754812, upload-time = "2026-06-13T14:14:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/43/d77779439d8c6c2e27a77bcfbd1d5cc0f568ebb611bb472b11af81b5f177/pyinstaller-6.21.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:5fa56746c1e76f93634d018502301378a2d0c382553d37d8c3c34ff436c12dd1", size = 753887, upload-time = "2026-06-13T14:14:25.268Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/c22df1f6837784ac349057ba693f08e7b1ca7a0e06f9c33c63bc6280007b/pyinstaller-6.21.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:42395ec76df8e8120c36b13339d9db8cab83e316a12839ee303cc00fc941bb74", size = 753779, upload-time = "2026-06-13T14:14:29.445Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/76/1ce8a27ce62ba8cf3a87c9ce6d575610f4e55d7cb0123e7512fc3f4b921a/pyinstaller-6.21.0-py3-none-win32.whl", hash = "sha256:c6b28d30d8fd99ce162ff3aab5013ed44dbfb747566b1f01b9bed7964d7c14e9", size = 1336462, upload-time = "2026-06-13T14:14:35.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fa/ca1d7e5257dd8566a9dfc0dfb02f8a8075eeb53d4b2d3c579f1276759042/pyinstaller-6.21.0-py3-none-win_amd64.whl", hash = "sha256:7fae06c494ce0ebfe6bd3055c0e409def884f63af2e3705d06bd431ad9237fc7", size = 1397487, upload-time = "2026-06-13T14:14:42.328Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/75/21b51523ce8d96629b71311775a0a65f5f5a872124ab0de33e5c848f8bff/pyinstaller-6.21.0-py3-none-win_arm64.whl", hash = "sha256:f13c95c9c03fb567217135919f93815c305813126780b0ed6e0123cb8acaf025", size = 1346094, upload-time = "2026-06-13T14:14:48.914Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/5b/c9fe0db5e83ee1c39b2258fa21d23b15e1a60786b6c5990ee5074ead8bb6/pyinstaller_hooks_contrib-2026.6.tar.gz", hash = "sha256:bef5002c32f4f50bd55b005da12cff64eca8783e7eaf86a06a62410164bab725", size = 173354, upload-time = "2026-06-08T22:37:16.152Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/31/f2d7343d8ed5f7c4678377886f6ce533e6eaaa131b252ce950114c2a7efa/pyinstaller_hooks_contrib-2026.6-py3-none-any.whl", hash = "sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3", size = 457159, upload-time = "2026-06-08T22:37:14.722Z" },
+]
+
+[[package]]
+name = "pyobjc"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-accessibility", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-accounts", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-addressbook" },
+    { name = "pyobjc-framework-adservices", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-adsupport", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-applescriptkit" },
+    { name = "pyobjc-framework-applescriptobjc", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-applicationservices" },
+    { name = "pyobjc-framework-apptrackingtransparency", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-arkit", marker = "platform_release >= '25.0'" },
+    { name = "pyobjc-framework-audiovideobridging", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-authenticationservices", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-automaticassessmentconfiguration", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-automator" },
+    { name = "pyobjc-framework-avfoundation", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-avkit", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-avrouting", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-backgroundassets", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-browserenginekit", marker = "platform_release >= '23.4'" },
+    { name = "pyobjc-framework-businesschat", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-calendarstore", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-callkit", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-carbon" },
+    { name = "pyobjc-framework-cfnetwork" },
+    { name = "pyobjc-framework-cinematic", marker = "platform_release >= '23.0'" },
+    { name = "pyobjc-framework-classkit", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-cloudkit", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-collaboration", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-colorsync", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-compositorservices", marker = "platform_release >= '25.0'" },
+    { name = "pyobjc-framework-contacts", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-contactsui", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-coreaudio" },
+    { name = "pyobjc-framework-coreaudiokit" },
+    { name = "pyobjc-framework-corebluetooth", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-coredata" },
+    { name = "pyobjc-framework-corehaptics", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-corelocation", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-coremedia", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-coremediaio", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-coremidi" },
+    { name = "pyobjc-framework-coreml", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-coremotion", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-coreservices" },
+    { name = "pyobjc-framework-corespotlight", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-coretext" },
+    { name = "pyobjc-framework-corewlan", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-cryptotokenkit", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-datadetection", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-devicecheck", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-devicediscoveryextension", marker = "platform_release >= '24.0'" },
+    { name = "pyobjc-framework-dictionaryservices", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-discrecording" },
+    { name = "pyobjc-framework-discrecordingui" },
+    { name = "pyobjc-framework-diskarbitration" },
+    { name = "pyobjc-framework-dvdplayback" },
+    { name = "pyobjc-framework-eventkit", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-exceptionhandling" },
+    { name = "pyobjc-framework-executionpolicy", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-extensionkit", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-externalaccessory", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-fileprovider", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-fileproviderui", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-findersync", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-fsevents", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-fskit", marker = "platform_release >= '24.4'" },
+    { name = "pyobjc-framework-gamecenter", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-gamecontroller", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-gamekit", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-gameplaykit", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-gamesave", marker = "platform_release >= '25.0'" },
+    { name = "pyobjc-framework-healthkit", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-imagecapturecore", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-inputmethodkit", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-installerplugins" },
+    { name = "pyobjc-framework-instantmessage", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-intents", marker = "platform_release >= '16.0'" },
+    { name = "pyobjc-framework-intentsui", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-iobluetooth" },
+    { name = "pyobjc-framework-iobluetoothui" },
+    { name = "pyobjc-framework-iosurface", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-ituneslibrary", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-kernelmanagement", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-latentsemanticmapping" },
+    { name = "pyobjc-framework-launchservices" },
+    { name = "pyobjc-framework-libdispatch", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-libxpc", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-linkpresentation", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-localauthentication", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-localauthenticationembeddedui", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-mailkit", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-mapkit", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-mediaaccessibility", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-mediaextension", marker = "platform_release >= '24.0'" },
+    { name = "pyobjc-framework-medialibrary", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-mediaplayer", marker = "platform_release >= '16.0'" },
+    { name = "pyobjc-framework-mediatoolbox", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-metal", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-metalfx", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-metalkit", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-metalperformanceshaders", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-metalperformanceshadersgraph", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-metrickit", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-mlcompute", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-modelio", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-multipeerconnectivity", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-naturallanguage", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-netfs", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-network", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-networkextension", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-notificationcenter", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-opendirectory", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-osakit" },
+    { name = "pyobjc-framework-oslog", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-passkit", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-pencilkit", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-phase", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-photos", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-photosui", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-preferencepanes" },
+    { name = "pyobjc-framework-pushkit", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-framework-quicklookthumbnailing", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-replaykit", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-safariservices", marker = "platform_release >= '16.0'" },
+    { name = "pyobjc-framework-safetykit", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-scenekit", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-screencapturekit", marker = "platform_release >= '21.4'" },
+    { name = "pyobjc-framework-screensaver" },
+    { name = "pyobjc-framework-screentime", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-scriptingbridge", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-searchkit" },
+    { name = "pyobjc-framework-security" },
+    { name = "pyobjc-framework-securityfoundation" },
+    { name = "pyobjc-framework-securityinterface" },
+    { name = "pyobjc-framework-securityui", marker = "platform_release >= '24.4'" },
+    { name = "pyobjc-framework-sensitivecontentanalysis", marker = "platform_release >= '23.0'" },
+    { name = "pyobjc-framework-servicemanagement", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-sharedwithyou", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-sharedwithyoucore", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-shazamkit", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-social", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-soundanalysis", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-speech", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-spritekit", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-storekit", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-symbols", marker = "platform_release >= '23.0'" },
+    { name = "pyobjc-framework-syncservices" },
+    { name = "pyobjc-framework-systemconfiguration" },
+    { name = "pyobjc-framework-systemextensions", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-threadnetwork", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-uniformtypeidentifiers", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-usernotifications", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-usernotificationsui", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-videosubscriberaccount", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-videotoolbox", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-virtualization", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-vision", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-webkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/09/68336c2ed662cecc8dc71e3bdcde2666430f3eb981cbd86661e7aa260cab/pyobjc-12.2.tar.gz", hash = "sha256:7074dcb0999e611e456b12cf94b7289cf6327094359b2c21c5ae593048b909bf", size = 11841, upload-time = "2026-05-30T12:28:53.751Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/25/f988de6a2028550fbd79f386938c4d99ac0f6b7652ad212cd8b74654924c/pyobjc-12.2-py3-none-any.whl", hash = "sha256:f3b0d4cdb7d0be242a37ff27c9f0b3ef182fe8ebdbac6ae0c40ef87539fe7d77", size = 4225, upload-time = "2026-05-30T09:44:22.344Z" },
+]
+
+[[package]]
+name = "pyobjc-core"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/e8/a6cc12669211e7c9b29e8f26bf2159e67c7a73555dc229018abf46d8167a/pyobjc_core-12.2.tar.gz", hash = "sha256:51d7de4cfa32f508c6a7aac31f131b12d5e196a8dcf588e6e8d7e6337224f66d", size = 1062064, upload-time = "2026-05-30T12:29:55.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/cd/2e8cc2d648648186aab7e3eea76d89ad02f10eb752f3846c1aaba2c93e22/pyobjc_core-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:45fffb2b8dc0ae4480386429bd1e7fa8aabeb2eec81816d6971b33936dfcfff8", size = 6478736, upload-time = "2026-05-30T09:47:42.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/dc/b68d8bd769865d509fbcab81f5fae6497bd4e33409a44925e5d5e7c68d72/pyobjc_core-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:17b4e003af384d3086c2f39989a0b282c5755dd1066f331cf7c9fa65febe22ce", size = 6475918, upload-time = "2026-05-30T10:00:44.669Z" },
+    { url = "https://files.pythonhosted.org/packages/24/be/4771f4fd786f0e1a2bd6d8931a72a5f3929b7bb1b28a1fe6ca8a08371c55/pyobjc_core-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7677ed758a367bbbb5589d6f5276fb360a45c89168276c26162f61840b0fa03d", size = 6421145, upload-time = "2026-05-30T10:17:41.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ed/6e62d038992bc7ef9091d95ec97c3c221686fe52a993a6501e961c757613/pyobjc_core-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9287c7c46d6ae8676b4c6c0389a8f4b5381f42ae53a47151900c08b157e5a992", size = 6428611, upload-time = "2026-05-30T10:21:33.83Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0b/d492110202f4d1050a5e590620ebd1e730cf89f9880a26cf18205e0f5800/pyobjc_core-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:515ecf2afe168301feb66a7230d700584ce2e4b8a0ac178e19450b8898384139", size = 6677992, upload-time = "2026-05-30T10:44:13.039Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b2/ecfbd0c80e7688ed6f3db23414758443c69c3a9d318f2036e26530ede955/pyobjc_core-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a51352e478785cd7fce1604b9902125a286139caea0759cb340e59d75b594992", size = 6421372, upload-time = "2026-05-30T10:47:27.907Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/89/ecd5cb62573fba9a95f8bdb838a9860a360907104a0724af6611d3b20512/pyobjc_core-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3137b2d14f9f2154fb5b1c092c38d15e164f68ab190c18335d76e4e7e1583f79", size = 6676789, upload-time = "2026-05-30T10:59:33.811Z" },
+    { url = "https://files.pythonhosted.org/packages/74/24/5091d156b19df0f657127f42b08eada11c9b9cc5df49fedb91bb354d9821/pyobjc_core-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:1e4216f2ec962dc13cf7f31b9bc3a7190337a0f401e7dc9de6b2d8c08b9dbb7a", size = 6476112, upload-time = "2026-05-30T11:21:46.914Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e2/ee91ea8a0ad28e759f351ed8654027c34fc62ad5e207672522025a6a3fc2/pyobjc_core-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ac952bac8057dd0b97ee7b311c39f97cad7430b7cfbd67ca0a30135a7d17d2ab", size = 6718365, upload-time = "2026-05-30T11:51:47.35Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-accessibility"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/31/ddc59bea6388a37461e919f25d2120bd93df0b30f552c606fab2804c52c3/pyobjc_framework_accessibility-12.2.tar.gz", hash = "sha256:86f82cc21db65c73c72ae93b7536381f1e12a1c89d4c554a216217dacdf60bb3", size = 34357, upload-time = "2026-05-30T12:29:58.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/88/f24d797b4f5c75288da0f2d1353e6e0c683524a3ca011df64bb913f77587/pyobjc_framework_accessibility-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bcb73e79f4e2740341e5bdb7b5112826fb9bfb2bd9e11c4c2f59f9bf94e7453c", size = 11516, upload-time = "2026-05-30T11:51:49.973Z" },
+    { url = "https://files.pythonhosted.org/packages/41/56/4f3c3ef77499d16cf1a2218d5a56a4bc2cdcd462b8005d299b10a38d3519/pyobjc_framework_accessibility-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ca321d2d3c501a26cee32a3659167d5cf788e9f08fddf505a1ab80540b2223b9", size = 11516, upload-time = "2026-05-30T11:51:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/45/6c/dc7cf2eca4239e69942d68ab16b5708707975548a197f081c8fdc3445262/pyobjc_framework_accessibility-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4c2e2965bf539e356ccb92aa3ea4e9fc764629e5fa7d5a9c52387970ee021038", size = 11545, upload-time = "2026-05-30T11:51:53.936Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/1d/d13365b48fc989b5217ef94facec719f7c7ab2878e573462cf822095cb3b/pyobjc_framework_accessibility-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e60d910261d018770722ad0987291e94229e09aef0e919073c87a30cf677686d", size = 11564, upload-time = "2026-05-30T11:51:55.545Z" },
+    { url = "https://files.pythonhosted.org/packages/28/22/2f3ebe592655f5106a072cf1f1fe331f7c9ba06b24ac8e3dcdc9e9294d03/pyobjc_framework_accessibility-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:535a3e2ccb36e707dd72ed54f7f1772ef41526cebe6fe52acc081d45a10ede15", size = 11732, upload-time = "2026-05-30T11:51:57.41Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/68/898391808390d55e38d97ba9bf975e5cd9f64692c051d290ee8f366269cf/pyobjc_framework_accessibility-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a6b1bcadaee86389775288a2f44658fa6a5b150ecb8bd3ff694ed9a0c2a62e7d", size = 11626, upload-time = "2026-05-30T11:51:59.164Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/1e/070f0260e49efdf2e96b805efc6a5b03f7f0e7d85f9f07aaa6c8660c7869/pyobjc_framework_accessibility-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3c52e73046cc32830ddc494d10ce76292c13f8f16b1e8dd96af3e9a972755e23", size = 11809, upload-time = "2026-05-30T11:52:01.081Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b2/8fdcf94b5f25b6b8410ab3ae5106b6edadbc6131ce133cc8be76f4f7a8b3/pyobjc_framework_accessibility-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:4a998d5fa8bfa43de83554187cee3ef3db2c2b144d5799eac5852266c1d1fa7c", size = 11615, upload-time = "2026-05-30T11:52:02.811Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/3d/a4908231fbf37ff60cafd7c66cc080ba1c3265090810e2a416ecf5dc8444/pyobjc_framework_accessibility-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:76495fbe29ad10051cfd66d1f9e54283a82b22e70b0a25ee6481f8f7e0de5b9d", size = 11805, upload-time = "2026-05-30T11:52:04.54Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-accounts"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/ec/aea64ed95dda48f2c1a049c638be39822f731e79ef9fb4202dd2b3d87b86/pyobjc_framework_accounts-12.2.tar.gz", hash = "sha256:823b61e3ed964efde365e6c83b605692f72cb7f7e0782dafea674f2de8e3f8ed", size = 16208, upload-time = "2026-05-30T12:30:00.949Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/fa/61661645bdc59e6aa9c92791731d688c76b84260362849f8c768e48558ea/pyobjc_framework_accounts-12.2-py2.py3-none-any.whl", hash = "sha256:a1638b7758e6371f59e7ea9f912922530062ce9640a0f1d1e66a0702bff7f8e3", size = 5104, upload-time = "2026-05-30T11:52:05.957Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-addressbook"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/03/76bd426954723343854c2f4da82bbcd61048eccce31c00381dbfb7677c85/pyobjc_framework_addressbook-12.2.tar.gz", hash = "sha256:5f763983c1c32e70f7b742e35a025530be4bf6742ff4ac98f71ab0bfeb5cf9bd", size = 47681, upload-time = "2026-05-30T12:30:04.791Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/00/0397f91c536d45640520906e7cf5161876a72bef015f9183a7ded444c0e2/pyobjc_framework_addressbook-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:267a4453bbe917791837ec8bdc6ba221a115c796cc0cc28a8b3be45542f2b8bf", size = 12797, upload-time = "2026-05-30T11:52:07.86Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d8/4dcdd8940d341e609f46b9d7cb589654cd385a6a653fed42b42174de0c8f/pyobjc_framework_addressbook-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:96b01e8119559662cd81ab22442d596361a90fce8194c174b793522c545fa05c", size = 12796, upload-time = "2026-05-30T11:52:10.04Z" },
+    { url = "https://files.pythonhosted.org/packages/17/f0/0eefbd03448706f71580ea82254cb72a0aff70d6df6fc49e2e6ad915fa56/pyobjc_framework_addressbook-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9cdafcbad3d9e145a32390dd026bf27da3be1aadf337c3d56c08ee4a791755a6", size = 12805, upload-time = "2026-05-30T11:52:11.851Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bc/d3afc72e56b2e49580ada60dff250669f2b80ee1e2c59bdd3e577f32d0cd/pyobjc_framework_addressbook-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:37dbd5a712c2ff71ec80cc5a86d96c98b1d5e26eb2c7bc4d251f84eb1a3c8893", size = 12826, upload-time = "2026-05-30T11:52:13.667Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a6/9d0a9433e3b76ee9e6d728d463377d1833389450315a6122342e4d42c5c1/pyobjc_framework_addressbook-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:899b19c7c2c4a8ee7020a20022a8c64daf86dccd163da03a41bbd585565d18ed", size = 12981, upload-time = "2026-05-30T11:52:15.771Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/2d/4bbd5dc76233c3c1ad4529536b3c47fd7c20faaa88a915f509baaea1050c/pyobjc_framework_addressbook-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6ea77ba8de1ffa9a05836081bd36ec3828cadc0215f1fcd64446b80228e69775", size = 12886, upload-time = "2026-05-30T11:52:17.742Z" },
+    { url = "https://files.pythonhosted.org/packages/95/79/f76414b5643f3828fa8e03c6f2cb91307c27785f930a02a37ca0299e522a/pyobjc_framework_addressbook-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:76839a5441cdbecf3b0984d83385a80e926f38234f98063af297b646fe9dc658", size = 13043, upload-time = "2026-05-30T11:52:19.566Z" },
+    { url = "https://files.pythonhosted.org/packages/95/dc/9d748ad57fde50831b59704c13f82cf658869d6f8de428455f127a49324b/pyobjc_framework_addressbook-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:155f285e181a8b4c72dcc559a044c8a2c2af5271ab5926356ad67daa5a0600ca", size = 12877, upload-time = "2026-05-30T11:52:21.45Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/20/c03dc03da793fbdbf3bf381979c1301b66642cdc43a42ac768715283c2f1/pyobjc_framework_addressbook-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b0b3c2e00500d4ee3ebb62df367473cc8c92b1ece7b4ad65384e1ac56d6a7c68", size = 13042, upload-time = "2026-05-30T11:52:23.251Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-adservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/05/fb43d284efe7e48b43abe2507f79b91a4c9ebce4f76c552fc228b647c0b9/pyobjc_framework_adservices-12.2.tar.gz", hash = "sha256:77a3cf0acdf5e83c29c26be60a63e35a31ad5076ac60188a52268fe53de7cee0", size = 12249, upload-time = "2026-05-30T12:30:06.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/2b/230ad0f52e7f960a560afbae80dacdfc831a01a3507989e1ee41755ab793/pyobjc_framework_adservices-12.2-py2.py3-none-any.whl", hash = "sha256:7c1b1f78689f66fa724c23fd20dac56e8ea3190e868d9859d08294a58e26cb33", size = 3485, upload-time = "2026-05-30T11:52:24.532Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-adsupport"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/6d/6041af76d08da1ddae42804dfff3b5fb0fb27c2da8eb7a1a04ece4532e46/pyobjc_framework_adsupport-12.2.tar.gz", hash = "sha256:fe8e730c102a6579fe905b20e497423a080fd1f6a75eabf7356d2394467f64a4", size = 12112, upload-time = "2026-05-30T12:30:08.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/b7/956f2d841a8709ab7cae6726dcd953a54650768f9b78cf9821fb732c6cca/pyobjc_framework_adsupport-12.2-py2.py3-none-any.whl", hash = "sha256:39ca7e3c336c32c5d9d5780eba7606f4d53034bb53bc7b55c8a5a2e430ad7c66", size = 3402, upload-time = "2026-05-30T11:52:25.922Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-applescriptkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/e8/1af0305da68a6923d269806f6f60b900e473b3ac03279a8614d71e224592/pyobjc_framework_applescriptkit-12.2.tar.gz", hash = "sha256:1e1f91966b42f902d954a570a2aab8a4e24af465833525863e30c8a5b47ee4f1", size = 11690, upload-time = "2026-05-30T12:30:09.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/2b/3abd0d61208205b5617590e6c9cc35f744a41a2bdb81b5e18eba7810b9ae/pyobjc_framework_applescriptkit-12.2-py2.py3-none-any.whl", hash = "sha256:4b2a2f02e159c3c13834c3a605c1445563592f41d57ef6cdca2bd39e6409270d", size = 4352, upload-time = "2026-05-30T11:52:27.452Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-applescriptobjc"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/bc/4bcbb2fdae7a4526432619ec9a15fb7ee8ef22358be422e7b3c23c280f6f/pyobjc_framework_applescriptobjc-12.2.tar.gz", hash = "sha256:118abccae98c0af67e7c850058e4651748256eba52da382a2cd58e0e7c74418e", size = 11787, upload-time = "2026-05-30T12:30:11.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/a8/bb375c57509a1553e5ee51758caad3f946a98180577680b33a509f65bd9f/pyobjc_framework_applescriptobjc-12.2-py2.py3-none-any.whl", hash = "sha256:0a3019b16959dd8bef9fb581894901e89e027fa0b8b21b8515deda13a3cd9b34", size = 4452, upload-time = "2026-05-30T11:52:28.996Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-applicationservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coretext" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/ab/1776ac62687cb3d81e59517ca55970f26efa5a96bbf3ebcea57afcdd6b06/pyobjc_framework_applicationservices-12.2.tar.gz", hash = "sha256:4f6c4027405f709872e5b098f3cd86961bdf262fb80679a548725a02171bb0cf", size = 109325, upload-time = "2026-05-30T12:30:18.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/f2/9ff3266166a9e0ce61292c44ea18ab80010ea3448ad673458af6b3c3b6b0/pyobjc_framework_applicationservices-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:07433804aa59d2a870cf62e6556cb63bef6ef9dade51dbaef3580a1a0e276460", size = 32691, upload-time = "2026-05-30T11:52:32.183Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f7/a0e49ff167980f441c4511856c6bada593cf234ea4f1fc2dd6071baa9c76/pyobjc_framework_applicationservices-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9eaa9fa92d4fa35b08c7612af321615cccdcf0dec26b04a92521153730144f5e", size = 32688, upload-time = "2026-05-30T11:52:35.471Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e4/0c7c5a48f88ab7510365559facf060f7c059dd4d5e39571d07d96a2b84a8/pyobjc_framework_applicationservices-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:36a03ae7168657379e3ad96397f3ebb15e6c617b96901a919c7610ce2de0007a", size = 32736, upload-time = "2026-05-30T11:52:38.386Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/28/8c85ef2dff09fb4c6adf2161bf1d32ff81dca497863682ba46107e38bbb9/pyobjc_framework_applicationservices-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7119c75ad2c0e21b0bd44865641944e691e80abce0d5805fa344730238b16b15", size = 32754, upload-time = "2026-05-30T11:52:41.299Z" },
+    { url = "https://files.pythonhosted.org/packages/61/ee/4be28e61319055092d3a963514c2fb4daba86785d4044f073a4135273bb0/pyobjc_framework_applicationservices-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0492c478b175005f38c887523f895382a9ed47c0810ab786c6712d3fda245832", size = 33017, upload-time = "2026-05-30T11:52:44.534Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/60/43c4e2697971bb9ec7766d6fe00861ef2055f3fa7d733c407676fcd5cbac/pyobjc_framework_applicationservices-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d157ace1d768665f180cf9711fb31ddb29006e5df545e7e3ebf2be5054c6170d", size = 32896, upload-time = "2026-05-30T11:52:47.456Z" },
+    { url = "https://files.pythonhosted.org/packages/03/12/4f0662012b77b9c15afb6c52fa92e069d2a6793dcfcd9864bfef4c7d3c4b/pyobjc_framework_applicationservices-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9be6f6866f532fca35f7d62f27f43df6a95c8b195030d44b9d68ed63ecb1e1f0", size = 33135, upload-time = "2026-05-30T11:52:50.587Z" },
+    { url = "https://files.pythonhosted.org/packages/36/9d/91c93ad58e6b52035da745c2ddcbb32018a03091d9f139e077f53089a002/pyobjc_framework_applicationservices-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:01afa4ef373edc58cd3fa55f5fe5d7db5dda22b8e6ff65f743a509180149dab7", size = 32888, upload-time = "2026-05-30T11:52:53.487Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f5/c25b153ea0be05a749915bc45b4f9d85e7d84d2fbafc81efe68cae29540e/pyobjc_framework_applicationservices-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:8e14e97fc6bbedc95479f7b408f00e3b4aaaafafc23f9e2a955210beca15b474", size = 33128, upload-time = "2026-05-30T11:52:56.477Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-apptrackingtransparency"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/08/28b67c30aae6b1d870aac62ef63e7f518f3507a5c8c34378ca2cd89d2f7d/pyobjc_framework_apptrackingtransparency-12.2.tar.gz", hash = "sha256:7887b9c574c8a4edafbf8e34649a77ea91aab93dcf92b22e272ab01341d9e404", size = 12778, upload-time = "2026-05-30T12:30:20.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/65/1a2b950fb8c7c98ee6ab894e5466094039846ff10986ceb04d4c29ce3118/pyobjc_framework_apptrackingtransparency-12.2-py2.py3-none-any.whl", hash = "sha256:f0b51c30dc8c32882aa88e891ec13e52a0b339a3bb52ab7eed162a9640b76b4a", size = 3905, upload-time = "2026-05-30T11:52:57.929Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-arkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/27/94cce926f3a8d95050bcfa14b1fe4e6d45ff86b93f3aa53f336a9eb3e5b6/pyobjc_framework_arkit-12.2.tar.gz", hash = "sha256:48f7241f07c03a5caad05b8998ee23210f9fd2395be69b635fdcd41d11329cf3", size = 40141, upload-time = "2026-05-30T12:30:23.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/cf/7fc4248af3c7ef766137ffa831dbe999efeaef48df108e62d35099aa6b5e/pyobjc_framework_arkit-12.2-py2.py3-none-any.whl", hash = "sha256:6a8065f5e49c6efddfa9250f14845b5a5fc0cada5444a87d1f96fcf72ac71f19", size = 8305, upload-time = "2026-05-30T11:52:59.499Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-audiovideobridging"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/cb/4e941fbd2e199b92accbee50839a7841dee74d63d6b199c0d37e7df0e40c/pyobjc_framework_audiovideobridging-12.2.tar.gz", hash = "sha256:7019abd29ab7b232618a5ab7135670e6f1e15744167b8d4f841133893914ebf5", size = 44219, upload-time = "2026-05-30T12:30:27.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/5a/d6629c2d74b57836f59ea86591850f0512e683187cf29ed18b2822531f41/pyobjc_framework_audiovideobridging-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e5e84cc43c34ba843011834c2bee9a2d48f21a255bda656bc9059ce88892fce2", size = 11045, upload-time = "2026-05-30T11:53:01.432Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a8/927f13bfd32d8c52ae6d9526c4f71f1a3d3ffab3ec8c8a697c3092728659/pyobjc_framework_audiovideobridging-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:68f0a786474682fd4e203904dc364413a919e19a9ce8ca1e053a5a536288a298", size = 11049, upload-time = "2026-05-30T11:53:03.34Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/82/41160cab1bf637d7b5f7a048dd79d78a72971b2be7556d9071cbac47e51c/pyobjc_framework_audiovideobridging-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7d97571f76a0da68a30b2cf717b4b200d26dfcbad73a040c3c86b4b0ef341c3a", size = 11060, upload-time = "2026-05-30T11:53:05.296Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/d0/146911872702f1e2e25fd3274d29e796ace042d863f076947344158ffbca/pyobjc_framework_audiovideobridging-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7b07278a182e177f0e6417d8252df6ad6b885e17d6b7d09965d35510983bf9c6", size = 11074, upload-time = "2026-05-30T11:53:07.266Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/48/3f73eba1e79e0eea83fe8504f64fe62688178c51ea6ec4b1f90aabeeaf3c/pyobjc_framework_audiovideobridging-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:46e962bda54b81fa0e84bd58ccd0284ee680689891c04b869542bdcbb7c3870e", size = 11249, upload-time = "2026-05-30T11:53:09.207Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/75/2aa2210ee0892a2076c58918f9ee53f5c9f62fd5f9b70b4a2e5a56384a1a/pyobjc_framework_audiovideobridging-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d439e659e732b5da958543a2979a7c518374aa2fa2009dccc5bc823043e0f647", size = 11132, upload-time = "2026-05-30T11:53:10.755Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/11/5ce0c697668f3df9aa56c748180e52e0cf93c63cac9622f981751e882ed9/pyobjc_framework_audiovideobridging-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f11f209a1fe86c82ffe0e9dcb5ac22a1c1ccc5ea1133e2dbd43d93218969b4a3", size = 11311, upload-time = "2026-05-30T11:53:12.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/f1e8ec87cfcded57e1ad86d2a6e369cb39ba5bcb64878813dbf2acda9d0b/pyobjc_framework_audiovideobridging-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:98986494aee8c8e70b92757fd3e159ca1a9bbe049062a481ff11bd60ec6ee0b0", size = 11131, upload-time = "2026-05-30T11:53:14.193Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/8cd87e9f4b74cf52332269dca22bd34c9db94ec50c6f1f240eef43ace4eb/pyobjc_framework_audiovideobridging-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b85588556c9987e64f458eb7beb99773f7b854a804ffe025c492f8eb04f996a6", size = 11309, upload-time = "2026-05-30T11:53:15.883Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-authenticationservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/a6/973aca6e96097cf2121027b09720d6e564d381c8f024ae0ebb67939d184b/pyobjc_framework_authenticationservices-12.2.tar.gz", hash = "sha256:c99c11082d5ac6c454d729142709552b10e385d99e34d8e631bedca1886c8b78", size = 75719, upload-time = "2026-05-30T12:30:32.521Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/5d/b675539405d4a0b645fb2d31fe334fefb48c20ae6fa3454587f8b2b85768/pyobjc_framework_authenticationservices-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:fcd4f30529ff85696c80321edb13a73d8e9323527fe935aef89a6b9aa99bb6dd", size = 21257, upload-time = "2026-05-30T11:53:18.174Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/cb/ab5f68aa6c9473a28ac015d0e54e5fbd82fd465bc04fcabd3e3da7a9168b/pyobjc_framework_authenticationservices-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4d2efe165b7cc0da60a28d4e1e1acce6913ccb1547a03a1da30027f64e6bd347", size = 21261, upload-time = "2026-05-30T11:53:20.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c9/6f1a312a3d5705ae3bd20660b19b1fb1fa8e8b8bd80d5df1c6e6f7fb7df1/pyobjc_framework_authenticationservices-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:011e44ad3a42e3f27381f733931677106189c3979841ff8f2b097b1fc1ab6cf1", size = 21360, upload-time = "2026-05-30T11:53:23.218Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ef/4cd4e3648d0187aa06de7146eb7597a2ace07fe5007dab0d99d5565c1175/pyobjc_framework_authenticationservices-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:98e3b27b9033bb21e12efe89700d0d4cc1b72a90a98ded4d19c3af7edcf8eb50", size = 21376, upload-time = "2026-05-30T11:53:25.564Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ba/b1b41b65dcd3ee357fc3716e5f241ead2da57c9a8984b6a7b8c71f160d3e/pyobjc_framework_authenticationservices-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0a0e966a24d0c1b9a8c6c94751c05e2cd4f4a47a06ec53822aa626677f52959b", size = 21620, upload-time = "2026-05-30T11:53:27.891Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/95/bfec54f879d12fb78a035923f9d26e08d7d16fd03a8f3c9d2ca56223525b/pyobjc_framework_authenticationservices-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:62b4fd6303ff3476637d006b4dfef0814f6e163693901f6e66b4d2102f9febf7", size = 21377, upload-time = "2026-05-30T11:53:30.272Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e5/f52075b41a5e89fe9b5b472ce0d22975081ee3b6ccd141ff9f6394157864/pyobjc_framework_authenticationservices-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b9efe881067d2201fbaae49fcf8df6c032e571f43921c262719f2c37c03b9d63", size = 21651, upload-time = "2026-05-30T11:53:32.539Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/09/623d86fa7a7cafda9b441e2fe1660b431172fc7a209f7bc0992f36737f2e/pyobjc_framework_authenticationservices-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d081e3b816db301582cb516a252ac83ec0c686ea00b5011c12e42d73fa871dd5", size = 21376, upload-time = "2026-05-30T11:53:35.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d4/16086f609041d5894450f2cbd64521439a16608b2d063cf368afda2537f8/pyobjc_framework_authenticationservices-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:bab948aaec62be6351712c32c56647e678add6313d07c7cac3277c222ead5e65", size = 21659, upload-time = "2026-05-30T11:53:37.524Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-automaticassessmentconfiguration"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/6c/1bb82a3487454624071fe1ba5d75e005dfd82770d1472a1cbb78e4508316/pyobjc_framework_automaticassessmentconfiguration-12.2.tar.gz", hash = "sha256:dbd96b6085cc9da3f5115d418b2e052a5807a8964e49422c0d7bf7196499f78c", size = 24753, upload-time = "2026-05-30T12:30:34.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/8f/7e4220e0e0d0ca90ae780afaca1df2ef9a061a5a01bdc02c69bfab6dd918/pyobjc_framework_automaticassessmentconfiguration-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5b2b2a2f5dcb3d1158515eb8a91dab8feb323c674d77676a2554e80ef7285ffe", size = 9345, upload-time = "2026-05-30T11:53:39.289Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e0/22b224c9ed1648336f8256fd9c59d150c65d284dbbc773a8e42a774a6a29/pyobjc_framework_automaticassessmentconfiguration-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c5b9d2490ee6849f4a92db6d2ca4a79a7a1ebbf8050287bd854e524982300b85", size = 9344, upload-time = "2026-05-30T11:53:40.982Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3b/0c5344819de9ef7267fff2c773649b5d3c988207edcb74cc4399795dac3b/pyobjc_framework_automaticassessmentconfiguration-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:79076241d12df1c60d52ff9ef554f201eb010ab3d9d244ea5d015b628ef2b735", size = 9358, upload-time = "2026-05-30T11:53:42.562Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d9/7b56f64006c83a65b38e7b58d0a2d3d499f8633d066617c5c0e1ac338970/pyobjc_framework_automaticassessmentconfiguration-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a045df9bf1224d30727db4af8ceabc2f227356e494e93db69b4abc058b4e4edf", size = 9368, upload-time = "2026-05-30T11:53:44.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/82/1846574b7a414d29f0d81344be71a25f4d18ec5e02ad1fcf1db7c2af68c4/pyobjc_framework_automaticassessmentconfiguration-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:052e81f7a83ddb45ce5c4aeb01dc57f3cc42a5496e6117eb4174d195a2c45752", size = 9522, upload-time = "2026-05-30T11:53:45.772Z" },
+    { url = "https://files.pythonhosted.org/packages/78/80/05090a15011ad969ac8ee5565a77980b4cc35dfdfa8bd69b0ac714ffd4f2/pyobjc_framework_automaticassessmentconfiguration-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:3157826b9a7325433635cec279724c995f93dc09a64a46acc7ec26b25b9cd7c4", size = 9418, upload-time = "2026-05-30T11:53:47.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/bb/c84d56a921110a5f1bc2ae6d09af79eabdead30b1992a86f683a9c6f12d9/pyobjc_framework_automaticassessmentconfiguration-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:c9c5f31eb76405d74e0cdac56d8a6bc1cf2785a3a1121c91e49e852de7bbbe45", size = 9568, upload-time = "2026-05-30T11:53:48.919Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/11/dc4e0ff6a968e28354f1d5267e60b4ddd9026e9feb2f86ed9ad113d1e525/pyobjc_framework_automaticassessmentconfiguration-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d7c8bd3537ebe74153c9d9eb1d883be44788d1116757265b7108e3dbaf48b19b", size = 9425, upload-time = "2026-05-30T11:53:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ce/4d931993b0dafcc776d685a5566eafc8111684c9d3762cd01d420f7a23f9/pyobjc_framework_automaticassessmentconfiguration-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:793954d0a7b2d28fd21c509a897dbd78fa42433cf5f00c09091c143023659775", size = 9570, upload-time = "2026-05-30T11:53:52.047Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-automator"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/3f/65daacfdd38b6936cebae9c27f25b5bcb97e4de813488caaa066c80013a7/pyobjc_framework_automator-12.2.tar.gz", hash = "sha256:bf38231f0ad38115473e853e6419c5d0511f4fe6dd904ea380160da91cf27bea", size = 188951, upload-time = "2026-05-30T12:30:46.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/ae/a86ec615d951c1ef8ddd64a263a82de565386a56cc1ae43be430ccc63d2d/pyobjc_framework_automator-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7eb8e51ba9bb6b51d1e468016e536ef5247145dfaba20d4a682b15eb5cc86fd4", size = 10015, upload-time = "2026-05-30T11:53:53.625Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/43/f4e7d3b37c7c431e82c8e89b6ee96bcd6d02fd6c820f24d296791937d383/pyobjc_framework_automator-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7e7fb144f6adfaec353720d58f5aa8880a3c064d5c36d5042e816ac34f1d99f1", size = 10020, upload-time = "2026-05-30T11:53:55.296Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2b/7423f651934d5cdf44e8cc8b3a544530de173906766bb005c110ef91abbc/pyobjc_framework_automator-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e91a72760b9e23af2e7d2848deba25e76d05d8104f7aef85cc9d955aba4bf8f3", size = 10035, upload-time = "2026-05-30T11:53:56.937Z" },
+    { url = "https://files.pythonhosted.org/packages/16/56/1749bf5de1f138f68bfd498b639a480e06ac9b108c5e50a68cdf58379175/pyobjc_framework_automator-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:949f2d403d4d6d753122fa8ece9f9fd417b8b4afe6b65f64879259a03ca6f59e", size = 10056, upload-time = "2026-05-30T11:53:58.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/2f/de880591ffa058c8456157f5d618d5950ab8788b7f1e8f81d62ab8afe0d7/pyobjc_framework_automator-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:038ece9097bc9441554d48dac051bf445ed5496d4ced03962c5dca2ea46cfd29", size = 10201, upload-time = "2026-05-30T11:54:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/40/6db933f50cbeec6c5665c38d5442d9ed0cea59981d6295e0cb4a25d04331/pyobjc_framework_automator-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:349b7d02f898bf16edbadf5212758d5bac89440de9bd00edfd28c302bef8bf1e", size = 10100, upload-time = "2026-05-30T11:54:02.072Z" },
+    { url = "https://files.pythonhosted.org/packages/69/1b/ecc8113beb74c41a26336485030d127ebf6232c22c7e6e14ba9e99903b7a/pyobjc_framework_automator-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b62fa84bdf975e7c74973b37de491846fd7373eafdf5ec048d52a66b1cc24e8b", size = 10245, upload-time = "2026-05-30T11:54:03.664Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d1/ec4ff07ee7f1ea0f3b74b1f4d91113adb79e6a77a78b00f145cf92e35b83/pyobjc_framework_automator-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c1e1f2f64a6aa9b5d4d30db3794957d7d9d51a3d3e8c3563d0362ad10add5e83", size = 10091, upload-time = "2026-05-30T11:54:05.308Z" },
+    { url = "https://files.pythonhosted.org/packages/29/df/462ce3c16015fb1927c0b3b7a6f1a6f070ec7a4d5b0f0f270d0dbdddf6d7/pyobjc_framework_automator-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:86e9dfa9290909e999cd86686a4f7cf8f437a6c218d03dc244fea7b84cbd80b8", size = 10241, upload-time = "2026-05-30T11:54:07.731Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-avfoundation"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreaudio" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/d4/88d226694f8e598138fbc26808bb2d3a0637500691e42d15c64f3a8c1258/pyobjc_framework_avfoundation-12.2.tar.gz", hash = "sha256:d06443acf26f3f3e16e8a9bfad42db900af3b8c3ca34c5676343d2f8e001f56b", size = 410281, upload-time = "2026-05-30T12:31:11.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/96/853becd9612cec8349e8792d70f27763257151736b338057d6093c6b1745/pyobjc_framework_avfoundation-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c71e09a7b8ff94c488086908c21e133d618139fbc40c8b366db6b2522290b276", size = 85519, upload-time = "2026-05-30T11:54:13.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/19/1c6ce145492c820ffb64e248e9caaf6645b190ebd2e1df785848ccc74e91/pyobjc_framework_avfoundation-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f2d573dcd05591e77c320559c5f09c2b345893ff31902c4cb1baa5e69030575d", size = 85516, upload-time = "2026-05-30T11:54:19.83Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/0b/491ec7a65d9b6301a8a55a1607bb9079afc18946bb6c87944d51781b5e70/pyobjc_framework_avfoundation-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:593d2ec35f6799d9011f414247570457d8eaa68a1ce1381b4df2ab1daec509f5", size = 85570, upload-time = "2026-05-30T11:54:25.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f5/54bcdd1543663f7e90560adc2ea4daf2ed6bd7ab92f734816cec79cd2244/pyobjc_framework_avfoundation-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:67320d3c7cb0fe1caf019d29eea38e39ede81458e3f4c13c5483892dc66f3b3a", size = 85606, upload-time = "2026-05-30T11:54:32.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ef/f69dc23071b4b7f7a996dbeafee8afbd9be21fe2b651de2eab5d513d6622/pyobjc_framework_avfoundation-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4b45994d9230d2751590928d0421fb7d0b7e8988e52ec1d9ab3f1d57cb869a6b", size = 86054, upload-time = "2026-05-30T11:54:38.113Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/5c/7c2a89266936fc2a99f50810a459ce054035956b07d4d9cc33e9abc5b7aa/pyobjc_framework_avfoundation-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6f03f0122e4f0b2add93f02d92bd7274abf09979116382c74f79715d33e6461d", size = 85825, upload-time = "2026-05-30T11:54:45.189Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a5/78c75eca36aca64941451a61aa532bfe5305f886fc6f21fd4f4414ea4960/pyobjc_framework_avfoundation-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d2535a7bc3e579bc7621066481791f53d1ac83c0bda16fedbbfa513271238b56", size = 86153, upload-time = "2026-05-30T11:54:51.264Z" },
+    { url = "https://files.pythonhosted.org/packages/33/5c/f872e9502fc96894474b9e0fbd9e36f6fe38052d7f186fca79f150862b8e/pyobjc_framework_avfoundation-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b43a0d1344a062dd983881398a75e5916c46c479b299ff89c14d298ab0a0f1f0", size = 85863, upload-time = "2026-05-30T11:54:57.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2a/d477d3cd1f68cc14706835711f01b87c3063fb40002e79e3d798b6d6fc58/pyobjc_framework_avfoundation-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:d60d7ee5935266907acb1a61c25a0d2750f9b1f4ffe4fa6c908440f003d1addf", size = 86205, upload-time = "2026-05-30T11:55:03.541Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-avkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/5e/baee189b339f0249b35da67ff07004412abd4fbf74fbcb63b0208534991b/pyobjc_framework_avkit-12.2.tar.gz", hash = "sha256:e93667aa0d1283e692c6709b79212438e5fc7eb621371f573a7eccf3ecaa57ee", size = 33572, upload-time = "2026-05-30T12:31:14.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/75/9b92478426b9eeda4699e3bb0dfb66b0858b4bcc5dbae06fbc44bd56c50c/pyobjc_framework_avkit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3b795109fed005124119e3e7e04be5e4a314efe4914307cdb33a06820ce7bb11", size = 12324, upload-time = "2026-05-30T11:55:05.42Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/eb/eb62ff1232e6b253b02be5911dea99f45984f10bf9f9b71625b2db71bdbc/pyobjc_framework_avkit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f27c4d23b66ab428c57b7ae4682ca6117876cf4be1594f1f87eb57824ac2e3ea", size = 12323, upload-time = "2026-05-30T11:55:07.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/5a/3d81fbe55c5a62568810b37530631f2c50ec957add1b8cce48f8d249e655/pyobjc_framework_avkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:357dc1cb2f4b0ae60d89788cba6495fdacd773330d47e6687acd2b09859efda7", size = 12350, upload-time = "2026-05-30T11:55:09.154Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/58/d1737715102c83c82789fd8f68c323ef4571de79d4bc619800287af5b6a4/pyobjc_framework_avkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a9867e4eb5d84c88f962118cb22a74c594909dedd3d45eea85ead9450c397e76", size = 12365, upload-time = "2026-05-30T11:55:10.836Z" },
+    { url = "https://files.pythonhosted.org/packages/53/f3/f5a8f8d154b023930534a77b2039729968d0ade2136fc1c1672b40f3500a/pyobjc_framework_avkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ad719d907340151ff5c3d9b067e8c152a8a23c6d18fc8256fdbc1431b40cf7d6", size = 12557, upload-time = "2026-05-30T11:55:12.539Z" },
+    { url = "https://files.pythonhosted.org/packages/06/f6/5b226e18592b5b89419221509d37caedbd1f44ab9781c6abf9e9649ef9ba/pyobjc_framework_avkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:df3918f5f9bd687a6a6604dade8461a948c15fb8d755eb1aba21819271e822ea", size = 12377, upload-time = "2026-05-30T11:55:14.41Z" },
+    { url = "https://files.pythonhosted.org/packages/81/61/f2b09c245299251307ca545a3160565893fd3f6350f11b8142efaf37e87b/pyobjc_framework_avkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:fbe7c41d928849aa8628a893fb06b7ddd77af5f2dad9ba22e5ab88545620d295", size = 12569, upload-time = "2026-05-30T11:55:16.229Z" },
+    { url = "https://files.pythonhosted.org/packages/de/26/deefd3fba2daf5a196fd5701159d2ffac4bf9ee13677254ae2ec1eaeee33/pyobjc_framework_avkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b8200fbc2744791dfb4985ca5b7387417ffed8c47b81547d36863bc177b6ea54", size = 12364, upload-time = "2026-05-30T11:55:17.822Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c1/58b2ffdad3dce58e1d71e3baf0b2759b7edbe17f85e4a0346de21d985cee/pyobjc_framework_avkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f089e1022690eed0bb2111e64dec71b1779885e5cc7fe745b7ca1f6df1545fde", size = 12563, upload-time = "2026-05-30T11:55:19.729Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-avrouting"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/5f/dcb7d6a4615c0f4b80492b0ba778f0b49aba6c6b4c3a727d0bf38696aa28/pyobjc_framework_avrouting-12.2.tar.gz", hash = "sha256:78affe0c4335ff47f186fed21965f8a381e46429c1a52794044cf2835b48dd4f", size = 20872, upload-time = "2026-05-30T12:31:16.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/bb/35fc98ee526ca31ff739ef8a73bc552091367ec3a99b7d0f6d9194b5be6a/pyobjc_framework_avrouting-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:15cf594e0a1f83d4ae51040119c5318a883eb25c1ff5fd382675553c3ed9833f", size = 8451, upload-time = "2026-05-30T11:55:21.319Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5d/0314d8b4d8c37656a3449fedfca7d193b9c12c91d6e237058e12b1242cd0/pyobjc_framework_avrouting-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3b18f5eec55a9fe15176a52c31725117960a992b51d7e581316d474056418508", size = 8457, upload-time = "2026-05-30T11:55:23.004Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/65/b8053591a08574a7de17200a6d571193b3298ec86694b2c359126104696d/pyobjc_framework_avrouting-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7324cf41f517328a401b5e7f4a2c0ffd08ebdc32199d3058f4088ff8ea36faf7", size = 8472, upload-time = "2026-05-30T11:55:24.633Z" },
+    { url = "https://files.pythonhosted.org/packages/43/51/2a34dab903467a34377de5ddc111b33506eb297fa1103a433e00a4352c80/pyobjc_framework_avrouting-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:72a6408801282037ded8a852c5d266d0e99b637496ef3aee1ac179cdd89b8d76", size = 8496, upload-time = "2026-05-30T11:55:26.359Z" },
+    { url = "https://files.pythonhosted.org/packages/96/28/015dca6d3acabb21f3e93942aff5cb4420f82ded98e2761d13d932837f35/pyobjc_framework_avrouting-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:feee657352beaa05d98a00d5e744d1d7a95572baa2df34f55496ee70bfc74d35", size = 8649, upload-time = "2026-05-30T11:55:28.273Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c4/332d8a24c4bb5855eef4282d292763a3fe918d8630636e0dcf0e91c18115/pyobjc_framework_avrouting-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2e86f63fa45172d92ad653af5c9977d0b68e10b36441db0157a5485df8ca3430", size = 8550, upload-time = "2026-05-30T11:55:29.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d2/e1fb703d271cd37d9fbb9236deb6bca5fa39c11dfc3248aad68d9ebb66b8/pyobjc_framework_avrouting-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:15a2fe798b118ecdfc4c9b75057630f0fd019aac8e17b9272762e776511ab06f", size = 8710, upload-time = "2026-05-30T11:55:31.423Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f0/3833ce715747b99867e0615f4f5990cf6466b2e04d5354b78ab66ad40c1b/pyobjc_framework_avrouting-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3f862f47adf00f0ba38076949502025489f8c75a7782b393f7fb93cdfc016f27", size = 8538, upload-time = "2026-05-30T11:55:32.987Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f3/e68ca2735ec81fb13dee5b7f3f4f16b0dbe95765ffa221762721ced7d658/pyobjc_framework_avrouting-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:7374ea465ea07f70eca80896701bd216bea9f32a46e3b52db55fd34da287791c", size = 8706, upload-time = "2026-05-30T11:55:34.582Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-backgroundassets"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/3c/b344ae79feea1d4169c2e95684d9cd8b938391371b3db8f24abb98501c12/pyobjc_framework_backgroundassets-12.2.tar.gz", hash = "sha256:6df332f129cc025843f5ba6affe651bbf6499b6be35d781fbb12b52250adba9e", size = 29362, upload-time = "2026-05-30T12:31:19.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/a5/9982e8520ea64be25f90ed363e210744eb4e8479f48ca5296dbdf2fdb2f2/pyobjc_framework_backgroundassets-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ce49fbef8b92e326ef71d04f460e6e75cc1dc4e7940fb6f1f6c2c7e603ef71e6", size = 10900, upload-time = "2026-05-30T11:55:36.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a0/c9917212b177a6009b8acd99e16f45ed5a57dcdf4f2dbd206a982c274b84/pyobjc_framework_backgroundassets-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:27e2e8b174fdf01d6d0fa7f789f41ebcf0a78f05f45c16592ab3a29e496834eb", size = 10901, upload-time = "2026-05-30T11:55:38.015Z" },
+    { url = "https://files.pythonhosted.org/packages/03/45/bc0a2b94d221e5c094b8c90980f1dd89684f9124c7c63ca3f640081c4075/pyobjc_framework_backgroundassets-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7052f3eec8ce4db24f3c513455b470a6936776878d025e081501fffa9cf2181a", size = 10925, upload-time = "2026-05-30T11:55:39.608Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a9/b68ebcab2895a659cc18dcb9890aff8fb2f19f9f4e97dee2197de5608671/pyobjc_framework_backgroundassets-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9f40f72349412f7fe9b55e083de77f1ade5c33de8be529633727c83689421a21", size = 10943, upload-time = "2026-05-30T11:55:41.4Z" },
+    { url = "https://files.pythonhosted.org/packages/68/31/5e8d83b4a2269a6b8ba98a342852c5fcd6715390396c5a088e9efa88d9f3/pyobjc_framework_backgroundassets-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1cdb5e2c45786a6a36dea60fddc90251c6482bb6d1c05b499258ecd2a6972d05", size = 11192, upload-time = "2026-05-30T11:55:43.007Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/59/1356179290082932330c18b05ef6b2b2ee8c9d2546e316d555925d67301c/pyobjc_framework_backgroundassets-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:79e68372eb311932bd59dbd98523b3ecf5b6c3490f074be734b41b88ae276ede", size = 10992, upload-time = "2026-05-30T11:55:44.549Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0a/3e7dd4a6abba8dde3e0aebe54122bb35c8e32d55842b15632c0955b3d03b/pyobjc_framework_backgroundassets-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e7cc37f7cd15cbfd52c30764d31e8c983352fe9813976496d356acdd9e04b5b6", size = 11199, upload-time = "2026-05-30T11:55:46.283Z" },
+    { url = "https://files.pythonhosted.org/packages/22/96/609372b2cd4422d900ec39063ae9a033cda13d2efd57e02bd3cd10e1042f/pyobjc_framework_backgroundassets-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d327bf09dcc25a881f72f74e3d07adbf45e1188e5d1f7bbac8f1bb814af1de15", size = 10986, upload-time = "2026-05-30T11:55:47.827Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/00889013075612cda22866a3e0521091f2912854ffd18fef84dfba7fb114/pyobjc_framework_backgroundassets-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:028fb2d4adbfdaab9a531943b4019de531ae3a4a57415da6e4b059ded28b7743", size = 11194, upload-time = "2026-05-30T11:55:49.565Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-browserenginekit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreaudio" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/57/b5529f648215f9abf7f7bb5f57737b75d2cb12936a28907258d6ce2846e8/pyobjc_framework_browserenginekit-12.2.tar.gz", hash = "sha256:f38924bc5e8ab80d1248b00554015b4a86ec3c3c17c779a3e43a0179671e4d69", size = 32610, upload-time = "2026-05-30T12:31:21.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/ea/330d72e444c1685a1298d475f29e8ccad55daed4ad9e0ffe92f1ed5ca259/pyobjc_framework_browserenginekit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:65331ce92345623e153a5d8def6a3ea3cb8a5d3ac8e617a839806a47c0ef8b3e", size = 11714, upload-time = "2026-05-30T11:55:51.258Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6c/d391914ab726087ba89d902374b4adff58f0520a1e53e50743d04a125f10/pyobjc_framework_browserenginekit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:99ecaa16abd39efb030cef2b0e590e49cb7cc0b2f2a9588fd294a271e6c03130", size = 11717, upload-time = "2026-05-30T11:55:53.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d2/cabd9d636204dc08935c9120db60d74a56304d9700e9ba5842d7adf3dfee/pyobjc_framework_browserenginekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a5590d2301c7c0bfeabca352fc3eaa3314d918cfcb1b35b264c53c9364cb1ee3", size = 11737, upload-time = "2026-05-30T11:55:55.066Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/c4/34535b9a061dc619a2f3910d15fde604210187cda07bba4c720fedc77d26/pyobjc_framework_browserenginekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e500aa3ad0c9ef5787bc72a42474d58f8b3355d16f8944dabbe5db2f15a4634d", size = 11760, upload-time = "2026-05-30T11:55:56.77Z" },
+    { url = "https://files.pythonhosted.org/packages/63/05/c0c40325e75fbcf70372b7bea10eb875b24ced3582f580205d5a58ef72e4/pyobjc_framework_browserenginekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:88b2b6d5cf7b1e91029e3f32fa950bbed2cf43228ef6a0869bde915caf841152", size = 11927, upload-time = "2026-05-30T11:55:58.441Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c8/fee307a791f1315eecb4414429ba3b98f0571ca768ae5eb9cfea30c88087/pyobjc_framework_browserenginekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:87c2d039d7008ccc06b2bd8a4760d356a4d1f1cb267d680813919320e46e9202", size = 11809, upload-time = "2026-05-30T11:56:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/98/21/eeb8cd19ff856e77a96d06f51dbc7e8c0f885c71cd0673401100bfe41f07/pyobjc_framework_browserenginekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:79400862fc7c7bae77bdee8af2fb526877229066b6cf137a3514de8e304eab2b", size = 11995, upload-time = "2026-05-30T11:56:01.874Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/20/c3f5ded954426f8e44d831e18a5993d859b08c7a4a713a8de6c0016461a5/pyobjc_framework_browserenginekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3e02e17a4c7d28eea31fa870c48908d354e8ae9d07dae0691070feef584df7c4", size = 11800, upload-time = "2026-05-30T11:56:03.688Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f7/c468f25c1e19828ce256065d5d40b03b4f65229e3995de922d7c1569c270/pyobjc_framework_browserenginekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3eabf92613a55e9adbb0e8933898622868e2ab10e1731dca25cb8885ac73f0d1", size = 11992, upload-time = "2026-05-30T11:56:05.413Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-businesschat"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/1a/9ad0a1f52f5c670948a71eceb295b6273fa7b3422651f660f9eaac5c3078/pyobjc_framework_businesschat-12.2.tar.gz", hash = "sha256:77809904d62b18377e0764458044f30ba380f462f616cb69628431814afb6f14", size = 12403, upload-time = "2026-05-30T12:31:23.707Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/19/5b9e89bf4c62bfe4ab844027f75786d171aee623fb4ca0c4dc46e67ffd7a/pyobjc_framework_businesschat-12.2-py2.py3-none-any.whl", hash = "sha256:c96bceb6796f1fb82edafcda75d5abb59e165aa0f55a6e646638ab56d94ceaa3", size = 3477, upload-time = "2026-05-30T11:56:06.861Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-calendarstore"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ae/e6ab01011033d45501d96e388eff16185152ce2459174b13e22d90c721a1/pyobjc_framework_calendarstore-12.2.tar.gz", hash = "sha256:26fd412f9c4b9bf5243d44f87b03e24c80562012f6db4ec88c78cc2ffe63e7bd", size = 54421, upload-time = "2026-05-30T12:31:27.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/f7/356d958ef979f1dc7c01c0a94f0a0b0bf409919308b69e5eee750772f480/pyobjc_framework_calendarstore-12.2-py2.py3-none-any.whl", hash = "sha256:cc9b0cee139d0552d8b924aca13c8ea3a51caa0e2bbf57540d84f249decd3846", size = 5288, upload-time = "2026-05-30T11:56:08.493Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-callkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/63/f050271956d5742acde26d04ec6e602af9c39e6ac338c161cdd44b083016/pyobjc_framework_callkit-12.2.tar.gz", hash = "sha256:862c4e7475cfc2ee6c663f042fc4a025cbf07edb7608aa8556e64a0591e070fe", size = 32654, upload-time = "2026-05-30T12:31:30.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/c7/9563472f609d25cf92655d604e4946a2d8ff20f0e33941311902617a409b/pyobjc_framework_callkit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ac91cff88871cd38884375e6413b964ea22d1a5e1c4b61f22da353269f2128f2", size = 11306, upload-time = "2026-05-30T11:56:10.391Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3b/ae6b22f9257b4fe0bc758de0f78cde47ac663df195b8bdbc52b9851a3414/pyobjc_framework_callkit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5e4dcfb7d1ad9ced612c5fbdf7e9dfbc03dd128b987963e7c9f7e50f60d061f1", size = 11303, upload-time = "2026-05-30T11:56:12.254Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/14/a5cfb8c7a909836236c9f42ed4ba0e0566994828989cce99d646fb6032f7/pyobjc_framework_callkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe8d63ef451eac946864614874b03a2e68a87389e8af611aab32ba61b0e10d2f", size = 11368, upload-time = "2026-05-30T11:56:13.932Z" },
+    { url = "https://files.pythonhosted.org/packages/87/7a/4ac154b5bef806a770de93ff5bd5cb67ac92ddb92ceef697222919a8dcfe/pyobjc_framework_callkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:09f8e08298a46ceb53e50c1e17c5dd9e06ac2096f1bda2f956f2ba8693e91ca6", size = 11376, upload-time = "2026-05-30T11:56:15.663Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f3/72f5b9a00b7adea3cda7d911414c8deaf0bf37e0396c9c918147fa002005/pyobjc_framework_callkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b7242585de40273f82c084fe00a1658f34b0357695f008c8c468ef08c50cc2d4", size = 11590, upload-time = "2026-05-30T11:56:17.342Z" },
+    { url = "https://files.pythonhosted.org/packages/43/7f/5723741b95b838230f833a98dd9795d49810b3986534b88addf3b8779b05/pyobjc_framework_callkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:1548f4318427d392ba25296d84449980317a96e92ff01ad4ed77b11b69a8a5ac", size = 11366, upload-time = "2026-05-30T11:56:19.095Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/b9/43d2a04cbafee3f6ba86bbebb1767ff7678adcc8b78880725a85b9d4cd4a/pyobjc_framework_callkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:aa198339cb30cacf7783fce03b37a1e800e8ab297466c2e70793383a1658a701", size = 11591, upload-time = "2026-05-30T11:56:20.81Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ad/78870edd229349f9b6473fbfbc2612662166834f62474d830d80c972e519/pyobjc_framework_callkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c35bb086c67dfdc9facf0f56c8b7b3c1fb2f0ee5e373cfe6dab7cd91daf7b426", size = 11368, upload-time = "2026-05-30T11:56:22.495Z" },
+    { url = "https://files.pythonhosted.org/packages/43/74/0d66c43c2cabf383e304615bcbfcc9038ec66f9e8b7bf7becc3733625e4f/pyobjc_framework_callkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e0658e53a50a4244335b840c45825845350b2d2e9269ead43d7beb1430062d18", size = 11593, upload-time = "2026-05-30T11:56:24.352Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-carbon"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/ee/91f41ac1e637b999ba80ee3d5d2ceafaef8d8709012dbb8d0a904136ad76/pyobjc_framework_carbon-12.2.tar.gz", hash = "sha256:965a291f5d5db032057e00666b5a6baed66c564451db66e005fd88be17ed8e27", size = 39741, upload-time = "2026-05-30T12:31:33.954Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/6c/4600816c385ad52f748bf527c4ed15a15d51fb79770bb0a5d6642c4f49a3/pyobjc_framework_carbon-12.2-py2.py3-none-any.whl", hash = "sha256:2420af5872473b91080b8000a50ab2e5053611dc68c094e257b75939f3fddef4", size = 4624, upload-time = "2026-05-30T11:56:25.712Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cfnetwork"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/01/3976ae7dca6f2f35659c364c2e8454a678f730f96f50d41f8ff53cb00d8d/pyobjc_framework_cfnetwork-12.2.tar.gz", hash = "sha256:d50078305b840d1c4f9d47c7c7cb66508766189f9aec6683f4207fccd6d096ee", size = 47633, upload-time = "2026-05-30T12:31:37.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/ce/776ae188cf94522a3a327dadf38c5eab0195e6d8b9b93cbed8e4cf29180d/pyobjc_framework_cfnetwork-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1c1c910e1f917fe484b64b755ebd8a2befd80580308d0564b16fb7b00eb1ffb5", size = 19947, upload-time = "2026-05-30T11:56:27.974Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b6/7f0c77c25d147c5b30b66e5dac6e5b66e759e5ccc30eda4a639a0a375109/pyobjc_framework_cfnetwork-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ccb43583d1971168c624f1dae278e12ba768e584a1e1513bbca2edb067b45611", size = 19945, upload-time = "2026-05-30T11:56:30.423Z" },
+    { url = "https://files.pythonhosted.org/packages/01/79/29d6ba7cd1931c35b0b6590162b6ee21cae36c5a3597fe14ac69c1ff098a/pyobjc_framework_cfnetwork-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a38c3044b4086b840c974a430db0ca4f02b28b5bb18933da56e5fd3291458667", size = 20127, upload-time = "2026-05-30T11:56:32.622Z" },
+    { url = "https://files.pythonhosted.org/packages/07/fe/f89406f7cadd648eccb03d2777860b748f04db3245fd4bc7b1355cb00cca/pyobjc_framework_cfnetwork-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0b4c2eba6d1060b3e0e7d63bb67d2d14b46a7e51fa8ab2c2e7767cee266f548a", size = 20145, upload-time = "2026-05-30T11:56:34.838Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5d/3bb11f406df581059d65a7807dd986796aa388a33da1c816b37238c2b889/pyobjc_framework_cfnetwork-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f4d6db3702593b2a93cf9b793f3eaac6c0fa7d128a5abcf9f8b7a65079930e5c", size = 20449, upload-time = "2026-05-30T11:56:37.185Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7d/74225d22d6b26d44f51add2e7a24ed26cd083d52daa165b8fcfe668cfe17/pyobjc_framework_cfnetwork-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:760e6dddbd91013c24161413cbb4e91f0161d20815473d66cf6eb1826d579306", size = 20190, upload-time = "2026-05-30T11:56:39.404Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/6a/a040b6e60aa9ecd4b9b4ae606891944562312bc02a067538b9eaf06ea855/pyobjc_framework_cfnetwork-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4f0b1b47b0f230e4f24382dce5500fb1d19350c867e440eb01f31c24308002aa", size = 20432, upload-time = "2026-05-30T11:56:41.585Z" },
+    { url = "https://files.pythonhosted.org/packages/56/56/b7ecf9e748b86ceb0fd7f7b78f989b76aee05044346f1a6281e1cd095694/pyobjc_framework_cfnetwork-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b695807bf77444a08fc944c50c6a1aa246abf502c3c507ca04815964f4407024", size = 20193, upload-time = "2026-05-30T11:56:43.808Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/52/5fbabf17e9ae99a8df2115c21f4ac69463ed91f6e5b0481484b9c6d5ad95/pyobjc_framework_cfnetwork-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5400c56807880e58bac7ce3d48e7b9c773eda8ae1774f361e2e1c5e4afcc990e", size = 20430, upload-time = "2026-05-30T11:56:46.005Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cinematic"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-avfoundation" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/dc/afc97af264e477fea0f95b54f13350119d69d6eeeb68a6698452295576ed/pyobjc_framework_cinematic-12.2.tar.gz", hash = "sha256:2bec1954c5241e5c8dbefcab6d5b300e62f76eb3907a177840357f9de8474d7a", size = 24960, upload-time = "2026-05-30T12:31:40.317Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/b6/97ff3fa5efbd7b80d40ab5be590f92b7a7ed711ce01812bd0a0a3c0453d8/pyobjc_framework_cinematic-12.2-py2.py3-none-any.whl", hash = "sha256:8df478081b8248a32e91aa2981806e05c551bc6f9ec1286b5ca2d1c64e981f6a", size = 5101, upload-time = "2026-05-30T11:56:47.469Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-classkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/35/40a13933e42581a127334faebba2d352a01d3baab02693b31ca4622073bc/pyobjc_framework_classkit-12.2.tar.gz", hash = "sha256:41ca16e92a844bed689b634707a07ebd38bf53e1a0793bcb1005347221889d7e", size = 28943, upload-time = "2026-05-30T12:31:42.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b5/19594f6da9392c0ae5d55b2162b03d545190ea7bb50cc507a9f976948dc2/pyobjc_framework_classkit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1b3bf141c82e4e5f302d7e961e508c5f0271ff5609bd932006071182cb251815", size = 8910, upload-time = "2026-05-30T11:56:49.174Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/da/11b4875653d8f7b2eec6fa4e0b6ca8e628030d43341b6c412f631c8294af/pyobjc_framework_classkit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:65883957cf4c49223b7621bc6c5dafd79d8d65ef32d454291d32ec201e4657f1", size = 8910, upload-time = "2026-05-30T11:56:50.909Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/33/be5bf6a705893bc936b3bbc7f9da464b8c0911efbd787a9b2ed8e5a0d664/pyobjc_framework_classkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3b54bba859c942e00a279e9a42897897b6789ab46270ae02b9826b789def898b", size = 8928, upload-time = "2026-05-30T11:56:52.582Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/54/bb0db5a07037e4745deb8f0176cf78b03e4176bcd965693998fec86f5b4e/pyobjc_framework_classkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:168c875649e7e43192ef2961569fdf2ac77f662a29417991a99dff5a44dd9881", size = 8940, upload-time = "2026-05-30T11:56:54.141Z" },
+    { url = "https://files.pythonhosted.org/packages/91/93/d6581548debc49ce93d94eb909d663ab1bbf15439f3febd5ba7cfda91481/pyobjc_framework_classkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b593774ad4809c896d735fe3c0d69664cc74d3abe56d1a5fee809a7c05646ea6", size = 9090, upload-time = "2026-05-30T11:56:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/17/78/7354e03126de7bd6a0919a73c4daf54e8e614b257e223caf3171b8ff03ca/pyobjc_framework_classkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f86e741cc43454de9560839e96800f2d0f9ab07f1e52416e82ccb343137d7e94", size = 9006, upload-time = "2026-05-30T11:56:57.601Z" },
+    { url = "https://files.pythonhosted.org/packages/03/6e/a20b725099ee4981facc259c06d674e84aafb86d6387c208f7cb595da5a3/pyobjc_framework_classkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d7de8bdafa98f64f69094d067cc2a5dabad62a7b861f4837c4e95d380af20df2", size = 9160, upload-time = "2026-05-30T11:56:59.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/b8352ce9ab8e178a7c4ad719573116a6f3a4b9e268a1704c65342f28ab32/pyobjc_framework_classkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:21325c21ca70c38ef8536bf80a25cabb575d7cff95afcabfb8824c180945ee45", size = 9002, upload-time = "2026-05-30T11:57:00.825Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/73/9a7247e52db4d236355f8db3f1e7f94231942f491433cf6e825bd86d0cbd/pyobjc_framework_classkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:566d622feb6c5c45a9a8b60dca97dc9941f8b88826f7f91138e81719041288e1", size = 9163, upload-time = "2026-05-30T11:57:02.487Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cloudkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-accounts" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coredata" },
+    { name = "pyobjc-framework-corelocation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/57/418b22c326c62f03341e7a974852c5a5bae4dfce1ec88a570e22f14c662d/pyobjc_framework_cloudkit-12.2.tar.gz", hash = "sha256:7849629cc7c726c1a3e16b3324d9fac57f72b938a66f10d480f52e381bef1223", size = 71957, upload-time = "2026-05-30T12:31:47.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/01/1ad78a6eebbbac6381aa1163028dfe74ccc4111444ecfc1954b4d02a53b1/pyobjc_framework_cloudkit-12.2-py2.py3-none-any.whl", hash = "sha256:1e00a6d02ac005a4dd31aa0aa5e22fdd3e05f8324f91a175dfae7fd45d85afd1", size = 11412, upload-time = "2026-05-30T11:57:04.221Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/cc/927169225e72bab9c9b44285656768fb75052a0bc85fdbca62740e1ca43c/pyobjc_framework_cocoa-12.2.tar.gz", hash = "sha256:20b392e2b7241caad0538dfde12143343e5dfe48f72e7df660a7548e635903dc", size = 3125555, upload-time = "2026-05-30T12:35:09.273Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/db/e86555b282c38bb0aadb63bf961c17e3ca70252774a677945f6bc4ee19c0/pyobjc_framework_cocoa-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a2efad455ded551d1a033fd22245d57b71b6c065e8b52158dceed1611b5ae033", size = 387272, upload-time = "2026-05-30T11:57:27.512Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/10/95edbdee61731dc0e18633071fe56a4220879a92e9ba77c330a34add4b28/pyobjc_framework_cocoa-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0bb7cd468ca89bbc2d1d8acb930b4f4fdce8826de30a66608fc28f8880c1f6a6", size = 387272, upload-time = "2026-05-30T11:57:51.391Z" },
+    { url = "https://files.pythonhosted.org/packages/30/66/5a91f2eddfced4f26bc2df2bcebb7f5f10c5bf5666aff6fa00ded845af07/pyobjc_framework_cocoa-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:06cb92d97d1af9d1f459ae6cf1d1a7b824c12d3aff1b709885966acd6b7208c2", size = 388093, upload-time = "2026-05-30T11:58:14.921Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/3b/1af2be2bf5204bbcfc94de215d5f87d35348c9982d9b05f54ceefbc53b8f/pyobjc_framework_cocoa-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f0bbe0abedfb24b11ff6c71e26cdefb0df001c6482f95591fad40c2688c16498", size = 388154, upload-time = "2026-05-30T11:58:38.547Z" },
+    { url = "https://files.pythonhosted.org/packages/41/cb/c0435d64f1199210af36141b90aea2ae3344719f7313d4160b8b0dd527db/pyobjc_framework_cocoa-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:46b6681e2b21b099ed095339c140f2c8137d6ac5658653166ee90722f9e3c621", size = 392245, upload-time = "2026-05-30T11:59:02.436Z" },
+    { url = "https://files.pythonhosted.org/packages/56/4b/df8e359e5e422e8f1430bde038aa64364e8c1d4542d7f6fcc4f8a97ec0b7/pyobjc_framework_cocoa-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:aecfd44908fa12a9291fb6ca2458ebbc611102de6784f2202a35fd5ed9f56c60", size = 388334, upload-time = "2026-05-30T11:59:25.861Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a2/68c0702cc9d6dbc7077edbd13ccc9aa30ac589d514f51ad6f5c3840e3bf1/pyobjc_framework_cocoa-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ef679740f541c52118149b558b757d1f11d9dcf30c2a23344b13a6af6a99a1ab", size = 392376, upload-time = "2026-05-30T11:59:50.031Z" },
+    { url = "https://files.pythonhosted.org/packages/83/c3/e170672302e75cc1aa833546fb0d5a3bd4a126ede4124566d5a2e4a50cd6/pyobjc_framework_cocoa-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:290e544a8c2d0786a34a359d825eaad44ebaaa3b30cdd765b2755422ca39a0d2", size = 388566, upload-time = "2026-05-30T12:00:13.606Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/6b/78e98e4de11646e56cf98066f9f84b43c86adc8b273a660d85a6ceba7a31/pyobjc_framework_cocoa-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5a0bed77b0b56074cc2b4564aae3e6e9d5da5fdf93252f50b6dbced0f7fece3a", size = 392674, upload-time = "2026-05-30T12:00:37.572Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-collaboration"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/72/f84e5835a01f42a8b14c165490e24ba72839ed411a24bd7217f4d37c7d54/pyobjc_framework_collaboration-12.2.tar.gz", hash = "sha256:77707156f677c502fa973bbb3028ad1cea8557875e75f1a03f605678c881289a", size = 15069, upload-time = "2026-05-30T12:35:11.891Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d8/a1eb9888ca7ee599bc484feb78c43453f8c154c986bdc0daff4948fe39c7/pyobjc_framework_collaboration-12.2-py2.py3-none-any.whl", hash = "sha256:219f8e5b1f0cc25dc48460ca909c09127eb80b3aa0262cb50139cd46c84b63d1", size = 4853, upload-time = "2026-05-30T12:00:39.271Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-colorsync"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/7c/eefce8ea94a1817842b54a1d6d472ae184749ca6ad8d84386436b10ac757/pyobjc_framework_colorsync-12.2.tar.gz", hash = "sha256:b403820f3504b0e728f883575637c217a2043fafca5c0b315f03c88805d37958", size = 26911, upload-time = "2026-05-30T12:35:14.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/c7/0562840adbfaa21c37ced637653e4ade70618e911a151974c53d25c8f5d9/pyobjc_framework_colorsync-12.2-py2.py3-none-any.whl", hash = "sha256:5d2ce9acd7ec28133facf0af900fc4a5d36971083811eb6da775be4b659f9b77", size = 6006, upload-time = "2026-05-30T12:00:40.915Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-compositorservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/da/0f975d3bb2efbcd305d76f9c8869b5918116731e739cf071630ac3e1f818/pyobjc_framework_compositorservices-12.2.tar.gz", hash = "sha256:2c1e940959270aeded95b573ed57c9edd7d3da0ccd45fb5be262c93cc62e2704", size = 24919, upload-time = "2026-05-30T12:35:16.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/86/f172e0a687dec40e7809e1efdffeb666c8d369cb73c7e50cb6f84d0b49cf/pyobjc_framework_compositorservices-12.2-py2.py3-none-any.whl", hash = "sha256:486f5e70250892122ba90f2923dc955a3622c4a047536ee3a0b15bd3568cd171", size = 5972, upload-time = "2026-05-30T12:00:42.699Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-contacts"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fd/b1569ca626fef30123f0fa5d3cb6126e171cea0900434e4b629f15c5f403/pyobjc_framework_contacts-12.2.tar.gz", hash = "sha256:117989ffed4f41d0bbf7e81dde8154a31995d2adf1fe898c2917bc6e9c1dc122", size = 48703, upload-time = "2026-05-30T12:35:20.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/53/6e725408309534d40d3f644085d7df7e036a578ac707f888612832872bb0/pyobjc_framework_contacts-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1bbb9153a3ef706230d05ddabe3a953b136fccba643a404e6ca3df8068f08348", size = 12067, upload-time = "2026-05-30T12:00:44.676Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/7b/7af492af38d81b555345eab1b978e58892fb744ae5fe7d234e2133c15ab9/pyobjc_framework_contacts-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3db10cb109f687d7ef28c471d54ffc63df77ec7685bd2663fd2b8c75a1be7f66", size = 12067, upload-time = "2026-05-30T12:00:46.631Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/03/2a6cd96ffa4d3d11216808d877913ee4a527adbfed56660ec7b577c568c8/pyobjc_framework_contacts-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:50a4b3b1ba1a27691dce40db61deff1b6e52889e063076411bcf797dd958d299", size = 12152, upload-time = "2026-05-30T12:00:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/79/609e55416da80222dbce2ca761f70ced7e45c85244f7b66e8713eb26dae8/pyobjc_framework_contacts-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1ee92445cb2c5168df0b25bb6d897b1389d55571eb6bba229431c1d933940a7a", size = 12164, upload-time = "2026-05-30T12:00:50.096Z" },
+    { url = "https://files.pythonhosted.org/packages/18/36/701eff1da16bb3d89dc28d0db6acf5604650dad6b722cbcba2ad9c8a6233/pyobjc_framework_contacts-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:91748bc3a42723d088f7ded819cf0155868b9bca16ed8cd753695bc71710f45d", size = 12325, upload-time = "2026-05-30T12:00:51.734Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f3/1c272535422ab8642ce251accceef3ab29695742be5f1e658a41b0027a99/pyobjc_framework_contacts-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:63abb417bf2d3565dfc79cd8febdb2499040ec44900a972c7aeba02120bc27f1", size = 12237, upload-time = "2026-05-30T12:00:53.552Z" },
+    { url = "https://files.pythonhosted.org/packages/02/98/59a842bb85f1524996eb884a62d8e4303c28b0c480aaf221a95c0f480040/pyobjc_framework_contacts-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4cd0d97c47a4c6a6822fd213612a0b9a48a6f37f76f9b19bfa922b58a5ef061c", size = 12393, upload-time = "2026-05-30T12:00:55.355Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/dd/244f231b713ceda4873cac2f57e2c05ac77d6dbb37066223509b8042f3fc/pyobjc_framework_contacts-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:37d4e0b512de0586f90b306a4cc4ddc0752edf7ae8caad11317516da7d17d63a", size = 12231, upload-time = "2026-05-30T12:00:57.042Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/1e/870fbb8b096150a89159aec4d23f1ce0fa4ca0ffb532c5b4575a2234bb4a/pyobjc_framework_contacts-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:8d50405ecf31ab5370f9ad5fe4aa4d69e0bca5c8fff0991671bb88f65ebdf3c0", size = 12392, upload-time = "2026-05-30T12:00:58.798Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-contactsui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-contacts" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/e1/8f51114ec751ad746cd0aaefcb130f5dd3b09537a326425b4c8f47fc1345/pyobjc_framework_contactsui-12.2.tar.gz", hash = "sha256:ca1ab431b8838240877d8c8c1776d58c7eae9f9a7b193b0cc761162f6baf58bb", size = 19347, upload-time = "2026-05-30T12:35:22.591Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/ee/9ee75009dbc36e495f5385d4f39a386c59d354379df3a26b5b2f9a1ab777/pyobjc_framework_contactsui-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3ee2052602e2ec612d5734265ee1489111c9b6a194e27676e1bcce8e8b2ad0c3", size = 7870, upload-time = "2026-05-30T12:01:00.476Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b8/2d254631796d98713c933cf98cd74ffb3091a8552abc9cf7fd7b820ccfe3/pyobjc_framework_contactsui-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cb5a39864af643f8bed07a99e22c73f0a46934c4247369a50c305ea11c435755", size = 7875, upload-time = "2026-05-30T12:01:02.252Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b1/e95a20c1a090db78be1ab46b0d36e808dcfe8c759627359bd30c7830ffb5/pyobjc_framework_contactsui-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:22aa70253b9c1087f5a1af645c87792096cba494d5a34edd964a2d8a4ad1cb1b", size = 7895, upload-time = "2026-05-30T12:01:03.734Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e9/e4433cf42edaf26aaec04a4c059733b98ad9c0982a5e72da192309fbe391/pyobjc_framework_contactsui-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8ac61436333c416fada5053c9d8b1879f82efa9bd96fbd5027da6ffcde0728b4", size = 7903, upload-time = "2026-05-30T12:01:05.63Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c2/cc3c32d9811798adf6404b8204731f855714869dd0e0476b6b4d6302ef42/pyobjc_framework_contactsui-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2c7a4f5e89a22eafc056a52caa07e96f35b82a628b42a9c47d0720634ee01099", size = 8051, upload-time = "2026-05-30T12:01:07.166Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b0/e65fb4c42eaa394e568aa7585baebe765a10076c868c552dc4eded593441/pyobjc_framework_contactsui-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:91e82a66a34fe939274f4f6867e157adb608e0aa52b9dcbff7c0a199871195ac", size = 7961, upload-time = "2026-05-30T12:01:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/6d/f922216e36b461d9ddb348beaa300a21df6189ba85718be34bb230d0ad66/pyobjc_framework_contactsui-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:583c884823816c0c890e070fc738522dd0c2081eb3663db1c64647ee1e76002c", size = 8114, upload-time = "2026-05-30T12:01:10.512Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5c/163409abc851ea4b79097d1d08033c8ee1ca01df21093b74fc16bdbd8d0d/pyobjc_framework_contactsui-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:eacd68ff0b2dcbeca2ba272799aba34bd2d966d3289a00aa8e4684b2870b96af", size = 7965, upload-time = "2026-05-30T12:01:12.191Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/eb/29970ba97be46f444e24c7e669f9fa87e6f2429d089bdedb4487bf3f7879/pyobjc_framework_contactsui-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:993702a013f381d763be9b2bb45a363439562dbfe6238846c76c798305e3afb5", size = 8111, upload-time = "2026-05-30T12:01:13.649Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coreaudio"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/d0/6e4adb375b81c06fbf28d758ea60281cf78f5675a68f7f3613d5ca28aa71/pyobjc_framework_coreaudio-12.2.tar.gz", hash = "sha256:1990be9a9311869b551e6a997ee84bee12ea38fc978d5fa7fc0119caff2f9ba5", size = 78669, upload-time = "2026-05-30T12:35:28.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/58/7ea5e40e7d2e84b7af8215cdf1b06159670fb0c6abf9d34bd85c4a029f2b/pyobjc_framework_coreaudio-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:22451de9c391d6f82a89f8cb9a2574d89da7534ffaaddfb0b6b034709a8df5be", size = 35134, upload-time = "2026-05-30T12:01:16.78Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4a/e4ff49bbd5a0f24d32ace77b922a660799b43bb1f27be70ddff49bb1fa24/pyobjc_framework_coreaudio-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c74eb20e20597b07a702a24ae9fd8bb986a51baf24c503e5a4de2511dc01114c", size = 35129, upload-time = "2026-05-30T12:01:19.931Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/11/b2c641e4aaf79ff664c081ea09a79366c60406b36e80bece6faec83bf7a5/pyobjc_framework_coreaudio-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:038293a480ec3afc902541ece05404fffdb915f0a6ad60fc81156beeb256cc5f", size = 35395, upload-time = "2026-05-30T12:01:22.951Z" },
+    { url = "https://files.pythonhosted.org/packages/14/3a/d2905ed8f0bfd74d7284e4018e11bf22f027e3ce7921a3298322d2273b4b/pyobjc_framework_coreaudio-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:505564f35227b6bf3bcfcc950edeae81628724202eb2a49f4bf213be39589521", size = 35423, upload-time = "2026-05-30T12:01:25.959Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/33/cf17a929f444bca49a88f4c059868eda4ecf94ab7ab89e4d47b943d5a824/pyobjc_framework_coreaudio-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1640bf44b001c960ae7ae84a43382141711bfbee439c88dea3872c64556e0308", size = 38179, upload-time = "2026-05-30T12:01:29.23Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e8/6fa5951c9c2f87fa7c973fe179d53245f49e0878221305e01eb0444a218b/pyobjc_framework_coreaudio-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:27ef90a6414bbb156a8f2ea22afff5af080fc7fcfb570f215739c1ca136544e1", size = 36672, upload-time = "2026-05-30T12:01:32.506Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ef/227b913bca61d3cf1c7be13b3fc8b60eb4895a6dd6a2371540f75cd1c2e2/pyobjc_framework_coreaudio-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3fa7e25e6b90dab26bc9f94ad058e0346424604daa103d03ebbb6c2636772c1a", size = 38281, upload-time = "2026-05-30T12:01:35.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/de/d4c9de8311c73db5de4f75de88ac049990574c1f3dc7f2fe60879b84f482/pyobjc_framework_coreaudio-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:4aba12b357f4e429a5c8a1bf6ccb7b5902ee8726863744284e3f6ae9b76fbdbf", size = 36706, upload-time = "2026-05-30T12:01:38.854Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/77/84f082096c107dd15956ad4752105e794efbcee415db5595bb2a376a5f17/pyobjc_framework_coreaudio-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:7f8ebd42735ca954d457c87e815da632e2ccd3b55ea501cda488389dd1f37093", size = 38314, upload-time = "2026-05-30T12:01:42.106Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coreaudiokit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreaudio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/d0/189f067979cd117cfb1464dac24bd64e1d4127b09366fbf17a9bec84984b/pyobjc_framework_coreaudiokit-12.2.tar.gz", hash = "sha256:cb743400fff2cc0ee5837d124c1665135559d8505d28996423ed4a609221614c", size = 20916, upload-time = "2026-05-30T12:35:30.615Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/e0/b3868bfc554472da4509aac71794f8ed0ff4e3950648cd5508b82750565c/pyobjc_framework_coreaudiokit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:76a562dffde10d87c208d9f9443545e3dd2b596d7a1541014642b4f75aebd7e9", size = 7254, upload-time = "2026-05-30T12:01:43.866Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/47/c998217a4714984ed0de0aecc3d756dd2f2ac16d03fc3d6bf50ff4e58efc/pyobjc_framework_coreaudiokit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1d26f4b1751c1351450f4446cf9ed549de2109fa984bfdb700666c1123eaed0c", size = 7256, upload-time = "2026-05-30T12:01:45.537Z" },
+    { url = "https://files.pythonhosted.org/packages/33/84/b9b3436b22c97d0c8fd56214d49c1f41f90787377aad6e9c8abd1984ffd0/pyobjc_framework_coreaudiokit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9ca439517d0780dfa9d85175a6a1db29b89ec2c55d1cd8711ba6a6433f9d637d", size = 7272, upload-time = "2026-05-30T12:01:47.161Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e4/d59c8bc9f0dc3c953887fa9b5be06ffb6b007e3fe931b4faebb533c10e1b/pyobjc_framework_coreaudiokit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1da5bdab7f4d3c3f6b420f3d57e28a05c620e71cd3310499d415db0bb1f65c7f", size = 7286, upload-time = "2026-05-30T12:01:48.762Z" },
+    { url = "https://files.pythonhosted.org/packages/06/69/e46f04648626f8c70cfb5e024fd52a3ab3c832e40039b7d125fe62d2a49c/pyobjc_framework_coreaudiokit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:baaa6b2c32fe2cd2d554f0503b773710f21e061ad544773c86d7df95ddd983ab", size = 7449, upload-time = "2026-05-30T12:01:50.363Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/0a8102a256bfbda603b94856ccf4c840658956e3b469725559af132984b5/pyobjc_framework_coreaudiokit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:bf135b76cb36ef940ef340cafe233882edce97391e591ad635c6c1fbaa60565f", size = 7352, upload-time = "2026-05-30T12:01:51.811Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c4/9a05f93a0efdb13b1edd0422d9b5508e334d13bcfecf59afae98665b2572/pyobjc_framework_coreaudiokit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:680800157ff8e1b3f8f3654fc9d1f92b3919aa550c4be2fc926859b87374e20f", size = 7508, upload-time = "2026-05-30T12:01:53.289Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/9f/97cc6d01cd4d31c76ede65ad85a63ef32171b5c40edaa56b6efe0a41efc2/pyobjc_framework_coreaudiokit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:42471d1aa5240df4596d0c236b3d037827be66f6b4faa86fba743d2016902160", size = 7347, upload-time = "2026-05-30T12:01:54.741Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/72/b333b5ea068ad7c4bee7c83259f95c8a703532049650c828da09039fb90d/pyobjc_framework_coreaudiokit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e06953ff761da08123cd18225d008f6b6c35f1809862d46bfe825f618409acc8", size = 7500, upload-time = "2026-05-30T12:01:56.203Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corebluetooth"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/df/bee7ba216f9fb513710aac1701b78c97b087b37fca8ec1806f8572e0bbb3/pyobjc_framework_corebluetooth-12.2.tar.gz", hash = "sha256:8b4e5ca99953c360c391a695b0782a5328fcecafd56fdf790ad709e932feb306", size = 37552, upload-time = "2026-05-30T12:35:33.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/2e/03974693bf040ff819f3141f4ee88bfd190407370e83fcab70472698eb8f/pyobjc_framework_corebluetooth-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c2732cd05d26ac1541ce41cc6ece4d94108601ed503ddfe6dc6afd36a834cd65", size = 13164, upload-time = "2026-05-30T12:01:57.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/2d/ee819fde6d48f2d43733ae40097f4872e1129fbca40847d434939cefa552/pyobjc_framework_corebluetooth-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b03beace02ca1963697f35faf4d3d0263f707e0182f67950212c890dd9d19e6f", size = 13169, upload-time = "2026-05-30T12:02:00.003Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9a/99e61547e61b0e38cb13c67931f9ca9bbd1dc72c1ff78322c7c3af805e8b/pyobjc_framework_corebluetooth-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:31da3686ea55e9f7f8fc321fe2fcdf23827acd24c91ae1798e47e1f3a8355ab7", size = 13191, upload-time = "2026-05-30T12:02:01.811Z" },
+    { url = "https://files.pythonhosted.org/packages/25/eb/04f0ea541e6df3b7a328fe63ed1f508898d84910be66ae0f4d08103ad5a1/pyobjc_framework_corebluetooth-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b43a21eb9388453c867ce82bf5d475cfce4fe2ceaea974474071f1cfd178f40f", size = 13205, upload-time = "2026-05-30T12:02:03.831Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b7/502b1e5ff1feede7fbed1f28e1fd14604cf564e4a4f5d4f33c93a4706739/pyobjc_framework_corebluetooth-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:162623f74c85041bb8a2c9a8862cee6674531d603ad7a8d65a3efc81619f84c5", size = 13389, upload-time = "2026-05-30T12:02:05.647Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ef/a75bd6c17e012f7d73a8a2d94e324528a82dc06451b6019d910b1a993864/pyobjc_framework_corebluetooth-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8a3b35a1253de626d5efe705dda36a4f1fb8753e48aafdc4dbf99dc9c9526d86", size = 13196, upload-time = "2026-05-30T12:02:07.462Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d7/11a8a90463e6a3928274e65bd17acaa3f0bfbd9c19a68b93c61cbc4fa379/pyobjc_framework_corebluetooth-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:bd0b9e7bc2fffcfa4843d7f103e1e927ce37817a70932d080378e1e29a073381", size = 13387, upload-time = "2026-05-30T12:02:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/10/d0/d5cc4ba6dbe21f6f4c90e8f0087254f1f742134580394b763025416ab7d2/pyobjc_framework_corebluetooth-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a2dd4bd8fde13b97a3339a42d6703c9c9b148663e2e23a184ffe2877c8e51470", size = 13192, upload-time = "2026-05-30T12:02:11.41Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a0/964b18affc8f6b582ed891f3b59413452fd95acce4adbf070a389b5197e4/pyobjc_framework_corebluetooth-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:42db087cd3a328abc620c76c7f708d7c2b451f3dbc0779983812a0c84320fe60", size = 13394, upload-time = "2026-05-30T12:02:13.443Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coredata"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/67/e3eb3661c72ee1bd97eab9f6fc5121987f8f8f78f47d07418c1ef6f8fd1c/pyobjc_framework_coredata-12.2.tar.gz", hash = "sha256:1942049d656e264f47177c2fbd84314839bf55f61a825ae49f4fc7b0ebb078da", size = 143296, upload-time = "2026-05-30T12:35:43.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/25/8d4367a5bbcf5d911cbccb5f30b86728659eb46ac19ba0a79f235208c39a/pyobjc_framework_coredata-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:70d4fe5a2b5d88d85a9e433ee84694879c447ddbd009265f1f9dc354a6809615", size = 16512, upload-time = "2026-05-30T12:02:15.531Z" },
+    { url = "https://files.pythonhosted.org/packages/12/e5/5ada25156fec6802ea5495298783aaa19cbcedfff81a8663133bcac6bcee/pyobjc_framework_coredata-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:69dea4cca7b279ec66abb9f3804763770917b232c6f3df460dc150f687136c1a", size = 16514, upload-time = "2026-05-30T12:02:17.734Z" },
+    { url = "https://files.pythonhosted.org/packages/33/54/ceac7d7f2c0a56ba8daa931c8ce44b9d050c9c2a46e20ad7bc75b18c27d2/pyobjc_framework_coredata-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:32a28504e3fd2ba2f4da8019a5325010f21d1395062946f143ed9672cb6a244c", size = 16525, upload-time = "2026-05-30T12:02:19.832Z" },
+    { url = "https://files.pythonhosted.org/packages/26/44/0cec6323ea515dd5a8b5382f78e871f905aa295858716b53d4db8162d645/pyobjc_framework_coredata-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:36c1fa33a8221339983eef98c2bc9894813a51f650c30e92fbd3cd1e9f51921d", size = 16539, upload-time = "2026-05-30T12:02:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a7/844e5e193cd8a5ac4620f40fb40d1d039282e17cdc19e1f50addf36e415a/pyobjc_framework_coredata-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4ed76ef3c44a0f7f488ac445fe06878e90fedd55c6077841efbded1b125f33ea", size = 16694, upload-time = "2026-05-30T12:02:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a8/5dd670a58f82fb4adc1b5b9634e66572d6331a7e849e02ac36265b4d2753/pyobjc_framework_coredata-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:1c68b2fac8f9bf591296253f54742804eaa3c99844b487988e0090f51e69a645", size = 16597, upload-time = "2026-05-30T12:02:26.178Z" },
+    { url = "https://files.pythonhosted.org/packages/de/b5/bbd4e22732cce98979a2a7ba8798f52a91342036fbb89ea30df9f3ca1b34/pyobjc_framework_coredata-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1b48293e6d4f2dd2fc661e1aec65e71e2b4ec4fea9c61ae41eb265e61d4b89cc", size = 16756, upload-time = "2026-05-30T12:02:28.349Z" },
+    { url = "https://files.pythonhosted.org/packages/66/36/8592d816be70e5e64fcc02489f65d7fa55fb8ba7706e396a356d550a7d7b/pyobjc_framework_coredata-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:1145c11f4d0eeb7ec51818318027cd0bef8e65400186463d6f4ea5102ec2f160", size = 16594, upload-time = "2026-05-30T12:02:30.298Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f7/96f9c101562f3f6f4b7bfb728be64eb10730d696a9c2e923df91b2156a48/pyobjc_framework_coredata-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:262a9cdaa31a38bdf9087c4f89b235b389d1c778ab554a881559c3e0640ce540", size = 16750, upload-time = "2026-05-30T12:02:32.612Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corehaptics"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/c0/fa97c71176260bf0fb764809034e2ac4a6f3e47701d7526ff5844da8a1cf/pyobjc_framework_corehaptics-12.2.tar.gz", hash = "sha256:d55b39ea4d998dd50f980e8c1800df2558099b96a99f25813bed702ebc2bf43e", size = 24902, upload-time = "2026-05-30T12:35:45.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/19/b4842ca6182d754360289384aa3b4adf3775a6c4ec30818c8b8c1c473792/pyobjc_framework_corehaptics-12.2-py2.py3-none-any.whl", hash = "sha256:c04c64212e7e7a0859b23b939a4375a349176317cb2b11553d388965d9a8fec8", size = 5413, upload-time = "2026-05-30T12:02:34.2Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corelocation"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/81/f074ac32e9af964ba873ac646ceac9d372057ff8d1db01d31e8f5586a1f6/pyobjc_framework_corelocation-12.2.tar.gz", hash = "sha256:1e0f389140707ece2bb4d08def421e25b792dcc2a34000dfb128dec2e685d725", size = 60306, upload-time = "2026-05-30T12:35:57.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/9b/c1849ca284e637b1552c2d06ba0fe7e8fd43e353ab390b8280165cf2170b/pyobjc_framework_corelocation-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:09f52775ffa96af024cb810bcc606aeb5e41545b6f23cf40235dcfdddaa2f007", size = 12805, upload-time = "2026-05-30T12:02:36.195Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/f5988421b621f44a8e7073efd65715a61f737fbdf623ddda877d97ea6f23/pyobjc_framework_corelocation-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a44f5444b78cd8bb1c75c372e4418c0a2c37d5c9ebd60e5d20e3900b0192e203", size = 12804, upload-time = "2026-05-30T12:02:38.148Z" },
+    { url = "https://files.pythonhosted.org/packages/55/43/65d5d913e2aff660c71cfe6acec29adb6e461dcce3443a18c2bae03e6d67/pyobjc_framework_corelocation-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4f556f56955e9b909fbb0ab510449c89802f2f9e287bad402d0cd1b5c4e73c4b", size = 12822, upload-time = "2026-05-30T12:02:39.922Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/af/a8cf57caa11c1ce96bb19855ff02fd17a7e7f1d1ba3a890369be1f731f72/pyobjc_framework_corelocation-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8b355dcc544a2ab525744b777431cb902c951fbbf2281350b86323eb64c4b409", size = 12843, upload-time = "2026-05-30T12:02:41.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f8/4d1aa9f9736efa013cb73022df9f58beca9639d922613be0f2be16e0c709/pyobjc_framework_corelocation-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7515eda941b03c4e4f1e6d596383d4788997a05e30ce210ae250326ca418f240", size = 12969, upload-time = "2026-05-30T12:02:43.671Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e2/90e8bb8654bda885e6acc8f15be2544f1c7cdb58503389b970dca5ae5324/pyobjc_framework_corelocation-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a3b70cca208369e8c68afd8cbe865d25829c34b338309a61b3b354d3824055a2", size = 12822, upload-time = "2026-05-30T12:02:45.678Z" },
+    { url = "https://files.pythonhosted.org/packages/84/70/4e8ad2a3c4649af2f5f2f132d800a13e1743581d3871304e80d8dad32e67/pyobjc_framework_corelocation-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:54d47d7f8df4383a1e3d1201a80520068222fad373caffb8adbb134ef16b9b7d", size = 12971, upload-time = "2026-05-30T12:02:47.454Z" },
+    { url = "https://files.pythonhosted.org/packages/59/95/13c20405ab3f561e20c13d2b7bdc4d1b2deddf9f00476b50c74a9be705d3/pyobjc_framework_corelocation-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:472b95e1a6ec6f14545d1d523f03a688d60a32ad722a267a3f9539d7d38cc94f", size = 12809, upload-time = "2026-05-30T12:02:49.443Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/76/23c7147aeaaf7c85a6e3c140c560244de5feedc8f9834b5f65e526f05815/pyobjc_framework_corelocation-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0f24d4ecd314691d773b98276880864dc3899605b2d708c75532acaf9c517074", size = 12961, upload-time = "2026-05-30T12:02:51.232Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coremedia"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/63/9b25f9abb14e8faee219e72953c3cc4bed48b0de4b86f767f073fd2fdc35/pyobjc_framework_coremedia-12.2.tar.gz", hash = "sha256:95ed2063cc48d73f6eb06f4e603372515b5b009bd2d6e547f90bbe9e64217206", size = 98236, upload-time = "2026-05-30T12:36:10.943Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/a6/d5646ebe79c3c37e938efb321363fb0eef18ea2ec9a0513ed94201105a3e/pyobjc_framework_coremedia-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:422d8af0e8f62a1385aa86228e47ed7c01405831102bef1ee43f07320711c082", size = 29496, upload-time = "2026-05-30T12:02:53.923Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5c/06348b4e27a7332c40601b04a2714ce4080ee45459486283101e42348978/pyobjc_framework_coremedia-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:171b8dfc6ef34678d46470b6bc176e5c3cbb39c81abbce03d276d5d3680a5ee3", size = 29501, upload-time = "2026-05-30T12:02:56.845Z" },
+    { url = "https://files.pythonhosted.org/packages/99/db/966cad806594831379785af07669e5f2c1784e88c775a381cbcba215cfa3/pyobjc_framework_coremedia-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2eaddb2f4e25d7b6f32d4b85b828cc89ce6ae5502d531c2913b90d93f85fc2ae", size = 29400, upload-time = "2026-05-30T12:02:59.537Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/00/412b4b98b6c6b266a73be2862453d98a6f7f95e911c216ad2117831d2b18/pyobjc_framework_coremedia-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e992147e7b0c8c435f1bb786c8c610511453cf54bdf6c6b4a17e05936bacc44b", size = 29412, upload-time = "2026-05-30T12:03:02.254Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/61/e3285f4b7a889a334ba06c6daef78f32e39de40ca7b061443e39e0faf42a/pyobjc_framework_coremedia-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d9586fb8ae22ab1a500e812e5c16dde09b3ea75613a8b5ed61d17cd9ba75c809", size = 29472, upload-time = "2026-05-30T12:03:04.911Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/6e/66ff680d04e1e16321aca36524ef3b442de89330edd06275b9e2303b6af9/pyobjc_framework_coremedia-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c1adf7b6fcfb4c88bc2150c6f0366c19774e46c6978ebcfb7c70d02753bc0183", size = 29454, upload-time = "2026-05-30T12:03:07.771Z" },
+    { url = "https://files.pythonhosted.org/packages/74/dd/e61aaf92b4b7074b4f2609cd1a9c485410e76549a7f68ff10394e95396da/pyobjc_framework_coremedia-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9b75c3228732d78dacfac7a39f52470606e949f07c940b45ba73588db41fe73c", size = 29500, upload-time = "2026-05-30T12:03:10.304Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/aa/b3b65aeeb52cb08fc151fc6102d3127bc308e7ebd078410ff6832001d562/pyobjc_framework_coremedia-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:fff54b5907cd346daea1bf4d6554fd6da1d69ee9bf012774c3b4ec972f4257a6", size = 29485, upload-time = "2026-05-30T12:03:13.023Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b4/5c25ce6eaefc509a90c8f6efbb0a2a27e223552d4551c32cca514bd84ee5/pyobjc_framework_coremedia-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ee5889c07f61d16f8d195a793a7f0ebf7f5c4eef4d1ef2fdbf5c823c74e242d0", size = 29541, upload-time = "2026-05-30T12:03:15.744Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coremediaio"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/24/7c8b41310cb874bd308c875252ec6872198f19f3be27aacdafcd98a4b27e/pyobjc_framework_coremediaio-12.2.tar.gz", hash = "sha256:38f656ebe897262463277d4551fc6cca4ac766629476576f040b34e84c956506", size = 56592, upload-time = "2026-05-30T12:36:15.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/d4/b50c9cfa553887847223006f02d3406dad15c1418c5025daa8d40b2beb0c/pyobjc_framework_coremediaio-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bd3ee9dcd878337161d613a8346dd7012acab7638d83d68904d0bb9e1f65d2b7", size = 17285, upload-time = "2026-05-30T12:03:17.786Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e5/d59aab23cd2102c50f849afbc3c58becc869f90229ac6388a0beafd1c1f9/pyobjc_framework_coremediaio-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:43f21abfff64627906d66bacdc1b1bb4927607104cee2d3f29dcd0e3b22da1a1", size = 17282, upload-time = "2026-05-30T12:03:20.156Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ab/0e0cc4faca5bdb958c5da765de9d10a43f65ab57c1d400e06497a94221c6/pyobjc_framework_coremediaio-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2543d464db2b169571ec757241813c761abfe31033a533830f6e62d044a31edd", size = 17335, upload-time = "2026-05-30T12:03:22.155Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/4b/65ed6a4af11af67ee64b5fafbf12ef2d56dd38020e88d9b67aed2128703c/pyobjc_framework_coremediaio-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:95cfaa7b8a0c970cfacdc620991345a3b55ba641a8091a1467a94310fc11b279", size = 17306, upload-time = "2026-05-30T12:03:24.356Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6a/4b04551647534735d788919a8a62b5261b249654b6e427f27d12f7e5377f/pyobjc_framework_coremediaio-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f03e5f735b99508706f9ccf5233eaae4c53399459b6c87670112dcf1c0cd791c", size = 17627, upload-time = "2026-05-30T12:03:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/af/e39b0afd12229c9fc21945307d80f27f2e8548171d04327e4b6c8a601220/pyobjc_framework_coremediaio-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:057d63ce28a64589d4ad103c5e9b0ef1c23e45e63693314eb75de9aba78ae7ff", size = 17325, upload-time = "2026-05-30T12:03:28.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/22/f206988eab96acd7e7203b93109d93a2812dcdf320892657a8b5cdd27221/pyobjc_framework_coremediaio-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:03b68e48f0820f9aac4f2250ceed138c097fb806cdbbd064ccc463709e828b68", size = 17622, upload-time = "2026-05-30T12:03:30.479Z" },
+    { url = "https://files.pythonhosted.org/packages/12/2a/4afa7f2fb64b3903e0ec4eedf51130856aa768c73de9bfb90720d706d259/pyobjc_framework_coremediaio-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6fe8353ca1165120f69f8bc0aabc4041cdeda9b6fc4f3bda4ded601680df3061", size = 17346, upload-time = "2026-05-30T12:03:32.506Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/07/f7006431545f928f02eb1779abdf8e042238740469f137d20d0f0501670d/pyobjc_framework_coremediaio-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:9ce96c501bd64fbeb52e23332b72633f8b1d2f9390f01c5e1787c8f711eb4646", size = 17628, upload-time = "2026-05-30T12:03:34.549Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coremidi"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/ca/ccc156899161481cc2c22529645d590a6f570c0583567ab6ba4a0df71bbf/pyobjc_framework_coremidi-12.2.tar.gz", hash = "sha256:a00e1d906f1a1fca302c867406ed8e1e23651b1551ce1943e9495e7665b6b0d3", size = 63475, upload-time = "2026-05-30T12:36:19.463Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/32/4a566d2e48ff9a6b021d6607355af0f9f9c86f0075b0241189f577468888/pyobjc_framework_coremidi-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1cff986805ddf6fa4a1ea697e13102263284c726391a43779d4ca401e8c69904", size = 24467, upload-time = "2026-05-30T12:03:37.007Z" },
+    { url = "https://files.pythonhosted.org/packages/26/af/70be31b1c4460cb6f5c6a2fb83212bd2c3ca9565d7b2244364a296dfa720/pyobjc_framework_coremidi-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:151d7499a9e5343842c5deb67df8002ab22ecff92a0a238529c3d9abdbab9e4a", size = 24470, upload-time = "2026-05-30T12:03:39.75Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d0/5c7de6a375f63dd3bf772be75661f0cf1ed1949acdd89f539a32537fb03b/pyobjc_framework_coremidi-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4d480a526fca15ea16bb9e7fc7e5a7107c6263c8f791efc673525928f45a3c30", size = 24556, upload-time = "2026-05-30T12:03:42.158Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a5/b87175347becf46c8ade3593da8fc660d46a5fbf2794f5d7fcb0ca4694b6/pyobjc_framework_coremidi-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:86c7114af6e06650a84eeb781b90bfb3569304f36a40e38eb2e6113e72385444", size = 24584, upload-time = "2026-05-30T12:03:44.625Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d8/2953bc296baaed3a4207131d9b90797b6a12ebee204c92addc14b6c7ac8b/pyobjc_framework_coremidi-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ae8c2e5113fe8a4afa4ce9c5231a5bf8a2c25dccc909b80d0fdd9ca0996e6d1d", size = 24734, upload-time = "2026-05-30T12:03:47.053Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/17/098da114f1f628551a48570a077747505afeedc63c3e6639dd7d17421e1b/pyobjc_framework_coremidi-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2d962b3f77f60fe608b845b903845585d0a47aed6345192d5a22d3b1ed205f1a", size = 24626, upload-time = "2026-05-30T12:03:49.642Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d4/10a32149671d8813251ad1688fcac5c1d500fa40ea98c9f7581ad4fef18c/pyobjc_framework_coremidi-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ff07b6a479c2a273276f156e598c02c59c9c1cf4ba8b34c7e1e938df484388a0", size = 24791, upload-time = "2026-05-30T12:03:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/24/8f30c3f25775a2458d0cd4003ba72fec22f2b9de776f6c4553785b699749/pyobjc_framework_coremidi-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:cd719cbd917606fff46e5eb937c472f10986036d1f00c7af237742825ac67b81", size = 24614, upload-time = "2026-05-30T12:03:54.578Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/7a/3bd8616d43311564b7286926b2e071de3cf0db2711e3c59f9474de12533f/pyobjc_framework_coremidi-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:2f7e8a895852b4c3cfcc20cee8a1bd63af7577e0fe79a2e79de87d4da8ee671a", size = 24779, upload-time = "2026-05-30T12:03:57Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coreml"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/a5/ee39e19017348fcba998de71f4f425abf0563b693fcf5bf7f4b84232d538/pyobjc_framework_coreml-12.2.tar.gz", hash = "sha256:884f1f68c7a74c56d26858051da8a1e19848be97f2c4b06b32ae93e505109583", size = 49266, upload-time = "2026-05-30T12:36:23.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/0d/95d358a3cd73b2271f6ff69d072c087656ca156ec72a67d47c466698b0a5/pyobjc_framework_coreml-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8127be60808dba7e945f69598664b1a52e1ee6331f3695da08e8642b23b10f8f", size = 11928, upload-time = "2026-05-30T12:03:58.933Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/9c/b96593b8200d340b69cd00bb64376c8abfc2599dc240ffd6b2208545a235/pyobjc_framework_coreml-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:053f03cea0e7a4ab32ffaca03825ddbf1800a6a1dee1fa0e69e5b3948c5d6a56", size = 11928, upload-time = "2026-05-30T12:04:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/55/8bf3985e5639d95a44ee6431ee00f1ee823a36f9d1d5a5fe5efb60427386/pyobjc_framework_coreml-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:011dc67f11144817c9cf728cb7ae3d520001c4e099f9efb6a4c9fec4c19e6413", size = 11950, upload-time = "2026-05-30T12:04:02.515Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/42/93b24114d5334d7a1a5031788947f14f487c0aec4529ccfd7f78611c69b9/pyobjc_framework_coreml-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:64b66797b9cc1b20d726476f78ee2e69540fad60676d5dbb120530fbd429d3c7", size = 11966, upload-time = "2026-05-30T12:04:04.368Z" },
+    { url = "https://files.pythonhosted.org/packages/08/da/ccec3d91d7a740156d720056002befda423f3960691e4290460910d352e3/pyobjc_framework_coreml-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:774a28259888c1bc247e8ed5ad14d7fc8baa975591c89669cd952e1756cd7d48", size = 12188, upload-time = "2026-05-30T12:04:06.09Z" },
+    { url = "https://files.pythonhosted.org/packages/99/27/577ae403c3d2dc6c49dc18e8b16d315c54fcf31cdbdc839523ea40af4777/pyobjc_framework_coreml-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0ab804c7fdeedaea8fd6e1ec832a23d57913b280d3cc40419adabb0032271160", size = 12009, upload-time = "2026-05-30T12:04:07.798Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/605604165c57a329141436b750a0ac48860f59d73a015ca1a8abeed316d5/pyobjc_framework_coreml-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f55eb83825308fd759e053dcb9844ae5106e371645e7dcdb0777f161d59f8280", size = 12184, upload-time = "2026-05-30T12:04:09.554Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e8/048beb8ab0df464b493a9c376b830d8cc1c84123d2ea44e5e80e0bd6a60e/pyobjc_framework_coreml-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f5ebf148cedb1ee9b5183003cdb64033e97c7f50b4d073684e0fb54e63761259", size = 12004, upload-time = "2026-05-30T12:04:11.184Z" },
+    { url = "https://files.pythonhosted.org/packages/de/9e/b20114d45562f0f35ef0feb9aad604aac28a587ad7942b8c121cb9e6a85b/pyobjc_framework_coreml-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:82dded9d153db057aae965539cb28b4dc43391e5e07f38ac60db83061a9453ca", size = 12182, upload-time = "2026-05-30T12:04:12.841Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coremotion"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/38/90010239d5d6721d8670cbb0edb71c39a1abca0cf22cecbeba7cbd490de5/pyobjc_framework_coremotion-12.2.tar.gz", hash = "sha256:8a2a06809b78a72cad52f27aa830c883e19ca36b57f8418ccfaf29773c5dc5ac", size = 38055, upload-time = "2026-05-30T12:36:26.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/52/6117d2e6e324a8f5248ccbfef0d40384ece025786b2dd54401fcca87613f/pyobjc_framework_coremotion-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8ad115ade05565b7199e09a8bc879b26e98eb0c1295a5fba93d0fa261c8c6869", size = 10411, upload-time = "2026-05-30T12:04:14.403Z" },
+    { url = "https://files.pythonhosted.org/packages/29/1e/5841eef4b891cb90385d2883598907642a2ab5f4e9cb3001e74b1c0c8236/pyobjc_framework_coremotion-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d0ffddac1e843fd83dab1fb0d16c4ce7a63615a834cec5e7469d4db68782b8e0", size = 10411, upload-time = "2026-05-30T12:04:16.114Z" },
+    { url = "https://files.pythonhosted.org/packages/15/f9/4ef3ac3cb071cef44fafa2de17d3e482c9c519ae5c1cdf00e3a6aa86351f/pyobjc_framework_coremotion-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5b987d542146d75c890c205bc8c125b546c7bc35afb14d5156ffdba16914bed7", size = 10428, upload-time = "2026-05-30T12:04:17.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/62/606ca7aa90686f1eeb48d9870409bb1132ade70afc185816f12f0bce8f30/pyobjc_framework_coremotion-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:554bd583a6c36c659e83102832b65e6829c9f4c5d7dfe30f76e4fc62ab2ae13a", size = 10449, upload-time = "2026-05-30T12:04:19.591Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/7b/b5a942442e0b716319c442dd7a8cc2232b682509034c832898bbb7ba3783/pyobjc_framework_coremotion-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:657fc69c6446878c0a6b5cc53f689f110a8c4bbf0d57ae87f1d19ebf7bfc2889", size = 10597, upload-time = "2026-05-30T12:04:21.265Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ef/dc1a28f9f1fe86dd2b8b84bd1273cb1dbbf9fcd150097002fccc679eb4a4/pyobjc_framework_coremotion-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f5d1d3b4921cb334a4951623c85d3d5a2e79d13262d244e5355e42ffc0fc09e8", size = 10514, upload-time = "2026-05-30T12:04:22.828Z" },
+    { url = "https://files.pythonhosted.org/packages/10/7d/b3b3300224f0c26381911d6d58214c0fc354d3fd75a4d2c214bf880784a5/pyobjc_framework_coremotion-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:03968db63df5b5898973936545b9a800165ab33ff672823186407e2a6d0e179b", size = 10665, upload-time = "2026-05-30T12:04:25.173Z" },
+    { url = "https://files.pythonhosted.org/packages/24/3e/c1e7fbb6d32e2ec0d5777e7eff11a96bcb564c70ccd99dd7bf68dbde8ad2/pyobjc_framework_coremotion-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:681b01d4677fc9ca6b0ab6da876087198957141fbf0799b5892beb71fbada5e4", size = 10503, upload-time = "2026-05-30T12:04:26.835Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c9/a35d41cd83e9743fd26fe8fdc039b88fb8549c702524e97d94d0c864288c/pyobjc_framework_coremotion-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:55dc932bef0ffa3b23e7e07a4016f4fa36687204528187c17dcb19cc4d322456", size = 10662, upload-time = "2026-05-30T12:04:28.447Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coreservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-fsevents" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/3f/92b7df81848039fa9b3eaa0181d9969f42dd8a208e8ba8b8d4a648c2cd46/pyobjc_framework_coreservices-12.2.tar.gz", hash = "sha256:ea52c77e9a162b6823c3b364f391b4369d967365e5207a0d45cf6d0e37cec0e6", size = 399867, upload-time = "2026-05-30T12:36:50.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/e4/66993060e58d08a7f06760d5b28e05f2fb7a4b9b683c59532cac5c5e3775/pyobjc_framework_coreservices-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c8218a3e0f0814c6e9fadc4712ab4715097f0d388e09e85fc0a025e56b67ebff", size = 30305, upload-time = "2026-05-30T12:04:31.306Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/70/998b380bdc39f61e8b4eabe24b0eabaa16b586b91fa09fb285e859bd51d2/pyobjc_framework_coreservices-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:305a2c5c1830ac3c0bd18d08d7efee8345dd655d5cc79d84d3c43bb539b2f0e6", size = 30308, upload-time = "2026-05-30T12:04:34.255Z" },
+    { url = "https://files.pythonhosted.org/packages/55/61/59b4c1fdbf05bdfa19bed5cc46b271c37f486dea17df67812702b3551713/pyobjc_framework_coreservices-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0a3f9593b672b52ff31674104bcdd6ce6bf9f4560ca61380f2b35c904f8d77d0", size = 30318, upload-time = "2026-05-30T12:04:37.083Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ae/ca8c1386df09bcd7175f5fa8c37cf09f458b72549843e5454b2562db7194/pyobjc_framework_coreservices-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c07effb4e1bff841eec4304b759fe3ef73301a7b2ae3e5e3e203efe6c45e2bde", size = 30332, upload-time = "2026-05-30T12:04:39.951Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5a/1413029dd792fec9e9c27c18c6a48fccaad3ec675698fc2db6eb46d5e51b/pyobjc_framework_coreservices-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:fb713264a7151a92bb11e6125da06af343037b96f6f8021e7cc8f8ff42897744", size = 30342, upload-time = "2026-05-30T12:04:42.727Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f0/fc6dbfca3199ccb719c7591b478cd077746a924589383cc27bc426b64245/pyobjc_framework_coreservices-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:183a75dc6edeaa73f6f49b857bd5a61e522abcb5d7df1a3bee169896d0cac181", size = 30358, upload-time = "2026-05-30T12:04:45.682Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/2f/e3e711b8fb916d183f9e81c0871bb718680fd36277073e1eb962e29db10f/pyobjc_framework_coreservices-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:c2255f66669f8a70b3badae5d728abb323a042008c01b825333f6bcb1446e2c7", size = 30374, upload-time = "2026-05-30T12:04:48.474Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/32/ef39a7d4bd6fb67dd69e3680a3d27b7be0039055ced4027c7615a102617c/pyobjc_framework_coreservices-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:7c32519d13c882b2a8f844e4f4def32eec9bd3f29781bdff85750f80320709ee", size = 30387, upload-time = "2026-05-30T12:04:51.296Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/11/31ca4a107a68797b22daff1ba35d61e7b1bad951c17c1ca61c38059966ab/pyobjc_framework_coreservices-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b17f2743ac0fe1245b16bccc2abc2568d4b33f0655b8f805d4bf19754284363e", size = 30398, upload-time = "2026-05-30T12:04:54.255Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corespotlight"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/c7/ea47b22b51e9e0bc69dc4f70bf19d18c9282df5d1c11343138ee01f7022f/pyobjc_framework_corespotlight-12.2.tar.gz", hash = "sha256:6aefcef43d3d3bf3e7cbcffca053a7dad07c434aa11b117dbb39d5cf596ee829", size = 45678, upload-time = "2026-05-30T12:36:54.364Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/31/1c4b3bf0740b4f62287493bd73f388327d93af411fc52ecdda7816378d6e/pyobjc_framework_corespotlight-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f7dea56b3042bcf36e4c1e6d71220ef2cf3e47b7da20d65ea371ef0bc8b3f0bd", size = 9986, upload-time = "2026-05-30T12:04:56.111Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/26/6e2389fb39f50b37c739c3edc323f9269e7bf9b0c9b70528f32a2c1da690/pyobjc_framework_corespotlight-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:da63d132bbe0e0a3d90f79f3eee9227926189d2a4d0801ff2a879b6235402cfa", size = 9985, upload-time = "2026-05-30T12:04:57.907Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/3a/a48e6bbe5159a23f946745d395463593bc3eea35a7ae4135a59169b7ce66/pyobjc_framework_corespotlight-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e3d60d1dca50418143e7365b4535c25fe04c66af2f6304bcc4d06e288e783e91", size = 10003, upload-time = "2026-05-30T12:04:59.497Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/bf/79508c58d3f68ce8a564146dfa29ae661d9970f64f2f8615b6cba0b866a8/pyobjc_framework_corespotlight-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d35028c872a89c0450e067c021d64b29c013fe980617aa16e9d9778f566e167b", size = 10019, upload-time = "2026-05-30T12:05:01.117Z" },
+    { url = "https://files.pythonhosted.org/packages/94/46/15463f342139c8c9d95efa0aa434494c3782472fad1ae6e0436f624eb34b/pyobjc_framework_corespotlight-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c0d6b74f497e835f9de97aeacdab7a2c9a1544135dee1c9665b2074de44424a4", size = 10162, upload-time = "2026-05-30T12:05:02.737Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/94/4a9a50d83b026eb924f57399f741397ea999cc947367d78914ecb90ce51a/pyobjc_framework_corespotlight-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:884a7629a98703308b11a3b350899c89ad268aa278b005b289765a13172bb40e", size = 10081, upload-time = "2026-05-30T12:05:04.358Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/7d/a056a2d3ec4ea0e9db6ce74b99cd0c0037e5ddf7022f0b21a3f852957012/pyobjc_framework_corespotlight-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:70e9536e0992d0777ef24e6972788e72bc80290da89c03a84237b9ddb60e3510", size = 10219, upload-time = "2026-05-30T12:05:05.906Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3f/0d7780799604d6d4a922491cfc6db8a12c77544e45228a13d1ef883ef3d4/pyobjc_framework_corespotlight-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:e472ac4d16b0485980f0632b8cd650515de4a6b44958fd370b00490a1f1a1bac", size = 10077, upload-time = "2026-05-30T12:05:07.447Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/59/08223d893ed5b902cb36cd9bdf93668c72cc8e882a092776c99f6cc5e11c/pyobjc_framework_corespotlight-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:61b331e85d12f550797a8010aa2f1d369a2fcd21990adbf3675005dc9e2475e6", size = 10211, upload-time = "2026-05-30T12:05:09.017Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coretext"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/b0/e7ef99240f853d4dddde82c9c0114cc525de7355661b2bf2d5e04cfb1582/pyobjc_framework_coretext-12.2.tar.gz", hash = "sha256:82def2c281347e0677866315675124c84c36e9bc21651d62870cfdcecb7da34e", size = 97343, upload-time = "2026-05-30T12:37:00.996Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/d9/ffbe72f2bfbc4831d6714e6ca4641a22f1b0889c9e032aa14ea17dcfaad9/pyobjc_framework_coretext-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b81b1e7cd9256c5832af98ced9810b3680015a7b015db54276340152cfe7a065", size = 29993, upload-time = "2026-05-30T12:05:11.771Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7c/fc3252a4ccfdf1f0c858b1bae4cd6751581fed66d4efcb14b16939a1b5f5/pyobjc_framework_coretext-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:19caa22d623c73bb3e158b8807577926e3e8f85bc83e4e111e74fd019e07ad57", size = 29994, upload-time = "2026-05-30T12:05:14.669Z" },
+    { url = "https://files.pythonhosted.org/packages/72/8a/52cef4b31d5a6d3c9c426759bd256229fbf6757efec1b7f1ba5c2d051621/pyobjc_framework_coretext-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c1845fbdb96f605c7146c478c5d562961d77aadba6cc40e166fade08e11a730f", size = 30091, upload-time = "2026-05-30T12:05:17.568Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/db/783ae8290da2edb57b479fc474c7d66a319f4fd5f1f32dd642af1fd962ec/pyobjc_framework_coretext-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:09daa6b6befea7c0d673a037d02ed13bb4443ed65d8948329ba6c8a08e06c763", size = 30087, upload-time = "2026-05-30T12:05:20.422Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/6d0a37fed6eee8ed4c950f71cc98355e8ce8d3a38c19aba1bf7ff6ac5441/pyobjc_framework_coretext-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:867e6f56c1c7703f27a7328d42d37cd184151657a3026cf46c0de207cc90a46c", size = 30635, upload-time = "2026-05-30T12:05:23.59Z" },
+    { url = "https://files.pythonhosted.org/packages/26/22/3c6dbe97cb5b121b01f61d575bf202238b0cd6f39f22f15d94179461b677/pyobjc_framework_coretext-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:88b9e705d47a663f079f6ebbca54f5b57f305bb639d5a9d943231596653520d7", size = 30075, upload-time = "2026-05-30T12:05:26.195Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/28/ffd7807c835010839678c6a43b7aa66d956816becb035c2371b8d03325b6/pyobjc_framework_coretext-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:dec9a67529615fbcc7c11a9a655e8d17a6095d94807e5df11e0bda55b37f0190", size = 30614, upload-time = "2026-05-30T12:05:28.997Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/49/8c56735a3758b6570e98a22861becf514057db33abe48f7bfd6e7f533b91/pyobjc_framework_coretext-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:639ba39b119f24198184abf878bc1633355fecb36f8eab57f32956252df30d40", size = 30080, upload-time = "2026-05-30T12:05:31.979Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0a/5c881e86eda55bd4c7d33e7e93a8ef3b327e06203bfe45e16b7f8af0a3e8/pyobjc_framework_coretext-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:06bcb4e7de281423c212a39b3dc9873f09d9fd69da0abe93d987a59761bf265a", size = 30641, upload-time = "2026-05-30T12:05:34.814Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corewlan"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/82/0393b32be2551bbaf09211eff01f92c60f9c3f964d6ace23f14847d88550/pyobjc_framework_corewlan-12.2.tar.gz", hash = "sha256:e0d81a95f6923c3dea9b0ab34fb0b028f5838930a602b5aa4bf9546eb268be9d", size = 35525, upload-time = "2026-05-30T12:37:04.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/47/ee02d4bc64935e58d30bbdd96792c98810d4c8747f495226959d13ee5d14/pyobjc_framework_corewlan-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:fcf9fda60945d37517cb3b8314a6dfb70c3b9ef82546037898b405c33dbe4c2e", size = 9973, upload-time = "2026-05-30T12:05:36.451Z" },
+    { url = "https://files.pythonhosted.org/packages/35/54/d2574e80ddf50709211a160b4256d897893bd646b1b01cfe2dd2493ce2f0/pyobjc_framework_corewlan-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e619d44989c36a233fd35d32817aa0018d1556b3e67c22704bf594b82a7b7e5c", size = 9970, upload-time = "2026-05-30T12:05:38.226Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/87/d2a10c53938c5fe13548ae8cf39c8d807774b99288d25993feca36b6cf15/pyobjc_framework_corewlan-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ded695a9b0e3f4df19325bff6ee6c1ca6f601b6838a1f94fcc02892408e81051", size = 9993, upload-time = "2026-05-30T12:05:39.816Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/31/95f9eea9b71b724a239ca7445f666ec29cef9df7cc9ae3cfa77e1b9c875b/pyobjc_framework_corewlan-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6b922017499d6921a760bf3d359b1705ef31b87a2c4cfe763452759f9dc5a91c", size = 10001, upload-time = "2026-05-30T12:05:41.401Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/07/461ecada55a3d164f095e6e103d1bf9011e00334d2e7ce973048a0050512/pyobjc_framework_corewlan-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3435e7c086ae69522354ec4fb74bcb3bbaefbc4b895680dffe6fef634430d533", size = 10154, upload-time = "2026-05-30T12:05:42.982Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f4/4a6a649323b656cb4ec33453da378bf88b9feb12b61f086efe81efed5d5b/pyobjc_framework_corewlan-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:daac8e5a802e52aec0f1240430c785b1e20219b5fa9928d951e0d8d8f23debb5", size = 10044, upload-time = "2026-05-30T12:05:44.593Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cf/6cc4473726dbcaba595a22ed707ec1dbc04b998d01b0a76088dcc3a7a216/pyobjc_framework_corewlan-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d4116421fac622b0376220ce8dcf2769bd865412a0172fcea4fc3799f741ff05", size = 10203, upload-time = "2026-05-30T12:05:46.181Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b8/b4751f8788bdaf029af09fec09ab352bde587465ede0c24fb73ce9531b1c/pyobjc_framework_corewlan-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:06e722024d349d421825ce2354846c13684777290cd00e525650e064e5a6db01", size = 10039, upload-time = "2026-05-30T12:05:47.861Z" },
+    { url = "https://files.pythonhosted.org/packages/45/70/7ca06f390a382a49545b7a5b4677cf62b81f3f9ffd19b6aff44ec0b43c40/pyobjc_framework_corewlan-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5d31f40aad614fd19d6a9117f9a66f07eafe7a592ddc60258e9bf3f09d2fe552", size = 10201, upload-time = "2026-05-30T12:05:49.482Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cryptotokenkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/73/f77f0dca70fee8a1999700dc878eea1e558d7d2e5088d3bce59e425f23e5/pyobjc_framework_cryptotokenkit-12.2.tar.gz", hash = "sha256:bf070e95f82db3bf8dcb0d67d459df3810bd9dfec63a31982adefba146d9e777", size = 38281, upload-time = "2026-05-30T12:37:07.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/36/164acaeea6cd5b6ba5c3e93caedbaf0c18940f95e1572710bd6f79198c0f/pyobjc_framework_cryptotokenkit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:77067d69b484e18b53e9517c517e8c7c91d39e8822ef673280aafdff99b9ee59", size = 12667, upload-time = "2026-05-30T12:05:51.265Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/46/222349d11573d7777f8790c8a416c3edc7ddd131e32948f6bfabfbab3585/pyobjc_framework_cryptotokenkit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0146ebfa2f6603fe090a29e386d263569f043911694cade1b14e627c2325583d", size = 12662, upload-time = "2026-05-30T12:05:53.258Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/63/a20a4ab7148a732353fd335511c1252b6ffb312c4062570c2afc192b7749/pyobjc_framework_cryptotokenkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eed85a7bdc797abec1d57ea9af9a7e5cd30b428947a75cb33320290c7bf3ff70", size = 12694, upload-time = "2026-05-30T12:05:55.157Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/ad/deaada5bb4b9f1463d3cc8b2be809818a911edf3f6618053cf6ae5307e09/pyobjc_framework_cryptotokenkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:240f79011ed7750a441f9d07e971ae262551bae3e6a455f7dc2dc8641fbde6c7", size = 12713, upload-time = "2026-05-30T12:05:57.068Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c4/36dff9b7c73eccedc57ec8bf60948b9410a95eb27d7e94bfd4bd89586ba5/pyobjc_framework_cryptotokenkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:eeaa4be6eb2cc48a73a2444d5db1ad9f7c383e23d15efab12272cc66c3fc11c3", size = 12898, upload-time = "2026-05-30T12:05:58.89Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/47/c5c5e9988faae629356f1fc0e57f80e26c095a9a015a21af0dcda129ae71/pyobjc_framework_cryptotokenkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2ac46a8f261c465baa48c59b66fa4b80747033f6d9a252f23f6b7f24f2f2c826", size = 12691, upload-time = "2026-05-30T12:06:00.764Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/7b/9c924053856ef2d02ede6bd67b6df5608651422ae80b6086235d93645a1b/pyobjc_framework_cryptotokenkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:60a0fbc1191d239436892e84d526a80de7c57d07a2d1d713c7c21baf55743ef2", size = 12898, upload-time = "2026-05-30T12:06:02.588Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/4e/851f5ef1b357c0c1b0e42964920732ebbb7f939907005fd6470382ecb81a/pyobjc_framework_cryptotokenkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:15cf74cb05bdfc592c600dbf8b0cd24d18662158af93da399ba55762ef367020", size = 12682, upload-time = "2026-05-30T12:06:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/28/89/4054e14864f22515a9ef9c879d5ccdc77a9ac480f34701dfb5561dd68d1c/pyobjc_framework_cryptotokenkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:a0df6e75334f762402e18f949a4e8485c73361f9fbc94d4a0dc8351832687db7", size = 12884, upload-time = "2026-05-30T12:06:06.544Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-datadetection"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/fa/eb20c36de2d038e2c65629b600dc0642727ae68e96f3bc9a692cf0b7184f/pyobjc_framework_datadetection-12.2.tar.gz", hash = "sha256:5fe732751662f119c8435c608785e86edff1b2ee394fbb9f010b5613bb6703d2", size = 12676, upload-time = "2026-05-30T12:37:09.09Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/8c/080a4c6ecffe45a64db10912ecc8c777f4368f4c5ad859a584a73e7243e9/pyobjc_framework_datadetection-12.2-py2.py3-none-any.whl", hash = "sha256:23246bea4dce73c702e176ed2be1ba26afc48a627c713a91417716c3d5915ec0", size = 3522, upload-time = "2026-05-30T12:06:08.013Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-devicecheck"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/ed/0c173fbee96920addd4f2d9ad0e69dfc22b8080c16f52f6d75acd459692c/pyobjc_framework_devicecheck-12.2.tar.gz", hash = "sha256:2750bdfc7fa11e02c88fc8d681dcf202ce2f52c4eaafc55f0afa38df1bc66369", size = 13324, upload-time = "2026-05-30T12:37:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/58/8dbb51f3f462ce1d1a880f8fafc47980f56e0ad1b7472e2a500c81d6332f/pyobjc_framework_devicecheck-12.2-py2.py3-none-any.whl", hash = "sha256:77bbc267426dbdf80799d9a63ed17545c2c8332e765da8f5ce34f40be78e7776", size = 3684, upload-time = "2026-05-30T12:06:09.443Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-devicediscoveryextension"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/aa/848457f81670d784c3a0b35887f7d16fd76bad805ec06be21f9c15012b9a/pyobjc_framework_devicediscoveryextension-12.2.tar.gz", hash = "sha256:2f3f21f9f2c0e0f714bd38076d7082c923650ce180a15aab77f271575b4eef04", size = 15744, upload-time = "2026-05-30T12:37:12.525Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/9a/eee0a7ed475068d2bc24f2fe6a8243da384a3d5c742f6b0c436322e0b592/pyobjc_framework_devicediscoveryextension-12.2-py2.py3-none-any.whl", hash = "sha256:d0f2187013cefb9dc3ff20abd8dd0260a257a6bd6cd661b4d5a364c877ee4ac7", size = 4322, upload-time = "2026-05-30T12:06:10.939Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-dictionaryservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-coreservices" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/f1/07b79048947dcd0ed0aa2582591a17990252a5649be725c094662ef9fbe5/pyobjc_framework_dictionaryservices-12.2.tar.gz", hash = "sha256:51e826c92fc04a0aa531bd04f092ca1edb6c470bce3f04c4eff84fbedb61d929", size = 10693, upload-time = "2026-05-30T12:37:14.263Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/af/2b7cb4c630a0f9f0588a53a290d96898bb1fc8dcb2abf311c20e250d4924/pyobjc_framework_dictionaryservices-12.2-py2.py3-none-any.whl", hash = "sha256:9257ed93dad0b4bcf82c871bc587f994d7619e5916df3662cc2510fe8f85ed5c", size = 3931, upload-time = "2026-05-30T12:06:12.609Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-discrecording"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/ae/ea8b74b528cb281555bea842abbaeed99db66e8270d9eec37a3b2f5a9bfa/pyobjc_framework_discrecording-12.2.tar.gz", hash = "sha256:0b1df1d250b892d1b48e1ce87c9c89e944c28a4bb708d43848f12ff2d69cc396", size = 61967, upload-time = "2026-05-30T12:37:18.532Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/6e/0428d2bf48080057b29d73799629d27f643cf54499f8039cffcea253857c/pyobjc_framework_discrecording-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0c80862b61cd5bc5d364fe7d1a3fb6ba4ee91ff104d7d17424bc457db682c692", size = 14549, upload-time = "2026-05-30T12:06:14.598Z" },
+    { url = "https://files.pythonhosted.org/packages/74/78/065e08aa4fd10c3d97f1afd79b4303b714ce6f49bd13106730afc136e6e6/pyobjc_framework_discrecording-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cd8d85cd7422f472845c0f59ee179be191232342435dfc79ed24a8808105367f", size = 14548, upload-time = "2026-05-30T12:06:16.653Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f6/629885ead33cf4425d9be95c9b6f0bfa95f20444d2017fe2d07508b6de87/pyobjc_framework_discrecording-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2cd8b5260ae022ddd314fdfb92741cb6ed72e87206148a8b1018f064e4903852", size = 14565, upload-time = "2026-05-30T12:06:18.747Z" },
+    { url = "https://files.pythonhosted.org/packages/85/18/da0b7c2bf4d4cc9f6a3863ef635d72206cd6c3959ac27471db0c6b5969d8/pyobjc_framework_discrecording-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:23e4012a55a51e5af9d5a9526697efc1a0d55a1234541c58a27b464c2fdd4e2e", size = 14567, upload-time = "2026-05-30T12:06:20.632Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/24/e9abce96b6f19979e9701dd1dada13ac0e344425e144ee2e684ae5e62bcd/pyobjc_framework_discrecording-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:067095747927b85baf7395d16c033be15db14a61c3fa8f6d2d6ce1b06ab36517", size = 14743, upload-time = "2026-05-30T12:06:22.564Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0f/c0a93c4cc41c16ec0e71800b24e75a54e0262b895340900dd01118276850/pyobjc_framework_discrecording-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:99ef86ec82079ae4c413433ad6efe5fc526a3307cb9317f1614cc0acb55cfbae", size = 14625, upload-time = "2026-05-30T12:06:24.513Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/50/27aa4acb61f8c6275c1f188b7ffadb5c47bed5fe47a26c18edddf954453a/pyobjc_framework_discrecording-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:457a08b5f3d685e8b3802aa1e3d78dcb425616a20a38d2dbaa7ba987311437ab", size = 14806, upload-time = "2026-05-30T12:06:26.434Z" },
+    { url = "https://files.pythonhosted.org/packages/81/14/3c27363911d8ab60441c9d09a5ea900a89db4da01fc1c087b5afc5c1d802/pyobjc_framework_discrecording-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:dd4ca56fea006923bc9a581955b6f75e3f5989f76611a451d52dd3c029d1d72e", size = 14633, upload-time = "2026-05-30T12:06:28.443Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e9/004c04389aa5d2e0cb64ba246d15e287b0294b0f63791f9b4a3cbd22937d/pyobjc_framework_discrecording-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:df4b4a6badb024dc56127614712e2666a186ec3efeafeccb6c2cc3b7f10db75e", size = 14804, upload-time = "2026-05-30T12:06:30.375Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-discrecordingui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-discrecording" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/a6/3f94dfd9508f98aa5d152f8e56dbcdd8a0ddf2bbb9f7e180a5561772a839/pyobjc_framework_discrecordingui-12.2.tar.gz", hash = "sha256:932175c1c2df93673ffd87e4d5270bd03591548e26e39664d813b5e1b0c0a47b", size = 19543, upload-time = "2026-05-30T12:37:20.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/bc/3d75efba436c907629af9f17414f10bf105581e6e6803d20d0ab097a4b44/pyobjc_framework_discrecordingui-12.2-py2.py3-none-any.whl", hash = "sha256:4ae5d1ec84ff47cf041973c112024f7b3b7c6eb0d5cbd3cecc393998efa0f654", size = 4701, upload-time = "2026-05-30T12:06:31.841Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-diskarbitration"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/f8/aff13f6577bae073682c7e413ce725e51a11e2262c82956b5664621caadf/pyobjc_framework_diskarbitration-12.2.tar.gz", hash = "sha256:b5ce6750cec175066ed6dc6ccc9548201642f246130c1a82d01690747028505d", size = 18162, upload-time = "2026-05-30T12:37:22.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/c1/93db22bbc25358cf523e7a66a76de6fdfff4719ce60e86a87d368587520d/pyobjc_framework_diskarbitration-12.2-py2.py3-none-any.whl", hash = "sha256:9952012b50f8d87849ca74c56a8b6fcd9373e8b5aa4566f628165cd4a2458a25", size = 4889, upload-time = "2026-05-30T12:06:33.405Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-dvdplayback"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/87/6a2aa2a54df1b18f9543a2c64baa290be6e59d98b31b46559ea47b49b5d9/pyobjc_framework_dvdplayback-12.2.tar.gz", hash = "sha256:2f504e578a809ae8544e50d9958bc2101fbb0a35921f370c810b575b70d8096e", size = 34810, upload-time = "2026-05-30T12:37:25.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/70/c7cbd09f8a84f1fc904206f855688c76feb02aaae1ab4efb6f1858f0ec0b/pyobjc_framework_dvdplayback-12.2-py2.py3-none-any.whl", hash = "sha256:37d0b460e0783c78c3099a653ae1a7db8158b12e4da6ca91d513ec708514baa6", size = 8244, upload-time = "2026-05-30T12:06:34.978Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-eventkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/63/1acab761201e3ba2ddaa093470bb94373a11cee4f406587fb687e31062ab/pyobjc_framework_eventkit-12.2.tar.gz", hash = "sha256:c4e96235a1f0e43ea9699054c289369efb9d7645254a6169559c671b4ed21f86", size = 33759, upload-time = "2026-05-30T12:37:28.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/c0/257069ea9e34c3b0dc473f6ac9c03c95029e9b3c686875ae8f1c564eb0ac/pyobjc_framework_eventkit-12.2-py2.py3-none-any.whl", hash = "sha256:b56a736182365eff268b6a8c958a663d53432bac5befd3116570d3f1e4ec8b1a", size = 6924, upload-time = "2026-05-30T12:06:36.781Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-exceptionhandling"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/77/2ecf87e8ddffb3c43e0c79bba7e1113436b45c3bc30ee76a82e94f5028ec/pyobjc_framework_exceptionhandling-12.2.tar.gz", hash = "sha256:c11ab2b122b6f2d1dc4625d163a2c5713df5ec3b0372394d3b6ed875a49397f5", size = 17168, upload-time = "2026-05-30T12:37:30.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/24/9ab5cba61d04445d36ef2bd52ff871056cedde22c3a2a4ff60f111d1f25b/pyobjc_framework_exceptionhandling-12.2-py2.py3-none-any.whl", hash = "sha256:14a76583bec99e18c5d0b0fd1db554d6f75b614f2912435836bc4abe6e1220c5", size = 7114, upload-time = "2026-05-30T12:06:38.383Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-executionpolicy"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/e6/ad5d770d04c5cd057c20362724246d1a7407883854e065c86122bcfdc272/pyobjc_framework_executionpolicy-12.2.tar.gz", hash = "sha256:9b527b0deede8057a6482a6837ad8b3f6c3117232b8c9f97a3244991c9d0449f", size = 13040, upload-time = "2026-05-30T12:37:32.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/25/4b8994d6bc1b4647546a89225770e68121dad788e26fb2eba458e028d6fa/pyobjc_framework_executionpolicy-12.2-py2.py3-none-any.whl", hash = "sha256:a8b6177182c1cf316696db76de23dd40b47e41e8eebbe6fa204492055c8f1f3b", size = 3774, upload-time = "2026-05-30T12:06:39.998Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-extensionkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/37/d8578fa098ce7c4caf70bd02cc52ebae57dba3beeea260e27f10852ab738/pyobjc_framework_extensionkit-12.2.tar.gz", hash = "sha256:eb85b5ccea05f5bc41d5c134a2d199eae2a3bc4ee12cdddb94501272a45052e7", size = 19199, upload-time = "2026-05-30T12:37:34.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/ff/860be5832d27c0cba7f1333b9b696275cf9c3ee1fb02898c08e200116a80/pyobjc_framework_extensionkit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:848e601a3a566fd9742d1e6ce6e1d2109f0adf7aeed2380c319cf0661261b806", size = 7916, upload-time = "2026-05-30T12:06:41.582Z" },
+    { url = "https://files.pythonhosted.org/packages/90/e3/bf0fa6bc6ddb10b0624a0e166afe1ef7129d19b06a848b97550020c535cc/pyobjc_framework_extensionkit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7e8553ac034b73d26b06041c989532f6c918fcd9e1ec07a65eec71ca4839ba18", size = 7916, upload-time = "2026-05-30T12:06:43.415Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2e/f5a6c1f22f4237085b047cc5a632a2bd1c637e716e68562ba89a899d2d1f/pyobjc_framework_extensionkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8596735e5ea62af326a13fe61cd815027896e8960d32f7ed18f8c55e2911bf35", size = 7931, upload-time = "2026-05-30T12:06:44.916Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/7f/21d173aed300819ff9e7ed9918c8817f6279c0c85687208fc5466e92efce/pyobjc_framework_extensionkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e81277815e9b7ad6adb8141be1ddc794cbb92acbcb8b582f0b929100c6528ffc", size = 7943, upload-time = "2026-05-30T12:06:46.384Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cf/c75dc1b6a171743eb45ba4a28f51eeb3d348727d2b85c7af32609e18847c/pyobjc_framework_extensionkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7f480965e4c3d06f352116f9362ecfaee20337f16a832c3f39ec185ebfc87553", size = 8084, upload-time = "2026-05-30T12:06:48.235Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/41/acaf60a6fba4235d3d5079a5ca8a9b60b50cdc20408f3c5c8d3719f6a73e/pyobjc_framework_extensionkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e6b8b9ee143cba5ea27fb3afeb5beef58a33525f1d3374ea40b339079e853c2c", size = 8004, upload-time = "2026-05-30T12:06:49.713Z" },
+    { url = "https://files.pythonhosted.org/packages/53/34/cf0cb884f1d38f50da523e98aeffb5b5d09f81f129b5fbb7cf4d908d73aa/pyobjc_framework_extensionkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:bf4744cd6d3722a76dc61c8a7ff356457fb903ac5ac2fe20f49cc6f18dd95074", size = 8142, upload-time = "2026-05-30T12:06:51.395Z" },
+    { url = "https://files.pythonhosted.org/packages/73/9b/4dd5a8d62b8f8617f62f541befc4cc7ac5f8391add198641f723e64aa0a8/pyobjc_framework_extensionkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:0d29ad16d7abc03aec419a47a02cb7f1904345cfab2ea3831ba8f8ad58d494d7", size = 8003, upload-time = "2026-05-30T12:06:52.885Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/28/44c7d7c10ba9c395d5240652ef1dd82c02462d30f100a2876b46e5c83b77/pyobjc_framework_extensionkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b355d0689196bb5b3a62c73fb1a9abf4b68e5582cce2b1057f2a6a02a7177f8d", size = 8139, upload-time = "2026-05-30T12:06:54.705Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-externalaccessory"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/fd/8eaf82d13c74834007c716a13a10e6c2dfc0edaf62248c4801ad951e924f/pyobjc_framework_externalaccessory-12.2.tar.gz", hash = "sha256:0df5c2db52220753e3c7673fa3051fdf5d2890b9972dc3e140edc3dc16c7cd4d", size = 21989, upload-time = "2026-05-30T12:37:36.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/c9/3ea84a676e6fff51bf51b89a9750c0bd54a6fa8d55f937887f20c4853619/pyobjc_framework_externalaccessory-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a9cdc7483125a6e152b5de399ae8ae6df855c9a0b7d64700aecdbcd93b47345b", size = 8909, upload-time = "2026-05-30T12:06:56.269Z" },
+    { url = "https://files.pythonhosted.org/packages/42/52/a2db466cbe877579402d78e02fcd684a57fbc4f71cfb36ef3f8b63c79941/pyobjc_framework_externalaccessory-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b95353cab4515ccf3821fbe0535ba7270bd7c2b39ac144199fae6da06b6651f3", size = 8907, upload-time = "2026-05-30T12:06:58.009Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/89/e8fb9e30707a4535be8290788a950e02a28cc9c34de273833c3aae7207c1/pyobjc_framework_externalaccessory-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:01ee6ed84a307a8071de27cda8bc8abba748e818509d622728ad2c5f8d334f09", size = 8922, upload-time = "2026-05-30T12:06:59.557Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/0b/bf64b437eb48e86078cd2e9303ff4f45f1ea43b2f0febdf2bd03f44708c3/pyobjc_framework_externalaccessory-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c04313f4b68982d9f9f23d208f234b44d80472000b9945392459eddc44a61121", size = 8942, upload-time = "2026-05-30T12:07:01.214Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/98/2588a2e1888d91f1059ad0c3d1939a213f23fb5bfe0130828808eed3393a/pyobjc_framework_externalaccessory-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e546bb0db0e6832a40ac4978a24117eb1f93c2f419f6f26d908fd4315f04bd8e", size = 9105, upload-time = "2026-05-30T12:07:02.797Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5d/fb59ccf789d1a68048163f83ee3250ff0990fec759846ecca9c57dfe332a/pyobjc_framework_externalaccessory-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:55c985489251fae171a743a2d86f7d3011e8c5283e22aea803708d4fd2cd1c23", size = 8995, upload-time = "2026-05-30T12:07:04.42Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/53/a5831ff85fe3c16c38c210dc605961a26dbdabd8e27e996ace0a59c13f56/pyobjc_framework_externalaccessory-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1cc058e0a036d4c5c377272173029120f8950595688139d12f8e702e250dc479", size = 9179, upload-time = "2026-05-30T12:07:06.008Z" },
+    { url = "https://files.pythonhosted.org/packages/64/53/67748fab7d4e7e438db5d7fdce8e35f546654041868763cf26da99fb5ece/pyobjc_framework_externalaccessory-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:710b9da3f123a53c3b6618d920d07782462b68060c51f772caa490535db1880e", size = 8989, upload-time = "2026-05-30T12:07:07.662Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/a3/797b5d182fd3433996a87dd87097845062bbb738c4612ed0bd90c54473df/pyobjc_framework_externalaccessory-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:02e4c9fe185372906f4cbde8d16d5756e71c134e969618703e3449414774eac7", size = 9162, upload-time = "2026-05-30T12:07:09.217Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-fileprovider"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/a4/44d4f784ed0601800c80e06c53e892ccc39c2a5545bb1caa13b661fd6d83/pyobjc_framework_fileprovider-12.2.tar.gz", hash = "sha256:f9b146eab8a7f664f0e417310802bc2e31ad52b0f61951ce58e471a989ad4e71", size = 50565, upload-time = "2026-05-30T12:37:40.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ee/90884ac9bb351b43000d30ecc46af22d7953f8baf4e5d5cde344fb951987/pyobjc_framework_fileprovider-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:58f4b7fe0cf6511c6ebc1cfe40c15b4bd6310219d962c025b8236720b73364c3", size = 21039, upload-time = "2026-05-30T12:07:11.415Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fc/64b8dc35cd27dacb9e4d6ac0a708ceea83a93d0c6b4713a4d5a12c3a2a89/pyobjc_framework_fileprovider-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:50928a80708568c8d788de604c0747ff01ad825fb2ac770a9a38f184be1d504b", size = 21038, upload-time = "2026-05-30T12:07:13.905Z" },
+    { url = "https://files.pythonhosted.org/packages/36/cd/ec8d50d5b56f4edbf2d9622f495c99aad8842c7cbe9729089d695f8d3eda/pyobjc_framework_fileprovider-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:659790edec0edd536732f79d16a44bd7b4c3112b410d463615514753717a26d4", size = 21067, upload-time = "2026-05-30T12:07:16.232Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b6/27766ae4419f64f654c7c0b1f9892a0f82baec01a298fabd45d4fef10dfa/pyobjc_framework_fileprovider-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5718203d129eaf32dbf454b2a7a5f312f2dba108a4b49fa0536702537f93c961", size = 21080, upload-time = "2026-05-30T12:07:18.475Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/48/bb7466f3a3d990868eccee96c6eb02155af2aabb08b705f90302789848c1/pyobjc_framework_fileprovider-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:78c6528c5d59881f88b2fe657fb48aa75b652b830ca18f58cabc1ece2f308ff6", size = 21360, upload-time = "2026-05-30T12:07:20.798Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e9/60b8fb83afe07e69b0eddf382f2847bf642cb70ee5bc38ebd703b1a73f01/pyobjc_framework_fileprovider-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:746dcf3149920fe858d4b0bb725175f6df5cbd30fd35ff73a10cef30521c6398", size = 21117, upload-time = "2026-05-30T12:07:22.963Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ae/e4eaf9f79210ee04eff41af0e890b6f2b5c5ce7780a5f54d8de038136397/pyobjc_framework_fileprovider-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:950b1d249475ae9d4f3c2b96058be4be2cda511eb5590c3f3f2243b7c6f75de1", size = 21397, upload-time = "2026-05-30T12:07:25.32Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9c/4a514f54b03981f9cf3585b0052f8017005f876fb395e6e3986e9ea49f2c/pyobjc_framework_fileprovider-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:dca30fb647c7d22fa0de5d3c21ea6db01e2820ab9ffba4ae75cae53a6d4b750c", size = 21111, upload-time = "2026-05-30T12:07:27.832Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/00/de7f14ebb96afa2551384330b3e8f3a51cc4fc158b5fb49d7beefb24816d/pyobjc_framework_fileprovider-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f9002875073d1e0c74d760518bca5101743392515478eed570d67f28bdb6ba07", size = 21396, upload-time = "2026-05-30T12:07:30.111Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-fileproviderui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-fileprovider" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/53/ce4fc44c62f813e6572426c0f66475f5a5e4804693001185faa80aa95af7/pyobjc_framework_fileproviderui-12.2.tar.gz", hash = "sha256:520974c2966057cd47206f8792d8066531551b3222c8a5824851cc19e9bba7f0", size = 12852, upload-time = "2026-05-30T12:37:41.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/40/4514fc9cf9b9f20d2abe1dac66c4f94b8c20da9db7865ee9dec9dd6f3f65/pyobjc_framework_fileproviderui-12.2-py2.py3-none-any.whl", hash = "sha256:0874b16ea64d055f53d0c6ede6ba61b3dbe9d2b27a64db5c12b829391a510cb6", size = 3715, upload-time = "2026-05-30T12:07:31.596Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-findersync"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/8c/dc4e185d054d422f0b24417dd0a340923f7cd317e70879dcbb740bfdd01c/pyobjc_framework_findersync-12.2.tar.gz", hash = "sha256:e8c8dbfd0c1e9a055d5778c8f65a72bfaabfb8c30ff9ef635ea25ee2d607dd75", size = 14210, upload-time = "2026-05-30T12:37:43.536Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/3f/cd17c17bd1e3baa57388d80c5343bceb02df455047a3cfb91498b32849cd/pyobjc_framework_findersync-12.2-py2.py3-none-any.whl", hash = "sha256:6f7a461df88f4fe0cd64c0ad326c77bf1a8f72afb1bdf1f42c1d7e02b7340dd4", size = 4887, upload-time = "2026-05-30T12:07:33.154Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-fsevents"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/cb/f3fa1c24c2f7b3fc086b5cd0d7ec8bed1d5524e2b77d6e7b5c86d05284d5/pyobjc_framework_fsevents-12.2.tar.gz", hash = "sha256:c6599daed508605916fa31b23866c20ccc12565b568f61a43b5626d9b8bb8778", size = 27156, upload-time = "2026-05-30T12:37:45.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/e2/36a8033ef69d916608819fe25f375b8c9b30130b70bf5d2c7fe761e22d23/pyobjc_framework_fsevents-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5dea14ad5cbc42ed096e4544cde5d2a0f12cc4c6a743012095b96bea66b26df6", size = 13043, upload-time = "2026-05-30T12:07:35.049Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/83/dcd922303a84f1542f749a3420410b49ef3509064cd62c802db576eb9a3b/pyobjc_framework_fsevents-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4f705cf041ec7094aee1be2a219dd67a206cabf935b7d6f47eba8bcff5999f55", size = 13047, upload-time = "2026-05-30T12:07:36.946Z" },
+    { url = "https://files.pythonhosted.org/packages/69/cd/714e19b57f11c2f92e1b31787846f5ee806d84897f01e6d8d39ec51843a9/pyobjc_framework_fsevents-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3a96802c25cbdce74b5d02bbb00cc85747f8f745102d3d22ec9bb540c2e17ac6", size = 13130, upload-time = "2026-05-30T12:07:38.808Z" },
+    { url = "https://files.pythonhosted.org/packages/67/61/e5376e0c3a95b93a6f1a77f68ca7a454ffe892ff6c5f301f4b83231a26a4/pyobjc_framework_fsevents-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b4adc50338dc4f9f50f3525e2f070e2ab4b469976f9d4762e373505f82068831", size = 13131, upload-time = "2026-05-30T12:07:40.621Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/14/f0fc106e63187438c783f2b8480470d43fba311355343856bda91899248c/pyobjc_framework_fsevents-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a00440f1e79f6639ffd601bf973d6c7064d82174da8433999825c33617d9c053", size = 13496, upload-time = "2026-05-30T12:07:42.429Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6d/7cb724925e45553698e674ef48830052e1f7433d2ac715f90efc1c000ff6/pyobjc_framework_fsevents-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:caa86498ea298a542664222b33f6db2b09b7d315e1b1cb702c4652edb1fdca92", size = 13032, upload-time = "2026-05-30T12:07:44.421Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c8/f049d4f2b39f254e91c79e8b9703a42ccf712ed1169d79ba0902fb4edd7d/pyobjc_framework_fsevents-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b8e479864e232d76945219bcf3af12983a127a282f57af50ef089dc1b5116787", size = 13487, upload-time = "2026-05-30T12:07:46.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/46/176656c8bb720981e1806ec2f3c4396fa3f6ac9625bf69bb2a558b78b1fa/pyobjc_framework_fsevents-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:fe72e987dae3919e80e7c3641d74fee8fec2ca841268cdb855f903b0b9f6f681", size = 13034, upload-time = "2026-05-30T12:07:48.198Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0c/c3a1ea89db895fdd0ce10a4d2c4686ad8e404482b4d9c407ad44ad9d3b13/pyobjc_framework_fsevents-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:7665f7e2944fa50727e818dfa45a2c6d1234bd64d352559c2d6f3946febcf707", size = 13516, upload-time = "2026-05-30T12:07:50.03Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-fskit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/46/9f5162cfde0340792043ab60d1a039f442a67b001f7bfc981b6837a9b07d/pyobjc_framework_fskit-12.2.tar.gz", hash = "sha256:a1a7f9678c55fa947783caa24325c91727cc3045b877c6770262790c00da3952", size = 49558, upload-time = "2026-05-30T12:37:49.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/fe/5fe729a0e4c33795b85256b763139d7909faffc6b7a4e53069c86ed11df6/pyobjc_framework_fskit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9b506522235d8cf1fb76b0b95921561126a5b31b34c01629da00664c003c2fe1", size = 20567, upload-time = "2026-05-30T12:07:52.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/12/ea10fef4d7f18ec37dfa8894205b3e854c81e9eb9af1210306bc26b40319/pyobjc_framework_fskit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:26720885a6d1856d34ac83fa6e727e92111ebe582c0a2715e91b3e1c46864fbb", size = 20566, upload-time = "2026-05-30T12:07:54.681Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8e/325d1664fb5aefa2d7c2b3c3efc047cb2ec0b59f5948d63079c00ec35016/pyobjc_framework_fskit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3098dd1bb05c1e59fac70695b93e42f068735d0111aabff844781918895eedf3", size = 20586, upload-time = "2026-05-30T12:07:56.916Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ce/6bec42dade6873cf440f62d18be277b342b326bdb0ee7835b5f79b2748dc/pyobjc_framework_fskit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fcc8db6cf9e9b0e731e056411976c184bb3861288da4e97dae91a3e3e8063ade", size = 20597, upload-time = "2026-05-30T12:07:59.189Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/ce/385a29b02bc81bb70169cc2a5d85b78d3af131a113acb2615d87f12c5f16/pyobjc_framework_fskit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1f3935499d00678da05b97a7baa46bdbecaef3fd61768fa5dd34bd3dd484ad55", size = 20826, upload-time = "2026-05-30T12:08:01.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/61/b2900135b0cbc46edbafffd9b2bc13482d9ad417b7a09876464a2be09f14/pyobjc_framework_fskit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:844a2b9f7377cbab03a578f0ef354450cff86d1520cd4f9a326590776df914fa", size = 20632, upload-time = "2026-05-30T12:08:03.59Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/b926293d92e47ad6a5f6e8dd86b0e3625e9e5e0c8b478d954ee6b4553d92/pyobjc_framework_fskit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7504760f3ef0337375ab6ec91688903981e71c4f65f5791778b34c7b27b54aca", size = 20890, upload-time = "2026-05-30T12:08:05.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b7/968e71f283ec520c5d4d994b51849e2e409f0f1c8de1adf588a42354d0b0/pyobjc_framework_fskit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:47fda8a47bc4711ff697601b4dce606ed75cd460f3a52fe1d3214fbb79acc6d8", size = 20634, upload-time = "2026-05-30T12:08:08.032Z" },
+    { url = "https://files.pythonhosted.org/packages/17/fd/b0cb952a57c1b133aac064f566c7e4bb38485fcde5c710d7f8c48e902102/pyobjc_framework_fskit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c8f247c6b3b77edea91f70e9c125f7faa493807c5e6b1922842c0046bc83bf52", size = 20895, upload-time = "2026-05-30T12:08:10.272Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gamecenter"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/bf/71c09142969953637a524946c3609ddf472c0b4311d134223cc9c87dbf8f/pyobjc_framework_gamecenter-12.2.tar.gz", hash = "sha256:a1207696a547011094a4b8d2865a3a9018a622647a8a0371baf86a3e5959ef4f", size = 32153, upload-time = "2026-05-30T12:37:52.717Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/46/ef572c43f871c2c22793eeb21a5ded10349e073e141eb576c46e085aac57/pyobjc_framework_gamecenter-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bfe1cc3df6109f587252a10bfe04542677bbc75ff6965e19b5a19241196d42b2", size = 18818, upload-time = "2026-05-30T12:08:12.315Z" },
+    { url = "https://files.pythonhosted.org/packages/13/09/4e05abf098f9926e4ae4c0ad72fa796c9c31253d5112c3f31281ce676fdb/pyobjc_framework_gamecenter-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b08364d2a1a58386d47493495fed3adb9828a055b41fd6cbf3631861fddb4ede", size = 18821, upload-time = "2026-05-30T12:08:14.571Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/6e/fbf225a5826cfe68c447dbb1937d9c652617f5191772af95abca932cd252/pyobjc_framework_gamecenter-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d777dd5f2a1e4849434cb56f82418b4ee781718710b36c68860a91d85dcd1f89", size = 18865, upload-time = "2026-05-30T12:08:16.687Z" },
+    { url = "https://files.pythonhosted.org/packages/41/77/2496866b618c96b3569da87385db6593688222f6fcaf733cc702abf0309f/pyobjc_framework_gamecenter-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c5ff47f68b0f5f138fb91f03e5cc46dd12f00d95f795ed5b88f8b99c52e54e2f", size = 18868, upload-time = "2026-05-30T12:08:18.814Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/d0/6ec40754993e4f6f0366d7a13e5a19b6745b7c7d6395f2be0b3b60d5688e/pyobjc_framework_gamecenter-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ee1890cc3e1266407d41475659b382067a08765bdbc62a0ae4eecec733491fec", size = 19153, upload-time = "2026-05-30T12:08:20.886Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/52/7b37cae6390244058278a9322166b1d65f2a723d081b3d57f9cb4e5e3aca/pyobjc_framework_gamecenter-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:bec386091dc9ebad94939acd26d2877d8f3a6dcaefab8a8336bb384b8f3c8f4e", size = 18916, upload-time = "2026-05-30T12:08:23.115Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/86/89f7a17d40f0cfcf546f3be1ec9a3c4aee77e7e875cee569aed6082c96af/pyobjc_framework_gamecenter-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:81e9e4680f13061a59b2814fbb316c17ea6fd41333b1dcc368c5210a26ef466b", size = 19209, upload-time = "2026-05-30T12:08:25.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/33/2ce5abb83cc70f3504ee46e660d1bc3ecb5db6ebee64409493b29d3c7afa/pyobjc_framework_gamecenter-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:96dade30ae38e54bf58aa4b727f66dd3b2c5918b5855502c099b0eed441448c8", size = 18906, upload-time = "2026-05-30T12:08:27.458Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/bf/f4f28be2dbddc09afafd1869e1b09b5b65b692c7a3f81d36dfdafcab7a8b/pyobjc_framework_gamecenter-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:834171b3059e778365190dfef1e075ca897cfb0a11e4af9f8a59d3a96285f16c", size = 19193, upload-time = "2026-05-30T12:08:29.562Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gamecontroller"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/4c/440ac9652cae2fc386702a39973008fe0fd18928f70b359728c1926f5350/pyobjc_framework_gamecontroller-12.2.tar.gz", hash = "sha256:130418999cb5e202c0775fc1587666c6b9fa1d9285341eb6cbd589ecbe758a64", size = 65272, upload-time = "2026-05-30T12:37:57.45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/0c/9cc56b38b88507f76ceafa2117ec0f705ee05c9b35df69d834c716c1b961/pyobjc_framework_gamecontroller-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f0388a602396e6f4818fed38b940c8a1b10b108e854a2e3daa80e3674dad1e2b", size = 21484, upload-time = "2026-05-30T12:08:31.847Z" },
+    { url = "https://files.pythonhosted.org/packages/29/e3/3c147cc820627c687be8a3ab38706a7c7f2ce510ce4a146294daf5bccf9b/pyobjc_framework_gamecontroller-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6d3bb75d9db8d0074cae97617b6f8d2b2693530da6e39e0010b612691bae625a", size = 21487, upload-time = "2026-05-30T12:08:34.369Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cf/13e069a6c302c7f12e8a2fdd4da0ec2e4673936db28cf129af238d0cfb9f/pyobjc_framework_gamecontroller-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:76b488179bef3430eb91a5cd2961659af0d98893a577fe532e0c4af16b525a7d", size = 21503, upload-time = "2026-05-30T12:08:36.688Z" },
+    { url = "https://files.pythonhosted.org/packages/65/54/519b19e43bb3fcb8058c9cf780d324e7b3532a1b8a317ff1831615993206/pyobjc_framework_gamecontroller-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8a448b31594c68993da348c3f2f24c02323853905e999f930d7c5d0fa6b4468d", size = 21517, upload-time = "2026-05-30T12:08:39.214Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f3/11be9f022e2cc30f1ff2509bdb8405005b707beee2a01b70798054c52cdd/pyobjc_framework_gamecontroller-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d5a5ea2c31f179c72dfbd1564aaca52fcce742c27f91e2c7af37ba1e4777c3fa", size = 21768, upload-time = "2026-05-30T12:08:41.309Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/33/73b0769f8d91ccc992c4fc53bdc7de7ea8e1e425769b5a09e2136bf14d30/pyobjc_framework_gamecontroller-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:77f7e1155f7789ff5d86b202a37eb731db7d37796d4870ec9830bc94850ea806", size = 21537, upload-time = "2026-05-30T12:08:43.615Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/01/7786c685582915f804f137509c0e0e6b40fe3c3de4419eac7c7e6969b3bb/pyobjc_framework_gamecontroller-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9e79ab9d3133d0e104da33bda7207f293cf0b981230969b8d865fed831631681", size = 21836, upload-time = "2026-05-30T12:08:46.036Z" },
+    { url = "https://files.pythonhosted.org/packages/49/02/6d1347c85ddc14238683e0e76ed588d31463e447b2f754a66f8d168e9b2f/pyobjc_framework_gamecontroller-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:221c88cf75b91abb75e3bbdbd40eb962c467b9568bffea9decc09b3da26ee2c0", size = 21539, upload-time = "2026-05-30T12:08:48.536Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c1/91d0459b9811309b817b96a48ba0a1a233146a19946344797d3b83f5f593/pyobjc_framework_gamecontroller-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:821098a524459089c77b19c4d11a378378fb010732babbb9dab1ab11118b5149", size = 21827, upload-time = "2026-05-30T12:08:51.002Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gamekit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/e3/dfc67af937bdf98b92fc0f6518bd1ee17cf84025ded15bd64acb91f0db8f/pyobjc_framework_gamekit-12.2.tar.gz", hash = "sha256:d4f4f98539db6125d5fb249b845398a0534f8962e6db390822da808b91ece009", size = 82428, upload-time = "2026-05-30T12:38:03.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/f4/d91e1c9ae73aca3a82e23bda6bed276cd37544550200b8ea8e6d491188ba/pyobjc_framework_gamekit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:39e3368dfe30e777ca9e8c8f9b0749d325d16c82fb161f5bcd3600f1b18b54bb", size = 22526, upload-time = "2026-05-30T12:08:53.336Z" },
+    { url = "https://files.pythonhosted.org/packages/75/12/5494ddc01c2d59c17e26c10736407a4fe35ef2d978183a8fdb34319e36e6/pyobjc_framework_gamekit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1a0bc379c7f44581cf32990da3920adeffd20323e24b1028b4e164b03178955c", size = 22528, upload-time = "2026-05-30T12:08:55.983Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/90/6c3f9d8892d1c1490a76625d05817ae98cad664a56fe67c260a4a13662e7/pyobjc_framework_gamekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5bffec60177b0e2e20c239dd70035903a1937b0f9a8174029aa87a858ff8eabc", size = 22563, upload-time = "2026-05-30T12:08:58.282Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/26/f1af94c102570afb8ed0e1461fcc752098d8ea12e88959cbc3cd25709005/pyobjc_framework_gamekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:06ac26311a602aa0674c21d6dbc3fb0a19e0d8cc385e2e80b689518c3737df8c", size = 22571, upload-time = "2026-05-30T12:09:00.597Z" },
+    { url = "https://files.pythonhosted.org/packages/74/da/4020429066e04b02c1e40662dd546bba30adfbbbb19a3b87a4007bfe0244/pyobjc_framework_gamekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d915b5a8e8073769f0c371aedbbce31152859ab6352f7488f815bd572e1a12da", size = 22864, upload-time = "2026-05-30T12:09:03.066Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/fc/bd02d01198a4119f55b078a34ad90e6627be258d6eb9c26b570a39ca5407/pyobjc_framework_gamekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c891baea8d3f6530dfc0f1e824228ffd05f7e65f0053dc39c4dd6e3e56307b9f", size = 22608, upload-time = "2026-05-30T12:09:05.559Z" },
+    { url = "https://files.pythonhosted.org/packages/69/95/aca261e802409b745c2a0bf57a1dda51a67c51ee19bdabde40d63978c23d/pyobjc_framework_gamekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e4c0ca676cf6979d0ad503362c4f90bc46e22ef886528778ca086906080c53ca", size = 22922, upload-time = "2026-05-30T12:09:08.061Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/38/3deae98b764d3379e3a3841fa4bfdf090934b396472ebbaee5e91a1230f0/pyobjc_framework_gamekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:af4251f67756f5ebb54c2e16aa3a6ca6242202f52bea0b5b04ddf2ad35aa5648", size = 22595, upload-time = "2026-05-30T12:09:10.243Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/25/8c3a7d542728294effb68e07b0494ae1773aa5984d248808d369e0bf8563/pyobjc_framework_gamekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:97ebf06d2140661ab01701a91534b7ff9387625ee61e372370894e3debb004ca", size = 22913, upload-time = "2026-05-30T12:09:12.757Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gameplaykit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-spritekit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/72/df0abe840ebc9e62f8a04afefeb38997b7774ab2b68ceebe89a9dfb81b2d/pyobjc_framework_gameplaykit-12.2.tar.gz", hash = "sha256:27da2b7c4cdef038215246fc6c98e45e076f969ebb83d827095432a8213b57df", size = 50735, upload-time = "2026-05-30T12:38:06.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/6a/f50439200da023d8f3e1d2304368d16afdab7ea8b6f14920a3e331040850/pyobjc_framework_gameplaykit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d9259f75598163be71062e579c64479b2dce8f4d1f255b3166c35523335b8bdb", size = 13590, upload-time = "2026-05-30T12:09:14.648Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/44/b9357c2cb1d5b657cf0f5ca5cc33df43036451818f1171cf3d5f7b6a858f/pyobjc_framework_gameplaykit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a894a3177a144fbe5d7ddfb261c68a8453a2aaf86472f7e8c20f7da4d026a21b", size = 13584, upload-time = "2026-05-30T12:09:16.477Z" },
+    { url = "https://files.pythonhosted.org/packages/09/58/935593360dadbf4d266bb350bb950e024b800057bf25bc880b017f5ceadf/pyobjc_framework_gameplaykit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:792b527bda8e5784db552f4366de4e01f747a1b40a2c5445ed95cc75a687784f", size = 13612, upload-time = "2026-05-30T12:09:18.299Z" },
+    { url = "https://files.pythonhosted.org/packages/68/47/58dbd455f2d3cd18598408a45b05580387e788104148993aa79b8f4749de/pyobjc_framework_gameplaykit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:89a695937dff8a4a43ac9d389b5f3eb64ced06410e8fbeb6e04f1976ed7c8be5", size = 13624, upload-time = "2026-05-30T12:09:20.136Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/73/87d2d0f4b97942f1401fd8985e8d7b2191502ed210c945472da1e37a4d2a/pyobjc_framework_gameplaykit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db270f78befada566106e3557bdc7281fe2f2759cf81e664e9a45ff2ce709c72", size = 13839, upload-time = "2026-05-30T12:09:22.044Z" },
+    { url = "https://files.pythonhosted.org/packages/12/90/a87ffcf7b241918b09cbfdfefe2ca2a990c8645594953e121933530b62ef/pyobjc_framework_gameplaykit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:68482906120a563ec2830cc02e8548b98d6203893ff1e8164e2612bcc5837ffe", size = 13627, upload-time = "2026-05-30T12:09:23.891Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a8/8b031c9768c6f0c01d338b5adc3e5491be558865307af9a395c942053fc6/pyobjc_framework_gameplaykit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:92856cd1752fa4e50fb9522790969d57ceb8fd5ae45c9f766bf3d6256d5ddd86", size = 13821, upload-time = "2026-05-30T12:09:25.689Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f1/5d137c44e4e4c8b130bf225f67a3fb36ca0fed410a120f0fa226977628cb/pyobjc_framework_gameplaykit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c9e60138e7d2328085db96e1b4ae6100912c42fb8f8871d753f4b4ea4fe6d56c", size = 13621, upload-time = "2026-05-30T12:09:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/8b/8fab0ee194b93f8bbac39e0eca9b6e32562a1aab994d886a839bf4d75f7f/pyobjc_framework_gameplaykit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:14cb763e39a8705cdb39a28ada1c9ef2c5bdd47440155d1fb16a49641810920e", size = 13819, upload-time = "2026-05-30T12:09:29.466Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gamesave"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/fb/aed9853de0ac26c768c1bfefd7c32443367e489d16f5b5563043019aecf7/pyobjc_framework_gamesave-12.2.tar.gz", hash = "sha256:e272a1ec2fc84f680226abc6a4e034534509cbd545cb937fbc76b3a95d7b9e44", size = 13245, upload-time = "2026-05-30T12:38:08.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/da/570c14f8c63cda0a128084cfc53f729e9183987b4a5582cc5ce4b3dbc6b7/pyobjc_framework_gamesave-12.2-py2.py3-none-any.whl", hash = "sha256:766d6eede6e7f9ef1c43333127ce42fdfa9438e62ab94c9533d32d41eb79233a", size = 3729, upload-time = "2026-05-30T12:09:30.757Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-healthkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/c8/fa1a309cabfa0d7190a6dc1f6194d349cdde0105b86683780190aa4e46ac/pyobjc_framework_healthkit-12.2.tar.gz", hash = "sha256:48bda5f86fff2da976c49d27c746cd190d62eebdfa6197305c3656c64a6fbf09", size = 116197, upload-time = "2026-05-30T12:38:16.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/fa/f5c4bb870d80367150b98e00c0d0ff552ce844e6d33a709812cfc270f725/pyobjc_framework_healthkit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9ce9c1296608b26b13fdd9154e06928f854c41f9c8b519721a3ec1c17e17f6c8", size = 22036, upload-time = "2026-05-30T12:09:33.257Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c3/94476c8c0090e9ef4e6f8c41dd27c379cce5e3f042525059585bf56eb3d1/pyobjc_framework_healthkit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1166c17aa067e9c7cfbfd07f56eaae0f0ea44fa8c0e86c7772a985b40bd35342", size = 22040, upload-time = "2026-05-30T12:09:35.699Z" },
+    { url = "https://files.pythonhosted.org/packages/33/07/e2738cd62bd458a903112c6b3aec3bdc56c5fd54a734da49e19c5ae808fe/pyobjc_framework_healthkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b08b6a12a85c50bcd24286e3477070a60a9e602a34e14f1d1952fdd58e3e51c6", size = 22044, upload-time = "2026-05-30T12:09:38.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/44/db40ed76d01e0a99820f56dd0792448dbc34d508d2235d9185ec0fbb3db8/pyobjc_framework_healthkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:489858fd2cf97747390d14bd5343448a9cf612383e96958fd70968d1d7e75d02", size = 22058, upload-time = "2026-05-30T12:09:40.434Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/88/839c556d8e8e75b65961e65b78f683113cca6637e1917c9c4c0e2f050249/pyobjc_framework_healthkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c8d43159c2c40641f9306407ef909b338325028846d04feaf2b26673d6b1bb4d", size = 22228, upload-time = "2026-05-30T12:09:42.738Z" },
+    { url = "https://files.pythonhosted.org/packages/38/39/82d7c9e65344b6d223ea15132471e3091e85a6f0fb6e4672a27f2290360e/pyobjc_framework_healthkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:94a42750ac0fc7f0e624f5541798dc9dba4e557569016333c058552f29f237ef", size = 22117, upload-time = "2026-05-30T12:09:44.846Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2d/ef8d426d61ce4b41bdaa288b39246e7015264d96023318955e30f135e4ad/pyobjc_framework_healthkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:61b255e761c606a11f5a889cd3f7e251ae730bffbdd492e742030cd381ed69dc", size = 22290, upload-time = "2026-05-30T12:09:47.123Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/bf/c74fdf554df43bd0a52c97737e902aafa54aa5c38850749549c7b7a35054/pyobjc_framework_healthkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:328ff39f3ca9a4153c57b4a0ca38f7a5c8f289021f204c7347b04021100c277a", size = 22108, upload-time = "2026-05-30T12:09:49.443Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e2/aad8f382f66cf5bbeb5ae87b162771ba3015215ec26b3d13d72a8f7ca064/pyobjc_framework_healthkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:6bc2c41c2e4c42485bcb07a583dfa575678b1f220ec8b8186504495941d81793", size = 22274, upload-time = "2026-05-30T12:09:51.803Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-imagecapturecore"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/7b/fada6744e9409643f7ec948a9b8fd5632a8f935d2c1d53e8a9f443a613bb/pyobjc_framework_imagecapturecore-12.2.tar.gz", hash = "sha256:c2931ca0d40d6ffe159149e140d4d158d3f844f19b99dae35f57c34551434eea", size = 53438, upload-time = "2026-05-30T12:38:20.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/66/5e5532d70602174ac3252a735ccebd3d4650074f69a2f66d946290916f41/pyobjc_framework_imagecapturecore-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:da0b08d0550ffd6e11e9d814ac1c215bb9cbd0011f4fba54a19606d949a3380c", size = 16014, upload-time = "2026-05-30T12:09:53.957Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/51/7053c7b8ef462f2cb34e008f7d8718fb115626ad537d859f5d8d2433ee54/pyobjc_framework_imagecapturecore-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e41d42db77e0bbc929c406ee4b16f389c23b5b824174485ae71c35d15de7b07d", size = 16014, upload-time = "2026-05-30T12:09:56.131Z" },
+    { url = "https://files.pythonhosted.org/packages/88/26/ae619b47f178d4fbf3b3abe277e1e17000b2c396f02f8b09e9206473a6a7/pyobjc_framework_imagecapturecore-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ed4af478ae05a0c6890bb9b89fdd02e44ce5e6602145d5796299df1b729db43a", size = 16039, upload-time = "2026-05-30T12:09:58.219Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/39/23ab07b2cef5e26b017723f061d5941416a107679f19f5327b6576cf5df0/pyobjc_framework_imagecapturecore-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:12514630d46621acaeae0b921ee7c9c9e4a2bf81a936690b767a6b745e899812", size = 16055, upload-time = "2026-05-30T12:10:00.367Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/fed9ab9b40538711e3aba6c7b92a38c5439427510dd318923237f2280dc4/pyobjc_framework_imagecapturecore-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:56dbdee10d3d735fadfa15b3e7b9a11d3574493a4114fe9bf0eae86f55b43d2e", size = 16240, upload-time = "2026-05-30T12:10:02.684Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/4c/c35456724c11023080016a693bfd045263d57b493532bac08ca953c6d886/pyobjc_framework_imagecapturecore-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:daa65200664f6098ddf8f7525a83bcf77766fbbff98eba54226318cc624c0d2b", size = 16052, upload-time = "2026-05-30T12:10:04.856Z" },
+    { url = "https://files.pythonhosted.org/packages/86/94/fa7ab262c873fa598e97b3a514b65237fa7b179a70b537eec83dac18d4a7/pyobjc_framework_imagecapturecore-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8e072e4ec1f67608e932bcf08a37972c10e91f1dd1dc92a7ade7210553aaaae5", size = 16234, upload-time = "2026-05-30T12:10:06.758Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b5/126e7612bb1113dfcba7469c6a7a5440d41004f0c1a1fab688d5ad8a16ed/pyobjc_framework_imagecapturecore-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:bbefe336223ec5b3b18a211a6b65212da0cd5caa03124a9bef75e175ae913493", size = 16043, upload-time = "2026-05-30T12:10:08.913Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/5f/8cacbb42d183d47367a5aff499eb7c7f262bfc508ae10dd581d8a54a8568/pyobjc_framework_imagecapturecore-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:40488cbbb0ac35545a5f55c1e06327d43927db2cbd1e339cebbef10e4e12aba2", size = 16233, upload-time = "2026-05-30T12:10:10.913Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-inputmethodkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8d/b9ba4cf37ef153584df3098cbc19ba668aef8469f18af53ff464eed1bd96/pyobjc_framework_inputmethodkit-12.2.tar.gz", hash = "sha256:63ab93867f25a3f54fc55e98b6b0540d0d23bf6f91a0a475ff742e4221a75917", size = 26270, upload-time = "2026-05-30T12:38:22.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/59/df7a72fbce75d0e6b1daa594aad58c4cde5d525456b250297fba94f5fb75/pyobjc_framework_inputmethodkit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:fb241ca91e34dc6d30df752b332daa9920bf6f434293c590b846e91112e25647", size = 9498, upload-time = "2026-05-30T12:10:12.809Z" },
+    { url = "https://files.pythonhosted.org/packages/59/75/265a115176567362412c83ef144e240b0f4537ee4dec554256a9eb30ca3f/pyobjc_framework_inputmethodkit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c65d52b393e91af5340f8c404d5dca1bcac53a380045948fb5e5b25941010ba0", size = 9499, upload-time = "2026-05-30T12:10:14.562Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ea/e1f7e0d5984a6396e02930864e4260346f63506bf202a5e39a2052bf3f1d/pyobjc_framework_inputmethodkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:877c3fff5142434a8c7a5c357b5d44b731ecb1572c8f3ae275d54868fa9d46ce", size = 9509, upload-time = "2026-05-30T12:10:16.115Z" },
+    { url = "https://files.pythonhosted.org/packages/49/88/e5fc011ab34970cc1c1cc56b866e2edac6d160d25aafad7e86b033826cbf/pyobjc_framework_inputmethodkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:160ba62082a30d76b9e4aec1a4d54c95152fe39217940fea597756ad49910dde", size = 9527, upload-time = "2026-05-30T12:10:17.693Z" },
+    { url = "https://files.pythonhosted.org/packages/43/68/3c2fc27aab9cf228ede204ad7c8d1fe5f4e714aa4e478fe943dde6417258/pyobjc_framework_inputmethodkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0b81fba64e92953ffc1788ec13c630a9d19447deacde34a7309c0eae6412d628", size = 9694, upload-time = "2026-05-30T12:10:19.292Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4f/b8b96ca3392c7157e3abcd67f804ff1bc653b8a1c8c054a7717454e7d5b8/pyobjc_framework_inputmethodkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ec6fe7374c080676b0a3d54906f542fdf49d685c45b7988e03a58530f54b4522", size = 9572, upload-time = "2026-05-30T12:10:21.366Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f4/b4a07352bb14549d58edaed5eca2b97653960891d85dcb499425110e1260/pyobjc_framework_inputmethodkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1ee16198c4ac8e9327ce3d98f91cfe085d05eddae958a4e7fb3fe24e63d8506c", size = 9748, upload-time = "2026-05-30T12:10:23.069Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/5a54161025361652ba6ec476b55f4b9e6d89bf576ed3592b4f176c6790ea/pyobjc_framework_inputmethodkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a32436b7a498fa54e7a1a75d812dc7e61391cd7ce27d5ead0dd23ff0f3fbf74b", size = 9577, upload-time = "2026-05-30T12:10:24.674Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7f/8bd67197094b11037ea5512eac034b9ed1cfd509f2db2d5d2063089bd947/pyobjc_framework_inputmethodkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:155a5d6a770403a99dc9a359aed08f542a309f6e3b20e96115196e7e61585b32", size = 9740, upload-time = "2026-05-30T12:10:26.275Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-installerplugins"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/31/4284cba4b8904d2b93738249bb888762115d06876b92d30b721dea91e014/pyobjc_framework_installerplugins-12.2.tar.gz", hash = "sha256:6de54ab966f5bb304f9f5036c41937675cfdf49c44f70a1078a87dee2520261a", size = 26005, upload-time = "2026-05-30T12:38:25.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/08/9b8bb5f74df7d23d83ec5ab954301c91b8239091767df064aaff5b54c7a9/pyobjc_framework_installerplugins-12.2-py2.py3-none-any.whl", hash = "sha256:358ef2faefe1b9938c0563e95551ad685c4c2097a7b8bc46dbf394765eb00674", size = 4814, upload-time = "2026-05-30T12:10:27.678Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-instantmessage"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/20/2beaee41e71fcfe9bd3149277977aaef9510fae7d4ea3d70baecf2a978f3/pyobjc_framework_instantmessage-12.2.tar.gz", hash = "sha256:95a972697cc1c8c773d2e211815c7b4f3f11ad0aa114e46ec386d92f873d5533", size = 34017, upload-time = "2026-05-30T12:38:28.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/63/68356d5150c203b6b027dc93048b7e81d53c58d5d437b60dce914f861496/pyobjc_framework_instantmessage-12.2-py2.py3-none-any.whl", hash = "sha256:2fe9367f736b68557bf0c57a7da2c6a854cbf46ace9f6c5b161131309dc6b262", size = 5436, upload-time = "2026-05-30T12:10:29.334Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-intents"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/a1/2544e2b1e4fc794bc09b16651e967cbe11a17bf75f6d13c34a261e49a13f/pyobjc_framework_intents-12.2.tar.gz", hash = "sha256:441acf32738c8a4fa21458467ce451ce6880d0bac71b6e63e2e6634775f603b6", size = 187703, upload-time = "2026-05-30T12:38:40.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/7a/b54bfc7dcb43fbe8f4af7c33df42ed8370efbfff3649b1f3512474dea6b3/pyobjc_framework_intents-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c5cd933c8d832ad1ac817a815512d1960731f75b0bb277cf642291ffbbd7985", size = 35234, upload-time = "2026-05-30T12:10:32.605Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/43/bfa9a9869324e451e505b54b58783c49418effa15fdbac7c56cd56ab4a2b/pyobjc_framework_intents-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:89095f0f5b5f2c99d1b670fc179abf36f7c6107acaadc6f582f5abdbe83a2080", size = 35236, upload-time = "2026-05-30T12:10:35.953Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/40/01d85f90d9654083afd8588969b9d29daa8173463695e27df73103a74a16/pyobjc_framework_intents-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0813154a7d37ead88ef741e971b0e053560dfeec524b989f3b60b119df2b5976", size = 35255, upload-time = "2026-05-30T12:10:39.031Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4b/74dc067c2475881c4c93a2f4d6f460733a963a3f687de9f413b1280e40d0/pyobjc_framework_intents-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1786dd54d1c570ca6be16383e653b897ad4c1b0c3df9be60ac5f8e0096d4a181", size = 35268, upload-time = "2026-05-30T12:10:42.054Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8d/d6cb87fdc7df4bc81b61cb184d5fed3f55cc2cd30eed90033f434a32716e/pyobjc_framework_intents-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9d697dca29ce2c282dafc4db9c0a0f165802e8d056a68f809bee0521ca47ff24", size = 35512, upload-time = "2026-05-30T12:10:45.295Z" },
+    { url = "https://files.pythonhosted.org/packages/95/78/30348e2ec790164ae11df2f07de9464ba767d3a73a55875b3e904e847e20/pyobjc_framework_intents-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ed30e7c0b26622621046ce20c318084288d144ccc513736dbca856b91c5227e8", size = 35283, upload-time = "2026-05-30T12:10:48.573Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/f3/028fe6f22c6556c9f5faf391e3ea058339fd4ed2106fb34a6ba5c160af77/pyobjc_framework_intents-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d6ae3f19f711a256b370435df0bad11c805ba5513208b5abdc61c30e7c75fd44", size = 35578, upload-time = "2026-05-30T12:10:51.729Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ae/f0a94a60a788a25716f854018e415112b20b1b3db1a54897e0b3290cf761/pyobjc_framework_intents-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f07dbd2383f859ed18a390d5e02b28e7fbc89679246fc1c330ec56190e72db1b", size = 35293, upload-time = "2026-05-30T12:10:54.895Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/149a16762f0b496e1b025d6d56ed0a6447b1229ad1195297e06220931328/pyobjc_framework_intents-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e5a9548175ff5d4630a6f2d800bbfe82e26bc4205358a7fb28429c5d40727bf5", size = 35580, upload-time = "2026-05-30T12:10:57.953Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-intentsui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-intents" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/10/cdd1d80716e9970f5190517daa613a2d16bfec532b3fc9bd8f987c00a178/pyobjc_framework_intentsui-12.2.tar.gz", hash = "sha256:46292de2f2e915ddff88a060639adb175e0b3b2452a45f00e440dc04acbe0e70", size = 20742, upload-time = "2026-05-30T12:38:42.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/4e/eec104a8152df3d8f409aa00a22c0a444e7c3fdb045f2a5bec8b1ec8676b/pyobjc_framework_intentsui-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f73d4e93a8a2abb263c4eae213ce78fdd9326032f8b89cbd1759edcabbe023a5", size = 8999, upload-time = "2026-05-30T12:10:59.773Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b1/320ab363b6bada0f1e3aea4697aebede69bdc6790a1839bd26eb14464ea7/pyobjc_framework_intentsui-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a6e989903e2ee45b2da03a14e7112aa30a1cece2a308df756154256d96fb3035", size = 9001, upload-time = "2026-05-30T12:11:02.578Z" },
+    { url = "https://files.pythonhosted.org/packages/60/6b/06859a077829bcb895ac373cd1d3b268bb77bdfdd90d976c741c68bc0054/pyobjc_framework_intentsui-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a92c40a66a27e70c4ee70838f43ae2c6f8ca6263699ed5e38ba25ebfef35f6c3", size = 9023, upload-time = "2026-05-30T12:11:04.153Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f9/10f8bafdd58f136cd373fa2b0b5bd869dd6f7576abee9135fbc51c10e549/pyobjc_framework_intentsui-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:da18833b15f8f31ecc5d4769250de6883e1e117392840175ff33d002a8196f46", size = 9047, upload-time = "2026-05-30T12:11:05.908Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e9/6f1eb774981b665e87c08f21b3a4695d0d97dce1c2a9e7eb2ab1956605e4/pyobjc_framework_intentsui-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:96b0b96147554a0e848a6804ad725abbb183b3d045481abf54d31d6a334a1a25", size = 9222, upload-time = "2026-05-30T12:11:07.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/66/c65ce9b1e5241caec467ac8d983787cdfe8fb500ad4342d95cbcd9011674/pyobjc_framework_intentsui-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c369461ac245b084cfa4803e90a91f43838637a4cce4cb0d25e71cf02e8444b", size = 9095, upload-time = "2026-05-30T12:11:09.161Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6a/4d1eb10ba9cb2eeb30b22b2b10c274f76f25d0e2ea6b0d2a129d704e0645/pyobjc_framework_intentsui-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1c78cd4e536590c15926d3ec2d2e0eb7ddaee9430424b30d5478ae12d3a53897", size = 9290, upload-time = "2026-05-30T12:11:10.799Z" },
+    { url = "https://files.pythonhosted.org/packages/12/8e/819ab1305d33e6c0d1342d5ebbd216f13fc5f682392d85162ad8fd9d283e/pyobjc_framework_intentsui-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6a60e5f5277690479cad06df8a8e008f8f02e625bce2a24869770807576a78d5", size = 9089, upload-time = "2026-05-30T12:11:12.412Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/22/a674939ee5fdab2238452a9389d36e543ffef04432319057f357ed060a78/pyobjc_framework_intentsui-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:cad7677ef0ebe7e9fe83f07dea7e999f9fe067b3ff8e02520ddd3272ba19eabd", size = 9278, upload-time = "2026-05-30T12:11:14.014Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-iobluetooth"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/d0/ea3057fb6977ab87c85db9e676d8ec77ce77d096680bacade1964ced17e5/pyobjc_framework_iobluetooth-12.2.tar.gz", hash = "sha256:7fd7265db0f467a471a015f5a32ee79fd8f42440888d16b4206bbb985ed7331d", size = 174868, upload-time = "2026-05-30T12:38:53.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/92/f61a63272066701099b510b5f5b353abc5356f818207a494cadf8a235294/pyobjc_framework_iobluetooth-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2e848d5015d55ede9e66d75375fb14de5d9f691da04cd53c41378f002b7fb6fc", size = 40510, upload-time = "2026-05-30T12:11:17.497Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/51/fe2a1088e70d880e6dae4aa8024544e6045ae35f11e124bdcea2fb5d1b27/pyobjc_framework_iobluetooth-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6f0962cd2122cdf81e4d04e86380456f0caa7631e020cac5f60cfa60ed1db6e1", size = 40514, upload-time = "2026-05-30T12:11:21.038Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/cf25292e7c6336b189f9bf9cd99df59aab8e20de9028abb4d2d7bc3d4559/pyobjc_framework_iobluetooth-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b895e3c7665ac7d59f3356fc0c4471cf7c47146da65ee0b5cce327d3cafbdf70", size = 40541, upload-time = "2026-05-30T12:11:24.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7c/6252a3f61bd674c770d37517433485653aeb5e24ff2f5df2a71b79cf9197/pyobjc_framework_iobluetooth-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8bea83069a68476036c260e3c1f3f2a6cc919aa965ecd89c8821165daaf9886f", size = 40552, upload-time = "2026-05-30T12:11:28.065Z" },
+    { url = "https://files.pythonhosted.org/packages/df/88/4e49653cc0bf64a90b1aa10b89540cd8d6929a4e4ed79d5546b3bf6cc0f8/pyobjc_framework_iobluetooth-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2d058ea04a6924233701cb0c9312aea71174d38a37430494e725d17eb7933ae8", size = 40763, upload-time = "2026-05-30T12:11:31.474Z" },
+    { url = "https://files.pythonhosted.org/packages/20/cc/9b09bc4022a05b00a187577caba8d46850c5a1d29112d3cf3826993080fb/pyobjc_framework_iobluetooth-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:63e089fb47feee2dd1f7de136ecf4a4985597b175cd210252fad7789dff5c537", size = 40542, upload-time = "2026-05-30T12:11:34.89Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/59/a0ff3b21a108a8fe1bdbb2bfd831a07d4be77d133500a3ba2a9aa2a2d186/pyobjc_framework_iobluetooth-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:98685dae5876da9d01dd531ef8f2f40c87d076dca2b79edf12dc5413492127e5", size = 40743, upload-time = "2026-05-30T12:11:38.293Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c3/9dd84d41a883329e6cf2912f945ad2c22e9d6bb5802895e57e9fac4123ae/pyobjc_framework_iobluetooth-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f0f848fdc184ab910ab00e395fb1fe3de9b89625e0dc19967560b796da73bfdc", size = 40531, upload-time = "2026-05-30T12:11:41.71Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bc/bc8c028fbcb51a4b4a91224b3f0e40ef1385cc444764efdc4ba8f411cb16/pyobjc_framework_iobluetooth-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:6715d29e3f1fb465144abf77a7372795aa18e61b77abf44e9605ac657895cb9b", size = 40741, upload-time = "2026-05-30T12:11:45.07Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-iobluetoothui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-iobluetooth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/cd/0c14569b91e29bd0f64e2496c21b15e34e789f0ca07f5cf0149dec37ec72/pyobjc_framework_iobluetoothui-12.2.tar.gz", hash = "sha256:7902974cbc2ec50adc38dd961b03eae6a84f082812ed60a440db6f690b30b2d2", size = 17987, upload-time = "2026-05-30T12:38:55.655Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/a8/2ab7199c81c9f1541e20caa78cf44df5f05162665fcfd29f16e3a85fe822/pyobjc_framework_iobluetoothui-12.2-py2.py3-none-any.whl", hash = "sha256:60622518d2f70e82398c62edf5e4e72403ef9210312945d82f3151cb5e888ccb", size = 4043, upload-time = "2026-05-30T12:11:46.476Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-iosurface"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/3d/744c44cdd66f273e1ca731343e7845a281cb14a25c40d20a307334a36e21/pyobjc_framework_iosurface-12.2.tar.gz", hash = "sha256:d0315c6ad3b5ee72d3a5c946d9e92a4cace1a96bd0526f0b9f6b8009c26b9716", size = 18607, upload-time = "2026-05-30T12:38:57.666Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/f8/35fcd4d2504d0b470dd746138f47f6a8d8077fbde6aa85914c999ff9f7d5/pyobjc_framework_iosurface-12.2-py2.py3-none-any.whl", hash = "sha256:3ccd3abe40e21028419a39dbea36f60cb7e34335ab1b81aebb7a1a2f644443c5", size = 4903, upload-time = "2026-05-30T12:11:48.133Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-ituneslibrary"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/37/308813d2e80ce9c8c4e5710e0f1e1dc479be03bb06e2f28dc9058862a756/pyobjc_framework_ituneslibrary-12.2.tar.gz", hash = "sha256:780f7e5f354dc2b0a27df4abb6538f730e8a29371a8703bc05edd6ce50466f8e", size = 26172, upload-time = "2026-05-30T12:39:00.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/c3/6c8fa4798c8f3d5194dc7f1d4ca061840705b7a908b6ba05b3c9449a0b22/pyobjc_framework_ituneslibrary-12.2-py2.py3-none-any.whl", hash = "sha256:9876e99dac601dc523b2f0e528fb21b027693b2b6f7d697fdf460cb819339980", size = 5212, upload-time = "2026-05-30T12:11:49.77Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-kernelmanagement"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/b7/f367cc6c20fc0e9b80706284a1978fa0ee90ba61c2421d7bab867a3ce4d2/pyobjc_framework_kernelmanagement-12.2.tar.gz", hash = "sha256:01abc525c1edbacf88425a36a055e52d1b4a024299097d9a2b25c34f2df4bafc", size = 11935, upload-time = "2026-05-30T12:39:02.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/5e/f98eb2645e1899579eb0b30695866611db6c25cef135dfdd323a164a5d8c/pyobjc_framework_kernelmanagement-12.2-py2.py3-none-any.whl", hash = "sha256:14e789ed81eaaf3ca50557015416fdc232400b682b3756efaefe4afd061552e0", size = 3672, upload-time = "2026-05-30T12:11:51.232Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-latentsemanticmapping"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/bb/2824a4eae4fad404603e5ab859654f4f5c5efb9687b27f97c58915726a44/pyobjc_framework_latentsemanticmapping-12.2.tar.gz", hash = "sha256:20dfeeb005880053dcccc03dc6a58d796dd72d7f282caa625906bebc3631ecd4", size = 15932, upload-time = "2026-05-30T12:39:04.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/16/85b8b7dbc58a0cd0baba9854604be687620433fe354347c0e93e05025551/pyobjc_framework_latentsemanticmapping-12.2-py2.py3-none-any.whl", hash = "sha256:1c87b1dd06626eca6188c2939f0dc1f58104ac9f8979c1dd8fc5f8c7d4d901e7", size = 5472, upload-time = "2026-05-30T12:11:52.82Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-launchservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-coreservices" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/fd/3ecceb569730898ffe9146f3e544415b4e4ea7d3343e424a3cd17500bf5d/pyobjc_framework_launchservices-12.2.tar.gz", hash = "sha256:02c3f25311673fc26eebb256cd0e873c9883575804c98b97a5d2096c8cebcecd", size = 20826, upload-time = "2026-05-30T12:39:06.23Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/8d/04c6bb237127a6c109437af6bae244b3695deca6dae67a20d408db736a1b/pyobjc_framework_launchservices-12.2-py2.py3-none-any.whl", hash = "sha256:4a0a478dfee2c53b7f3e2168f3c0e4183621050d324e7225251706500f8f5f0e", size = 3902, upload-time = "2026-05-30T12:11:54.2Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-libdispatch"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fe/e23be301e46c30450955cdb096f16f6a86e7609787a4b8225ec24d6fdc9d/pyobjc_framework_libdispatch-12.2.tar.gz", hash = "sha256:4a41879ef7716b73d70f2e40ff39353d686cbc59d48c93217ed362d2b2baf1ba", size = 40345, upload-time = "2026-05-30T12:39:09.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/fb/b6948caf3e365aa3ad9400376832258ab25a10a43423d47a1be6d9ddef9c/pyobjc_framework_libdispatch-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0a43de8025ef9e2db597dbe3d2b49c9952d0b0aa93a78d89b0bfdc58f851f42c", size = 20466, upload-time = "2026-05-30T12:11:56.667Z" },
+    { url = "https://files.pythonhosted.org/packages/22/2b/b8d686307f4e8ba65afb204623da0b5568ac624caafc3a777a107c57fec1/pyobjc_framework_libdispatch-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:38fb417f3f3ee1ec20e14821f150210f5b6122e5c1d8b04958bddb660ce3d04f", size = 20462, upload-time = "2026-05-30T12:11:59.253Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/9e/94b587d8c5b243cb6026489752093a45d75fff08c85ed5b8b5548ad3596a/pyobjc_framework_libdispatch-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9fb0028b400661b6b2279e2b611d396a4217bc36aa9dadd3ae21419551f5e091", size = 15634, upload-time = "2026-05-30T12:12:01.08Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ac/f5e01c960287e3484f71a737e7ffd75ca1c192200de70fa342a22181895f/pyobjc_framework_libdispatch-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:265fe4edfd60de111c870932ab8397f845c314332a935aa7a27100fd8562cebc", size = 15651, upload-time = "2026-05-30T12:12:03.156Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d9/8bcb4e234aee09396d06515ed80fb1f79cee3aeb67a311aa8e81a085584b/pyobjc_framework_libdispatch-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:117ed20ca54e334f657e60b9b9a3de3741d91875fd50ee51ac6a09224912cc68", size = 15918, upload-time = "2026-05-30T12:12:05.257Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/0e/caee3281628ba4913206167062274334a62ba5dedb8dada5fd884a53584f/pyobjc_framework_libdispatch-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fef3158dd4a068a9db8108a5cbf7da385788136e1d8af2e6fb7f82215016ecb2", size = 15679, upload-time = "2026-05-30T12:12:07.217Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e0/ecf5fb9f11d12271818c5244c57d36ee654abfa2d15799bd594d4f58d931/pyobjc_framework_libdispatch-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:02dc66f1c11e25eceecf3c1b2b397f1727659dcac3e0c7b97784d5af3cfab491", size = 15960, upload-time = "2026-05-30T12:12:09.199Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/74/c1d1d1fc45434dcbab16887273d368d9ad89e65939babcffd502ed308ef9/pyobjc_framework_libdispatch-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a81d9329fdf5094c9bc09b916e1d2fb86ab27138161d3e7ddb76ec2e780a1aba", size = 15699, upload-time = "2026-05-30T12:12:11.103Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/46/6ba13e10cbac853af00ee37444f37826a0688e32d1d22ce2fde4e2add9d3/pyobjc_framework_libdispatch-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:8daaf8844b5b328cf8adb6e8c085bf2aad22237956f7c5dc6fbb7a46c5015af0", size = 15990, upload-time = "2026-05-30T12:12:13.077Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-libxpc"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/a2/443c0cad2a13ec038318d391f7ebfec2189ea6d97910c0ded4c863631603/pyobjc_framework_libxpc-12.2.tar.gz", hash = "sha256:6dcae3da5ab706762d68625a391c75a3969609e5676d4091947f5c1185d4f800", size = 37263, upload-time = "2026-05-30T12:39:12.446Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/1c/39666de6c68499049d21104ce5703cac237cc184e8b3cfa70e9737cb79ff/pyobjc_framework_libxpc-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2c9e5f079cf4d271be77f86ceb5928f056389354ef94fbea89d10c1c653b9163", size = 19627, upload-time = "2026-05-30T12:12:15.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d3/3042bb02359ea8b9b68184edffdcf0afba04b1b43c33056cc2c57d9320fa/pyobjc_framework_libxpc-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0484617362aaf302b28dfd5c5fe2704ff7834a539f01df0d86b1a357f5ee8911", size = 19625, upload-time = "2026-05-30T12:12:17.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/35/04ee5a0c94c0e59536cd5d20e5afad73704240ed1f5d770a6eebd4fcf992/pyobjc_framework_libxpc-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b1e5826137f5fe3c20a1f7f6d3bb55d7f692bbb85a16be209103f32761df3e0c", size = 19753, upload-time = "2026-05-30T12:12:19.57Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f3/9e971bd977c63575359c1e4d95a0c7ac8acba1d0094b190bd738bf64dedd/pyobjc_framework_libxpc-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7caa888b1046a7921121cb44087746803a458002a1182105b3e64734b0ca9f40", size = 19753, upload-time = "2026-05-30T12:12:21.682Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e7/143c999a6dde74bff96697b36270ee6d8b105ce01d11b1a066d573a5d722/pyobjc_framework_libxpc-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:56bf8fbc45e722af533bed03889d02c1dd7f81338946575bbad3efb049e8177a", size = 20308, upload-time = "2026-05-30T12:12:23.88Z" },
+    { url = "https://files.pythonhosted.org/packages/08/40/996207b9c0fff0ec877ca9ed88a3e546bdf0f82ac5052a9d3cc84be8e170/pyobjc_framework_libxpc-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2ef1feb41c7f52b771c9dd490d60b267d25983b19e7f6a896a0534bb97fcb728", size = 19486, upload-time = "2026-05-30T12:12:26.018Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b5/59eca99d7dde55d8af5b7639faa0bda9239ddd23f64424ca4ca6fcb22512/pyobjc_framework_libxpc-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:2ba3e82597fcb828b60b5a95f6a189ae3374257a99058109ddd4844926579c0b", size = 20012, upload-time = "2026-05-30T12:12:28.244Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d3/a023ec78325f3c5db3a58c17c5eb3323def22ea99c170cdf5361d47c572a/pyobjc_framework_libxpc-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:91d66e792bcdff0680698d8a4f4ca67962afb2810c3edfb652e34ebe6b4a942e", size = 19492, upload-time = "2026-05-30T12:12:30.308Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a9/368f38fa17b507001555ad7e4b6ee243920d6111358656334c038c85bc79/pyobjc_framework_libxpc-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c38d61a2ba5e26ba12bf0566dfa0687f396239c72f9d940d06b1e70af19cddf7", size = 20039, upload-time = "2026-05-30T12:12:32.574Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-linkpresentation"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/20/a55fa5ca6fbeb0a0b00515f4aa37cdb946e36fbaba8c8bef6c47774c10b4/pyobjc_framework_linkpresentation-12.2.tar.gz", hash = "sha256:bb910f692f3166d6c5fce44f501a4d64a6067bac9bc26ec9488995fae56bfe6d", size = 13988, upload-time = "2026-05-30T12:39:14.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/42/264d202bd16bb6d8b2820c4a0d3eb1267add1c94aef68aeb749927dfff52/pyobjc_framework_linkpresentation-12.2-py2.py3-none-any.whl", hash = "sha256:68f854b4b72fef3477f1fb6604b258207a5950164e8e278330cd4848281eafee", size = 3864, upload-time = "2026-05-30T12:12:33.935Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-localauthentication"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-security" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/bb/68ff2b154ed783d39a1752cbbb7dc9d0ce55c17097dc00fe56d9080c6349/pyobjc_framework_localauthentication-12.2.tar.gz", hash = "sha256:e1d734db5ddf35093307e213115bd122ef8712463be048eabfa4062022373e21", size = 33074, upload-time = "2026-05-30T12:39:16.945Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/cb/7dc0aa072261297e1661623937e7f20ba5a3cf370fee66164b18279f70cc/pyobjc_framework_localauthentication-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:df0770bb3bf8b2918c2395ff7f1368d2669a7bb189318755c7fec1e441c2ddc1", size = 10867, upload-time = "2026-05-30T12:12:35.622Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/2a/49cec4a50756c9192d21f60607548240152a93e0fc43ed5ba50959e39b91/pyobjc_framework_localauthentication-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cab043474b3337b6479ab69a0a205377b6c899b0956b1b87534bd8dcaaf58a52", size = 10862, upload-time = "2026-05-30T12:12:37.637Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4c/2893b8b70189597a84d5804e97df123f7596d83e5fa545894f2a0d6e3267/pyobjc_framework_localauthentication-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0e1287a84708dd01e959fe3099fb89cff72bba292e0bafdc2e0385e12f0729cc", size = 10876, upload-time = "2026-05-30T12:12:39.478Z" },
+    { url = "https://files.pythonhosted.org/packages/09/28/23c4a20e97d06854248625f53b30543340c17e478e9d6850cbee9ea50736/pyobjc_framework_localauthentication-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:38eab810ace8b5cd5aac593b8f0db99a9851a47e7310e0a010eb33d37043da30", size = 10895, upload-time = "2026-05-30T12:12:41.218Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/05/4b988f1e0f70b404b3e6ee0b0f63e9a368efb2a17c8b900e57992c126b2c/pyobjc_framework_localauthentication-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3b7ad8257cd372950463a4d6fe2f0b5ab14891ca756a8547c3fdb1b3236ec9ca", size = 11042, upload-time = "2026-05-30T12:12:42.808Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/38/a42123af0bc7ed7dba480b742fc97015bcf009dd81e2cf11b9eff79c6ed1/pyobjc_framework_localauthentication-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8ac59a0aa0ea790743b680eec3050d6df5319d5b473c7c1deacb037e2509c9fc", size = 10942, upload-time = "2026-05-30T12:12:44.703Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8e/915a63e42de556ed4da27c2537e0399213d22dbd1ed2bf6dbed43ad53b2f/pyobjc_framework_localauthentication-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ff66f71e12f30c6ee2c4438fa933f9fcb34468e68e5721e8e640a37a90ada0a0", size = 11083, upload-time = "2026-05-30T12:12:46.39Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e1/f8ea9d201f4118c13e8649e4fce9a21dbe196fc42424923fa13907514b17/pyobjc_framework_localauthentication-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:8b3bd2d3d9138cc091f977f8f69ebd71c9fa723086b5b1eca8f89f8c7a58410d", size = 10949, upload-time = "2026-05-30T12:12:48.083Z" },
+    { url = "https://files.pythonhosted.org/packages/13/fe/24d6a3a4e761772925dbd06588cd3085ed6800a4d7991bb3d7b1fd45000a/pyobjc_framework_localauthentication-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1de45570296d7ab3aa0bc66dc6d9a31d6c6b33f950ea3d5bee8e5042c6fde92e", size = 11077, upload-time = "2026-05-30T12:12:49.835Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-localauthenticationembeddedui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-localauthentication" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/93/a9d21a00896d016924d1912f2dd8918f8aa95ac0893c2b110cadc779a16a/pyobjc_framework_localauthenticationembeddedui-12.2.tar.gz", hash = "sha256:cff4e489375b3898f34d8ab378f8d84623ab19e89a35de958825c125aafceca6", size = 14134, upload-time = "2026-05-30T12:39:18.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/94/2e453acd660d9e1e059269c72a95b9f1f2de4a3b7a5dc0f6d6cdfd0eed5e/pyobjc_framework_localauthenticationembeddedui-12.2-py2.py3-none-any.whl", hash = "sha256:0b306917aa011deb364e85c118624d2d80c3eaf67016a345a6c4bc4960416b11", size = 3985, upload-time = "2026-05-30T12:12:51.194Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mailkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/44/b8fc4dec34b6f29a98f64f38eb6f37e9729aeee4d2e90887a9ece06010eb/pyobjc_framework_mailkit-12.2.tar.gz", hash = "sha256:e29ea94210faefc46a4aefe0c1647bfb77b42cfc2a4962fb8316cb967b34c47f", size = 23870, upload-time = "2026-05-30T12:39:21.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/95/2b4b95d7e5e43750631596da4ee8de4800883475864ca9f169881fbefb3b/pyobjc_framework_mailkit-12.2-py2.py3-none-any.whl", hash = "sha256:25b9aa8c513c40d931a7c5cc44571fd090e3d565f2e1153a634f6980b08da733", size = 4994, upload-time = "2026-05-30T12:12:52.648Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mapkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-corelocation" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/6b/0f3d14cd1b6f3d30420e268fe6b97f6ab55f1717a4c436ac6e57576c480f/pyobjc_framework_mapkit-12.2.tar.gz", hash = "sha256:65fdf104bd8a1d3e8965c689446b7e42a44ea4bc2da5c871ff389ef7a14ee030", size = 79554, upload-time = "2026-05-30T12:39:26.639Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/4c/4c595c11d9c8be8a8f4717a28e05f1ff8fafb78c1155de752c8a46c5f26e/pyobjc_framework_mapkit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3f186d0125c1a65ba9e08a10313bffcd7fb8569a827be0bf812743163bc4a643", size = 22808, upload-time = "2026-05-30T12:12:55.142Z" },
+    { url = "https://files.pythonhosted.org/packages/49/11/837c9ba6e481283c99e4613659149f128f0e7c990e26ec79bb1c296913f1/pyobjc_framework_mapkit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1fa28ddbc380eb66bc4b9a0bae9e931abb883498f3221baddd6678db37514dfa", size = 22805, upload-time = "2026-05-30T12:12:57.841Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8b/1f32a9a01f55fcdc86b4044a3c3b100901425c4a901b789586a1458ca44e/pyobjc_framework_mapkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3190f21e6bd9efda626da12e1f2d86bf26c56948dc6863358b0f62875fa5e288", size = 22830, upload-time = "2026-05-30T12:13:00.385Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/23/649ecd0f1b7092390d5012bfccf0d653840a002c215fe5c7b1d0e1ffb069/pyobjc_framework_mapkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4dc30cdae3b30869488ffa936d1bba327b6454809dc1d584083a8033637ab7f3", size = 22867, upload-time = "2026-05-30T12:13:02.802Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ee/d9a3b6a982a3e7fd04d06d1da9627c76b08c7107e46fff217f35a60f0350/pyobjc_framework_mapkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4245ce0af24948471eca1da30dac432712fb11ce0f65100420bfd74d176359bc", size = 23038, upload-time = "2026-05-30T12:13:05.233Z" },
+    { url = "https://files.pythonhosted.org/packages/22/50/679cd8f873fb077ef88cb7d36b485a5235f158dc70bea7a8357c9738cb36/pyobjc_framework_mapkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:45834cdf0845470504077fd352799a32dcee75ea66da20a3874ba1dbc52f95b8", size = 22883, upload-time = "2026-05-30T12:13:07.667Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/7c/ffb6b7abbb4a1f86d789b31da2516294465532c896f81665263ae8483f65/pyobjc_framework_mapkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5a7e425f626f796da48d3cf8895ccf2835c5b40432675630300bc2fcaae08129", size = 23095, upload-time = "2026-05-30T12:13:10.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a9/91f7aed638669796a13b08d7682e0681070f444d9e68c7abbfa60f3dc400/pyobjc_framework_mapkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:35fd5c1fbb0197ea7d44e739c1943270ec2c1e77f3dc6b363884943556b770e5", size = 22897, upload-time = "2026-05-30T12:13:12.601Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/6a/c5198e668724d04acb97fa44a31e2b11f664fa3aa8fc1438f479e928bb9d/pyobjc_framework_mapkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:71095b1129411dcf78aa2ff61f9a00679e5eeb6826ff3ef665a6f23156f4c393", size = 23100, upload-time = "2026-05-30T12:13:14.976Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mediaaccessibility"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/63/34d6f7af511b116dca7761385b7462eda9f39641a9ead9eb1404d621e571/pyobjc_framework_mediaaccessibility-12.2.tar.gz", hash = "sha256:9036a6412bce491b8ca477d4673b6e441cbf2cb2463d617f82bed818c5bde9d7", size = 17239, upload-time = "2026-05-30T12:39:28.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/b9/fb53b336b9d6233ca96e53aec4ea142d49b225f846bbd9e13353477f118b/pyobjc_framework_mediaaccessibility-12.2-py2.py3-none-any.whl", hash = "sha256:2e1d023c738ef09ed57635ae277b3644a09d7313e6bb979ee1c6d68bae57e4a8", size = 4822, upload-time = "2026-05-30T12:13:16.428Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mediaextension"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-avfoundation" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/db/c3c4a933685423d16f69daf8a0dbe026fd45a05e0988ed4842dc2a286097/pyobjc_framework_mediaextension-12.2.tar.gz", hash = "sha256:9affa99bd94774ed91f3fc9f314468b4dc3bc6fc110ee8a81884d3947a9ced12", size = 44550, upload-time = "2026-05-30T12:39:32.301Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/32/cd752d8412db4825bb5466d8234c1185b0a3fdf7774fbc7fc240ce573ea8/pyobjc_framework_mediaextension-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9eaa0b36fa2e4f43bdaf6783a18c16a0846966d41508b0571091d315c062af25", size = 38982, upload-time = "2026-05-30T12:13:19.812Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7b/717a6dc7e1e2a98c2f3a35c55d2d2532499955bed56a91ee1ca7486c46b6/pyobjc_framework_mediaextension-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a30162449f24b360b70a27daeeb159c8c308f5bd0d812eac9bc4e7e1a47be20c", size = 38987, upload-time = "2026-05-30T12:13:23.375Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/74/bad12d87ee91c01dc2af72e3e0fe3c4196764eb735759845f1ca1532d817/pyobjc_framework_mediaextension-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b1745f140a683cb1a310ff4c1206ad0d2e644cf1cfd1da3fd3be5de224890a4c", size = 38998, upload-time = "2026-05-30T12:13:26.744Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/8b/1576473cd8154bc5e2b36cf2f82bac60ad1223bc09145248639446bcfd18/pyobjc_framework_mediaextension-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:37e8a452f17db3bce2b50dec8a20b6851eed88906809d2361385c3b096751ff9", size = 39014, upload-time = "2026-05-30T12:13:30.015Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/31/473101b145d98dc738c021d66496149d38d2b57d746cf69a3665e5403dfc/pyobjc_framework_mediaextension-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5326b3ca9f8ba0f2b51525829bc833f9c441980e3cf6628137e51a50d9e45cbf", size = 39221, upload-time = "2026-05-30T12:13:33.332Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b4/9218de5d1a1018fa9bc52a342a128d1ff547613b8523b2fa48e215fbf281/pyobjc_framework_mediaextension-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9c315b0f9ec9a1a2239213d9b72f4653bc8ae8ff7a915e5c2b8b522e01b01c91", size = 39004, upload-time = "2026-05-30T12:13:36.818Z" },
+    { url = "https://files.pythonhosted.org/packages/69/a0/92f1046924df8ea54bafff6ca836254954f63232fee363cbd82d7084e955/pyobjc_framework_mediaextension-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:048a04da339030f15ec932de42428ed85a90faa6c80f982c710513ce43e54a07", size = 39211, upload-time = "2026-05-30T12:13:40.143Z" },
+    { url = "https://files.pythonhosted.org/packages/99/fa/80b00c06d4326039ae152393f4568ac7881d1080a98e436397b57ef18dc3/pyobjc_framework_mediaextension-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b34f4f1a89810925313ba97064e01b63b597e424749f0b78985c48dd5bf4cba0", size = 38998, upload-time = "2026-05-30T12:13:43.667Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f8/69b14a84ce316af7aac12ce3f7262fae225ead1ae9df1b8f9037762c0cb3/pyobjc_framework_mediaextension-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:bf567e1768b696f554b93c1f850eba474014d079abe70e65bbe816ed69e833bc", size = 39204, upload-time = "2026-05-30T12:13:46.995Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-medialibrary"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/44/ec97fab19e92f5d41c4e0f333bcd54f1f76a255406eadd93a95d753da711/pyobjc_framework_medialibrary-12.2.tar.gz", hash = "sha256:9b65eb789cf10b20f2c5bc4d5f4e61e5feb02a43bc213ac3c03b647e30b96634", size = 19019, upload-time = "2026-05-30T12:39:34.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/ee/8583d8c8a738e13f3e70bfb84ad70aab17f2995af55ece36780c1acbfdd1/pyobjc_framework_medialibrary-12.2-py2.py3-none-any.whl", hash = "sha256:3bc97cb03e633a3f6f0a4e9d351210000100ebd1a4b19624c49c4e9bc7b5e574", size = 4357, upload-time = "2026-05-30T12:13:48.479Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mediaplayer"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-avfoundation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/c0/aec081f84830e483e23a1763339c9c6ef9bd868d44d9aa39a83080b0ac29/pyobjc_framework_mediaplayer-12.2.tar.gz", hash = "sha256:ee4f818a85e89a4c691e368b2709709d11658b81713fe367342af24dba2c5e62", size = 42669, upload-time = "2026-05-30T12:39:37.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/89/a12bf5f69920b8909cf92b3e7722082600db4262293d5b878b58eaae8f7a/pyobjc_framework_mediaplayer-12.2-py2.py3-none-any.whl", hash = "sha256:436d3b410b84c7fa6577c4774faa4acc4bd3ca79f582b183e281ca63429a1574", size = 7176, upload-time = "2026-05-30T12:13:50.134Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mediatoolbox"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/6e/5181efc8c1a077599ab5ac1cb2263ebb43b1603ed994e486f8a983d2e694/pyobjc_framework_mediatoolbox-12.2.tar.gz", hash = "sha256:35fbaa7df491df5b756da1ad2035f0f04f72e556a560cdd9a6ef74ce315c555a", size = 22818, upload-time = "2026-05-30T12:39:39.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/23/1dbb7d105cb8498f75bfa9f797f0d0986830760ea0547941604ed2a6353a/pyobjc_framework_mediatoolbox-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:04d710cb762e3534af4adb77b63889b442abac664a8f729acca4f9e1a4876854", size = 12646, upload-time = "2026-05-30T12:13:51.972Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b2/c5d8bc13433156ff6cb2ad4410951aac82b76234175272209a56833eaf42/pyobjc_framework_mediatoolbox-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d381c72dd372abe15775d6c27deeb9260eb468bd12e3bf7928213f3ad6ab0c70", size = 12659, upload-time = "2026-05-30T12:13:53.845Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/5a/4b31f1751570b12f44ab4472786f48fe2e7540f96e52263ad384f5e2fe16/pyobjc_framework_mediatoolbox-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c722d9b86227fa0d5f091a151b19f80e2811323e6318a577b648412842e6c877", size = 12821, upload-time = "2026-05-30T12:13:55.852Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/5c/3bdcef52f234ce16c9b06aabfac43caeeea68a5068425bdd510e6277c256/pyobjc_framework_mediatoolbox-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:13cca0632cbb91f5c207ec6a9001aebb4bdd1077d3753a5bc7fef7f82c3e9a57", size = 12832, upload-time = "2026-05-30T12:13:57.732Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6b/8ca72d9579f84560f5a648973032757e5b0c61bf1eb74e763bdca6913ef7/pyobjc_framework_mediatoolbox-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5b876927d92fb35f6ca6a5c8e030cb853a8b5c68add7d59ebec4ae4358a1f5af", size = 13419, upload-time = "2026-05-30T12:13:59.497Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/23/5388bd9a31639e02c9b626c6b4694f807a836b3f6ecd76477a64c9208736/pyobjc_framework_mediatoolbox-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:193f021a90cda4e18523538f99348080147f0e35bb5ed45e44b0f8a964a58851", size = 12805, upload-time = "2026-05-30T12:14:01.315Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/e287f682182f1953b2b36d35781c91cced01d0f0ad7fa97836d9498a4bba/pyobjc_framework_mediatoolbox-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:58745d0f400c3de07e07b021574f38d73a3f69a886432470fc6e32824785855a", size = 13413, upload-time = "2026-05-30T12:14:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/99/6685f94cae3b4ee734bdd06fcb29c9c729d44b1cdaaf501cb1836902e0c1/pyobjc_framework_mediatoolbox-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9f028de65634bf4fe2d9addd4c85704778b91abb9f9bafe42f15268b775496e2", size = 12819, upload-time = "2026-05-30T12:14:04.964Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/77/10df782a4107d150672264914259c48fb98f235908716cf915530c26ce4a/pyobjc_framework_mediatoolbox-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f3d541185086c7fc4df76da60c577be8fed06f8507ef35b44082167880476cdd", size = 13438, upload-time = "2026-05-30T12:14:06.665Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metal"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/a9/ff281c31ce7d0cb819af1989b77258b2d8cffc0b9fad47fcdd39043f4d81/pyobjc_framework_metal-12.2.tar.gz", hash = "sha256:4fb2cfd42cc8e808f08f1f2fe57de713734dd2f495c666296b2c8a5fba9be6dc", size = 238106, upload-time = "2026-05-30T12:39:54.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/b1/ec8bb62f3e1ad8c27b72313750b0b6e2bd6bf3cc3b24e48c2cb1cf8f9e0a/pyobjc_framework_metal-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d59ee2a3ff68367140e2a94ee3c52807defa016c2589e436f34796fea6c22405", size = 75990, upload-time = "2026-05-30T12:14:12.033Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cf/d87b3462a9d16dfb33c4ab9103f9c2133f37237724329f85863182b7c103/pyobjc_framework_metal-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9fc402fc861b49c2ad59a2342ab0d65fbe206292ab6f127cb778e6e22483e544", size = 75980, upload-time = "2026-05-30T12:14:17.605Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/dd/948cdfbac4f20decd054b9cf134e8a69e71bf9dc5cbcc91d518bc4fb4f37/pyobjc_framework_metal-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2ce5cd713869eaaaa8298c9e21ce750957d063cabde396e8d158c10809b452f4", size = 75906, upload-time = "2026-05-30T12:14:23.044Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/90/f3832396e967ae149b480ebf31da0ab7b033c145b15274b2bd5357d8faf5/pyobjc_framework_metal-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:538826eb6020e2d49e481f7ad390319dfa1016aeeac623f8b76bfe8aaec8a66f", size = 75935, upload-time = "2026-05-30T12:14:28.505Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/95/f36313fab765e90c8400c9423cc0f6af6fec96a919ad894b09681d0b4a88/pyobjc_framework_metal-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b9a9ba61ab834ada0e23fe7d560cf01e6948a88a4aef3342c032683b795bc908", size = 76491, upload-time = "2026-05-30T12:14:33.968Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/92/3c9a3f13a968f8935d3ea46e0ca5d3662b5d5fcaa4faa7b19e68e33956f5/pyobjc_framework_metal-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:06775870d7f40496d647f9ac37793e4a037ffaad43612aea7313460a52ee9e7f", size = 75937, upload-time = "2026-05-30T12:14:39.603Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/34/9244ee1aef137fb8603daa7fcbe3919d4a27c894b120aaa22ba9c1481d5d/pyobjc_framework_metal-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:86296b6bf1b19f0e0c0d4bc1e99954eb666c48a386e61ed805cbaa961cc0cd6e", size = 76541, upload-time = "2026-05-30T12:14:45.26Z" },
+    { url = "https://files.pythonhosted.org/packages/65/c6/a5f5169c2799e67fbc7a159154ff9369dae2c1b0a76a87c1ab3206be9470/pyobjc_framework_metal-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:67619f9778593deb2596f7c7c20c230b93a1ebfd500b5cfd29c2e4d3db1e4a64", size = 76051, upload-time = "2026-05-30T12:14:50.76Z" },
+    { url = "https://files.pythonhosted.org/packages/39/f6/01b2bf593c60b325d4ad9568bb8b7861ddc15196d69bdf0e82871e417d8e/pyobjc_framework_metal-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3d044801562c2a411ac65ff8f2f5d4004b3d1bd41082e8bb52b1f7a87ac53813", size = 76675, upload-time = "2026-05-30T12:14:56.186Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metalfx"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/06/e29f5153fce867015298a9b0b0365777004ff5f4e5276728135afc496269/pyobjc_framework_metalfx-12.2.tar.gz", hash = "sha256:46774b9c938f2af40510a787be291dbc0c7e3778494704489e728fc349183244", size = 33397, upload-time = "2026-05-30T12:39:57.533Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/6c/fe438b4d355b9ac3f80ddd705ab4502d968354d8de60f5711a74a5022e19/pyobjc_framework_metalfx-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:18994e1478dd7360f2c5debb3c430dd81d5bf35edfa2b99a6a02dc31dfb77ca2", size = 15024, upload-time = "2026-05-30T12:14:58.239Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/ac/3b5c5efbca2ee87d2d995bc936d77c526dc515653b515e0a4c3db9cd7f6f/pyobjc_framework_metalfx-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:83fabc9b784a29eb664e8f03042d8b5a612b6f0c7774e350b0be3c6dd99249d3", size = 15025, upload-time = "2026-05-30T12:15:00.455Z" },
+    { url = "https://files.pythonhosted.org/packages/30/94/490d8a4339e8e7c02a9e5105307fa40ed4d5e251f4af824238158b7a798a/pyobjc_framework_metalfx-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f26bcdd3bd0ded637abaaedf6e1e42300de4694ea4b50a36322599fc126c43e8", size = 15059, upload-time = "2026-05-30T12:15:02.435Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/10/40bd25526328be5bb7aa14b481146fee3dbb1271662b5b69112f47f2833e/pyobjc_framework_metalfx-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8f079710065e4f4628c34a2528b0dd868c9d16e3af58230d5f18f6bd22d2ee74", size = 15072, upload-time = "2026-05-30T12:15:04.464Z" },
+    { url = "https://files.pythonhosted.org/packages/46/d7/5189782d95c4790b704f70dff50951c183e0567aa53fd4892ccbc91b6f8b/pyobjc_framework_metalfx-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:40c7e259991c04f5520c4c40eea02810c50812f2bac2c5ff845828a35d99ccbe", size = 15286, upload-time = "2026-05-30T12:15:06.581Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/9f/400860454b42234d9a3e8b22b9a39281556fd71b8a47a13f1f20e24437a5/pyobjc_framework_metalfx-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d2852041cfd3ab3a316412b3721074778d0ec8164e2f0e89daa3ce00b55d6b54", size = 16341, upload-time = "2026-05-30T12:15:08.529Z" },
+    { url = "https://files.pythonhosted.org/packages/62/73/3f7904cf7048af042f040e563222d9c143d15b3d7572501d0487b5c149b8/pyobjc_framework_metalfx-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0c58b878e2994fdb37a74ad1ac93e3d624e8212c6658d64d1d8f62b18f7aa7a9", size = 16591, upload-time = "2026-05-30T12:15:10.601Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/35/41cd0392d0c501611c32f0ee0e980cdc29b84bc445f4ea705a605f0ce893/pyobjc_framework_metalfx-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:bf2f970bf2718d10a87e8fe5dfe5cf7ec9ca6152f9b31e05de54ed97ab799786", size = 16349, upload-time = "2026-05-30T12:15:12.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/bd/bfc5faf66e708a4ad384ec54670b4d2d3ff505dfd269d721f1661be31472/pyobjc_framework_metalfx-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:8a7ab8fbfd7d54c0b362c7c568ba22e648a4981631001fb29cc93777e33330b9", size = 16582, upload-time = "2026-05-30T12:15:14.82Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metalkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/48/3bbf8a296054633a8a297549c919b3ff6f53c469bdcb0046d31fd7c92ee4/pyobjc_framework_metalkit-12.2.tar.gz", hash = "sha256:0f6379b74d64ce9cb864476caa277ab5010da3b0779b7fdc94af7da25f013a1a", size = 28168, upload-time = "2026-05-30T12:39:59.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/90/18547f06d23ba052bb36ce52fa07ed789c084a79f9e1dcd9c219683800ca/pyobjc_framework_metalkit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:19f2fdf75ea46aedeb72b274410f5d4c93414fe540457fb6886ed694e9f1cb38", size = 8758, upload-time = "2026-05-30T12:15:16.774Z" },
+    { url = "https://files.pythonhosted.org/packages/90/fe/1ff91bf19e66e0a842a204458787be29ed9bb41426f2e91c5b2be68d1582/pyobjc_framework_metalkit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b11b8decd36d242b748186d2d7d01f772f68652a7a06023757c62802cf68c70a", size = 8763, upload-time = "2026-05-30T12:15:18.469Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/3e/1bba6a52949a80a33c00650a1951e9f96ed27bf238e47694e35e4a8f087e/pyobjc_framework_metalkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7de453aef880ba546e87b0d433d203388e579d09f7cee1b6c67f09c7074c79f9", size = 8780, upload-time = "2026-05-30T12:15:20.024Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3d/982672d8b3b97e59214b85e694482f8d4b373d540f3d4eb1ad27c7763b0b/pyobjc_framework_metalkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d1f1e352621d5e89a2066f992a2b03091d180fd4ee3b6c7b58b432e22d76641b", size = 8795, upload-time = "2026-05-30T12:15:21.571Z" },
+    { url = "https://files.pythonhosted.org/packages/87/24/163bbd1c430a7c6adfec59ad92c3f1ec7f3de0ab6739e2f5839edf90f8c5/pyobjc_framework_metalkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a855935379ededd36ab55507af01b796b845a0acad7dddcff9d9f305fd903b82", size = 8939, upload-time = "2026-05-30T12:15:23.113Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7a/d7015d0501c741c470abea665ccea2832e762469b9ef37ccee9575130cc8/pyobjc_framework_metalkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:bbcd660af609451ad40bbbfb9ae44fd838a91a5754c19a6496819704bc72dea0", size = 8848, upload-time = "2026-05-30T12:15:24.664Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/94/bacbfdc43870f06d31935cf5efade46d3c9356e6cb52df2c171cc23b81c5/pyobjc_framework_metalkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5aa264c48301952fb6bc549e3e9e8862c41d0666d46ca356cc9606564f3bb59e", size = 8997, upload-time = "2026-05-30T12:15:26.375Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/6a/a79e6f27b96d85efdc896fcf2c7e7a090f2a355716f8c789de2a60e942e9/pyobjc_framework_metalkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:57b499d34ce41bf55b32a56fd1ce53d781d02d7c21d4fc92fd3ffa005e038939", size = 8843, upload-time = "2026-05-30T12:15:28.072Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/1b/f45b8b9423d66dbb463e19df3562e3841841fdf8e03e242926e30f49848b/pyobjc_framework_metalkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5c0fe3df589ccc0bb07086f894457bab37fdc682bf7107bcb5bbeb2c93b0a8f6", size = 8989, upload-time = "2026-05-30T12:15:29.806Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metalperformanceshaders"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/77/9675e6e2ea06d693a75586c4194630c4346e6661bcf9c9299353dde1edf3/pyobjc_framework_metalperformanceshaders-12.2.tar.gz", hash = "sha256:f428f762bcf552f1a8f5533508ae4c73057a7f4f4a93bc997a921edec63b51e6", size = 190423, upload-time = "2026-05-30T12:40:11.806Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/25/e89690007b6181bdf6c6fea5b6ad4dc58f51dd7e88c01d28c0b9b5df39f7/pyobjc_framework_metalperformanceshaders-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7dc079ed93521f250f4499774a986369f652e2431cb9d570420a7546a3d16f9c", size = 33902, upload-time = "2026-05-30T12:15:32.738Z" },
+    { url = "https://files.pythonhosted.org/packages/58/87/3f7a5d4d53a234f783f3b87472de056900715896bad1513d7be151f9d7c4/pyobjc_framework_metalperformanceshaders-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0904f387b1f1a89b4baa15a370e7a0e2222f508bbb5ef7ad86575dc89d2833ca", size = 33902, upload-time = "2026-05-30T12:15:36.027Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/09/a0906ac85670c10d7ba2ad597a66515f9d68cf1d16f69e76f9bb90dcc0ef/pyobjc_framework_metalperformanceshaders-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4b4129480193b524fa5b1407922539e2f52e2cb77bc20e16936711d70c4c61e1", size = 34165, upload-time = "2026-05-30T12:15:39.086Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f6/2eaf4c358eb9684b13a08f73239c654029805da1be0ae5052ac0e15fafc5/pyobjc_framework_metalperformanceshaders-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac154ee0c5bd0c715d2b837689a070b811994a772b209784907730793b725012", size = 34176, upload-time = "2026-05-30T12:15:42.108Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/f4/f134c898df89217ae3d07d364c75ac67048dd9106a164d7dcda52f83e5c6/pyobjc_framework_metalperformanceshaders-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:18cda4e2ed06da0caebb11fa54596e273e8d50cdbf243aa1d34fa347da71db77", size = 34374, upload-time = "2026-05-30T12:15:45.258Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d8/fbeb68c5c03d6d4ce8030c2b55b910ce987bec58cfc327971da7936c5f04/pyobjc_framework_metalperformanceshaders-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c6fda7dbcf6b64a9be973248568ec893abd4db96efd89c28a354605fae8dec43", size = 34240, upload-time = "2026-05-30T12:15:48.266Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/16/95c14b3e7a54da1a5cfefeb664cc553286706494825abc4864454a438e06/pyobjc_framework_metalperformanceshaders-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:bb9e81a36604523de1a82d28b8b25c32f9fedf58f17dc1ddd01a2676a39b67a3", size = 34462, upload-time = "2026-05-30T12:15:51.325Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d9/bbd6439aeeca621bfd27b9c6dd6d5d43e637a69355878802f0ba49e995b9/pyobjc_framework_metalperformanceshaders-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:40a6743b3352cfbac9209aa29f6404f12939cbff232104b6165eaa8c0723a1b8", size = 34261, upload-time = "2026-05-30T12:15:54.564Z" },
+    { url = "https://files.pythonhosted.org/packages/85/5f/084ffa1fdd63a0007924068a1877ca5e69c0fb475ab312cd053b6e082982/pyobjc_framework_metalperformanceshaders-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:df0768e6ff1e27b6963dbdd851fb771a72539f0357ac667dc9b91898ee77f0e2", size = 34478, upload-time = "2026-05-30T12:15:57.574Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metalperformanceshadersgraph"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-metalperformanceshaders" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/95/c274ffa29063e6f331a2d7d6942610ea2dc1e1984c647e68aff0f93e35b3/pyobjc_framework_metalperformanceshadersgraph-12.2.tar.gz", hash = "sha256:16249c5cd8d8403b5d81b871b618fdc0a8af0d7c81b461e733c0b5c1f9a9ef80", size = 60209, upload-time = "2026-05-30T12:40:16.281Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/ca/173cf282b48c454dac9ef40f96b0e5338077803f3fbf0f07c09333d3a9aa/pyobjc_framework_metalperformanceshadersgraph-12.2-py2.py3-none-any.whl", hash = "sha256:e465d7717df4b000e3a529054cdf547e50e175f321b53c9520bcd6c69c08c837", size = 7110, upload-time = "2026-05-30T12:15:59.125Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metrickit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/7e/b880dd8c641abbc0807d75396132df80d7d9cb0d64006b078c7f2e169fb8/pyobjc_framework_metrickit-12.2.tar.gz", hash = "sha256:c76cae82489813ca121de0ad6013555aa826f8742adf975028b3e4268ac51e6c", size = 30585, upload-time = "2026-05-30T12:40:19.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/5e/85ea34ae65f14a984932d75a988ebe0bbbf55f2f60eae77b8d5eb900d3cf/pyobjc_framework_metrickit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:23edc4fd09a6c08113374512d4249a329d701c43f6847bee74edea1141796a7f", size = 8092, upload-time = "2026-05-30T12:16:00.84Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c7/5807329fc642b97b24381a2f7645eec2d2eddf694d56d98ccf93ea838f33/pyobjc_framework_metrickit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e7f9c9b340538a03c73058bb6efa1fd3740b9b1765297e8bb8d613e7c5199eff", size = 8097, upload-time = "2026-05-30T12:16:02.704Z" },
+    { url = "https://files.pythonhosted.org/packages/09/48/3e08c40cb1f5f905a8c24f1969e8b51fd3d00428f554d48d69a36de808bd/pyobjc_framework_metrickit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a0c8f72b143fbdbfcf9f0316da44a6253071c493e07ec46ba7f7b5b91bafb132", size = 8118, upload-time = "2026-05-30T12:16:04.149Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/7a/224f8a506539197efb51df3aa84b269262ee14a6a4ecf9ac08d7267dbb54/pyobjc_framework_metrickit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:db64bd8d99011d67edb16bdb0f923191d95649ee7bc4a276d4f2516e975ec780", size = 8128, upload-time = "2026-05-30T12:16:05.825Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c8/a112d3aa27eb2749d1308122b40fb1b45947199034e37ee5d86759eaeff7/pyobjc_framework_metrickit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:eb146093ab8ec597e74307ece22c572b3654a4247d6e0d0fd3f4635f0166286e", size = 8267, upload-time = "2026-05-30T12:16:07.3Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/81/b37fc0c8c58af7537f224da4f1d16e161756c09df62255b2273c245b8def/pyobjc_framework_metrickit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:881f4e1af1f3e8bd5f9b58f9c1f3c2a51e2a119742ab98476a32c1cb03d09e33", size = 8182, upload-time = "2026-05-30T12:16:08.937Z" },
+    { url = "https://files.pythonhosted.org/packages/78/78/ff89dd771d30ae760a2549fc9384eb388b6771af59e8ae07e420d41dbb79/pyobjc_framework_metrickit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4e22d5026f99a4b355b7f0090f64ab857aabab672bc288d01078510b645d48ae", size = 8325, upload-time = "2026-05-30T12:16:10.362Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d5/d8fb9b2eb03c6833468541961db44812f6b19f03467577740a68a0aed66c/pyobjc_framework_metrickit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d8ee9eba35773440c26d572b673d80c2fa3c804b595451a01d3ec0ecae23f780", size = 8173, upload-time = "2026-05-30T12:16:12.098Z" },
+    { url = "https://files.pythonhosted.org/packages/30/5e/e2fac8fb3341737891a31cab6a07a0ead428ef2910f8c6ae3ad77af24f89/pyobjc_framework_metrickit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b788a3cf866474dc4569fc253a6c0f62eb02a3b0104e9b2e757da8629d550462", size = 8319, upload-time = "2026-05-30T12:16:13.552Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mlcompute"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/32/72a3733b6f3b1c60a18acfa517d28f9bcfff9822a1e21298c50c30c1a944/pyobjc_framework_mlcompute-12.2.tar.gz", hash = "sha256:7a2108c89ccae06e0fa03b1ef08c37bd9fae0ea0727d8b5890254bf44347eeac", size = 55014, upload-time = "2026-05-30T12:40:23.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/7f/44c69bb026a7ffc00686a51514b43d7fe1a09682997cabe7a39a016aad0b/pyobjc_framework_mlcompute-12.2-py2.py3-none-any.whl", hash = "sha256:18066ab867e02f5eb2cc66145b4274e6a7105e69165550356ec4a75937db1aae", size = 9622, upload-time = "2026-05-30T12:16:15.333Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-modelio"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/42/ff2d205133a753bd95c937b4591559bd10417d88da7debcdb7ef22e00dcc/pyobjc_framework_modelio-12.2.tar.gz", hash = "sha256:3f492868aa12c7107e456238fc718cac0316e8d95f7680b7465e41918d72db2f", size = 83763, upload-time = "2026-05-30T12:40:29.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/0d/21f900fd1c960a8c064111eb7b6fd52fb73e8bbe1ae8476c0dfedf1f6be1/pyobjc_framework_modelio-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c48e1c40813707b25e132c1bf8dc87aee3138e53eb448a54cddca23c934ba949", size = 20475, upload-time = "2026-05-30T12:16:17.636Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/c5/c06390b8b636170977086f7f1601b2539b57804edddf82ba98ea34460aca/pyobjc_framework_modelio-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5aa6db571b6e2940e57a8229ea1e53e3174ca7847e6334231ff223037f0ee324", size = 20472, upload-time = "2026-05-30T12:16:20.042Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a2/84d79cae91284b7fd9c148fc6fbd84e54b5a30c189e0561dc605567d9149/pyobjc_framework_modelio-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8d6c6fa5d5024495f7ee163acf872757824c4c2115909fb0f6e9ab045d1a6094", size = 20492, upload-time = "2026-05-30T12:16:22.228Z" },
+    { url = "https://files.pythonhosted.org/packages/57/92/6dc491a2ffe4c852c266d2a3430114fa0a4cee057930556adb5f27e4948c/pyobjc_framework_modelio-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a2bcdc8079e4886dbee3c2351da5dfc53fe46d1d8e73a9a751085adce97a74ff", size = 20497, upload-time = "2026-05-30T12:16:24.585Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/f6/c4253cdf4ce3d2b55465805499deeecaff9230425366bdb9266c0e811736/pyobjc_framework_modelio-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c7999915fad52b6578688d32ab4c761460237cb28b06dd663f81993fa6c4580e", size = 20738, upload-time = "2026-05-30T12:16:26.954Z" },
+    { url = "https://files.pythonhosted.org/packages/79/80/8f106d2a3c5236c05e58cf2652d0f346b723580b158543d33226bf0cdce3/pyobjc_framework_modelio-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d8d6e411bf94a589372d2025ad854e1d9d96fa0c49af70898fd92c0265389dfb", size = 20473, upload-time = "2026-05-30T12:16:29.145Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/68/be1d3a840e1aad3d4deb9fe69338af2ea37767b6d90128f89aa04b3e00b1/pyobjc_framework_modelio-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:aa3e1aa0452c75a2a33b465a69f2203c3dbc93d556761814f68546dae6e8d6dc", size = 20716, upload-time = "2026-05-30T12:16:31.418Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/18/d5319d61d40e9409cfe11d26db0cb107d838e9a39c16bf488528f2499b41/pyobjc_framework_modelio-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:2204e3078e1e10ee43068ec198e2b24a8064901abb4fb040f3f9b06066bcd933", size = 20459, upload-time = "2026-05-30T12:16:33.653Z" },
+    { url = "https://files.pythonhosted.org/packages/02/60/7a9bf4028cd412840acb04110ace00b04399b549298b93fd63a2045122d3/pyobjc_framework_modelio-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:4e251c993b7dc123a436cc39802d272893a4c374796b3793d8f6cfd4f1c90f31", size = 20732, upload-time = "2026-05-30T12:16:36.008Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-multipeerconnectivity"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/3112f721c54e1a09d12d8dc48b165ff51a1147783d8d63a53e1da5b603ca/pyobjc_framework_multipeerconnectivity-12.2.tar.gz", hash = "sha256:7a5879cb83e9a7ea8c8d9e7e11ed3de4c9d67046e6c330b8a5f6332339f631a6", size = 26444, upload-time = "2026-05-30T12:40:31.848Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/4d/3ca9ab132a2c8710d77ff7a7bd08d0ba7f7c00cf4e47bbf18e8d68c836b8/pyobjc_framework_multipeerconnectivity-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6bf6a5a35f5079b7468013d4a26b9d726233f2c5ff350d83d68377254fa1eabd", size = 11979, upload-time = "2026-05-30T12:16:37.783Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/12/c3a23955870fd1736ec5e15734d7753d338209158ce9943028042fd0b3b2/pyobjc_framework_multipeerconnectivity-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ae86459ccccd087956f561507a17fbaf35e54c4cbe4d4088a8edc264c4dae1f3", size = 11985, upload-time = "2026-05-30T12:16:39.884Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/87/873cc3512150455b387492dcac327e9ad68187b708b06ac4665e750d2bca/pyobjc_framework_multipeerconnectivity-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:548618e01d4df6aa80f3f855af06bbca9e7148c06f174d1b091f54adf5aa63cf", size = 12000, upload-time = "2026-05-30T12:16:41.693Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/50/4080a78aaa2fe925dd2473fde41f650e3433cbc658c062d09b3658e181a0/pyobjc_framework_multipeerconnectivity-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ff0c6305c3b573d97f217a69b8b82b9075d788a82768377a07a456114bec248d", size = 12018, upload-time = "2026-05-30T12:16:43.467Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/75/50488445848adbac42d752d99d126913dadf5e7026aaf28d83c836b6f788/pyobjc_framework_multipeerconnectivity-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5f5de878761b5e1cec4566df0aef13143845a83e4d12c80faeaefd308fd919c4", size = 12198, upload-time = "2026-05-30T12:16:45.195Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/6c/ff2eb6e93c855d62b8fa7b07b76d549e381d2cbe37ffe6988ebdf6148a93/pyobjc_framework_multipeerconnectivity-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4168de44baf26e779a115dba20d4c4415199874316135932f0c1647b638d1571", size = 11995, upload-time = "2026-05-30T12:16:46.938Z" },
+    { url = "https://files.pythonhosted.org/packages/44/6d/ddae986c4c54a47273baa6f068fe7b78b277d1bc4823c6f520d08c434225/pyobjc_framework_multipeerconnectivity-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e97c1fd9656afd8287c111341e44e1cd87ea5dfaabb56a899f589d63bcb1b014", size = 12209, upload-time = "2026-05-30T12:16:48.791Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/54/77a9cecd9ddf1b76711c0a90faa1177101f52057931e83c174e180e9b7d8/pyobjc_framework_multipeerconnectivity-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:8863bbe1774901dcca970e2113f95832fdfd2f3473de8df033411611224d65a8", size = 11988, upload-time = "2026-05-30T12:16:50.651Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/0f/0949e62302bbfdfa453e795ae88351b18d213b4308dfb03d4fcbf5b4f443/pyobjc_framework_multipeerconnectivity-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c83025bca07a25bf416e960906375f66ff7fff2ea4411d1be13fd51dce32737f", size = 12203, upload-time = "2026-05-30T12:16:52.288Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-naturallanguage"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/1b/8fe870dd9ffed8943e72328fdd71df69363ea55037107882a3c11182edbe/pyobjc_framework_naturallanguage-12.2.tar.gz", hash = "sha256:f6980ba957bb24501bbe135ffcdd0ff149f33d30e965f033ad153df756b33cc7", size = 27251, upload-time = "2026-05-30T12:40:34.327Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/00/5923b25edd9d64ba7494cb8e28c1c073ec5cbb43a41eaa70bffa4b7a2862/pyobjc_framework_naturallanguage-12.2-py2.py3-none-any.whl", hash = "sha256:8c02a9ea25b888eefb0ac503211e17a9868a1781f5d5bf9c1655445abc14ffe2", size = 5436, upload-time = "2026-05-30T12:16:53.941Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-netfs"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c8/e22988cf11df9b7c7da2ba04b7e9b9435fa7dc4ba3be7d6bb34d60f686eb/pyobjc_framework_netfs-12.2.tar.gz", hash = "sha256:fdb04ecc91864a4b79498a07f4d34f33b5dcae34958d555f5cbd69e20165991d", size = 15139, upload-time = "2026-05-30T12:40:36.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/c1/1584c42fc716ee13d085461913b59f5682fddd76b8094feb760477a8edab/pyobjc_framework_netfs-12.2-py2.py3-none-any.whl", hash = "sha256:864d09a7b671f4407ff577739949c98ae8ba9b013433cf938fb0c86319151248", size = 4161, upload-time = "2026-05-30T12:16:55.515Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-network"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/a8/12fcf0341ff377600a102f48266ef85e67af9dc7d894ca40fb18dd8702bb/pyobjc_framework_network-12.2.tar.gz", hash = "sha256:99d7a1900d8250d008eb285b20792d14076eedd665749cb0f48e1e102056207a", size = 62275, upload-time = "2026-05-30T12:40:40.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/59/40a6e196906e06d8ee3490292b6af7fe2d2971d00316267b70e0ae671cf4/pyobjc_framework_network-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:65cf8a53729b2d063ed83849b1c945e1af4845397dd9d06f3073c112ce915cef", size = 19604, upload-time = "2026-05-30T12:16:57.63Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/9e/f976ad4f4b8b4be399086fc85eda2310d57ecaabe472cbd064b973a23744/pyobjc_framework_network-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:97748fd712c08cbe37adbb0e34ad67939c14e27d447022602c2f205b2d653fd5", size = 19604, upload-time = "2026-05-30T12:16:59.862Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/7d/b519d186727fda8eb3d365312e2d4059e104f50525f0c0618083c43755fb/pyobjc_framework_network-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0173665fde7fe004c49e9786a0073ed50f6b2b7f6b78198bda78a01c36ec9650", size = 19630, upload-time = "2026-05-30T12:17:01.972Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/b3/c99e31a29975fe58d81396105518d74cdd1b0de5f8d939e5a5892b7d95f7/pyobjc_framework_network-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6677fac4bfe2d8ae320ffc069767c0e2ca7d50304ad3cf7a77d0a4d08d69465e", size = 19643, upload-time = "2026-05-30T12:17:04.223Z" },
+    { url = "https://files.pythonhosted.org/packages/85/94/233e77df7b4b53aa0316346540ee1345ed6c2d5b1893fd10fe268e1d9a1c/pyobjc_framework_network-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c198226431964487f1213ba17de69eddcaf5ddd1bea406b31c6845cc956da536", size = 19714, upload-time = "2026-05-30T12:17:06.29Z" },
+    { url = "https://files.pythonhosted.org/packages/95/48/9d19d4dacbe35ad331c952501776965686eb93e385fddb8aac9feb02cc14/pyobjc_framework_network-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:842fcdb53fcf86af1f5a2287107955e05f124be1e461a407b77b944628f7a57b", size = 19374, upload-time = "2026-05-30T12:17:08.391Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/b20568f13df1dde9b8520e84200581a3be120a7a9f57b98086e169a892c8/pyobjc_framework_network-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7f3748fe2d12061b6b4035d2a9575b81ea6911dfd3f2652d23bd913e9aa4b559", size = 19432, upload-time = "2026-05-30T12:17:10.638Z" },
+    { url = "https://files.pythonhosted.org/packages/32/29/3bbde722d3c54a8356c7a942cfa75f54a8589bc22899e95f27ad62967b63/pyobjc_framework_network-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c88b1b8666e007cf3388c17998147d12a9e80b103d21a625df170382990a974b", size = 19385, upload-time = "2026-05-30T12:17:12.667Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/5b/99538f4541949b561788eb2971b1b0f1a60353000f780266508a7cf1a2fd/pyobjc_framework_network-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:2157c11fe921fb76af55364b7ca1e9f9679156b2cf2b7b18f1a1e2d25bc4502f", size = 19438, upload-time = "2026-05-30T12:17:14.731Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-networkextension"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/f0/bf65ac7714c81159f295d9386d718c9a876fc212f8af54b6da22c2d2873a/pyobjc_framework_networkextension-12.2.tar.gz", hash = "sha256:45bc3e7966cb9fce997832960d8aaf324a187f84019e65fc4432c27046715f70", size = 81296, upload-time = "2026-05-30T12:40:46.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/1a/d23e036c0f1812c04fbc4fb97a701294dda0fa96740131c93d6271dd327e/pyobjc_framework_networkextension-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3ccef4d217de41acfac3a707180d6460afaa41312f8d44593c13d2cf0cb0db8c", size = 14439, upload-time = "2026-05-30T12:17:16.734Z" },
+    { url = "https://files.pythonhosted.org/packages/52/44/1d29baef6535bcfd1f6cc233ba6d53d0a4a7c16ed37fee224727298a2d34/pyobjc_framework_networkextension-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bcb7cb7824ef8261337fbd1e98ccf8456982108e0883a82fbdfcc1ae429211a3", size = 14437, upload-time = "2026-05-30T12:17:18.837Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d8/ad0b3dadd27ddffecc697f3155fc387b278d74972ae36e790c3bd69c92da/pyobjc_framework_networkextension-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1b9d588739185994e945fcebf23d1f25bfd0d2893bfc2cddc366a2f421943245", size = 14451, upload-time = "2026-05-30T12:17:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/86/91d135890a83c021e2b031c467001802314a5b2c6aa1580669b1bf524060/pyobjc_framework_networkextension-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:631ca462cedf277531800e3cbdf6d4f98aac2dd2ce8512fc855076fa373d6725", size = 14467, upload-time = "2026-05-30T12:17:22.768Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d5/47debfb91e4f0c1bdbb1d4f433662cdc97e0467bf84379764be7dc26dfe3/pyobjc_framework_networkextension-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1f9c7e7aa156d604a2c0764f65ef95131ff0c7724dd9ff35347d96b27836814c", size = 14611, upload-time = "2026-05-30T12:17:25.109Z" },
+    { url = "https://files.pythonhosted.org/packages/30/94/c894b717aafc6c93dfa02424e64025d2f15fe90c283b2166a9131e0c9306/pyobjc_framework_networkextension-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e2bd61562844e400f8b8c5b434be44e42164af3e64ea4f51cdee335f92e9cc8c", size = 14530, upload-time = "2026-05-30T12:17:27.228Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/d1/8073286f4bf3d38edcd506826101d4f421bfb140ab402a4e627ec9f5235a/pyobjc_framework_networkextension-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4a105e5cfe795914f728684e0b5b08647b7d7c106b9602ab782bb0af93f44bd9", size = 14668, upload-time = "2026-05-30T12:17:29.176Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/71/2ee8580786367e4376a2bb76e45c17b81d7b85436382bb40f8236f7f8700/pyobjc_framework_networkextension-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:fdd6a5807b30077ce1545b0a9583a8f878f220f6b5f246daa470d77ad0b1a692", size = 14526, upload-time = "2026-05-30T12:17:31.141Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d0/053e00fb31b9b1cd0ecb207ac61f59befc9ccf3f257af7d05445b3a83e8f/pyobjc_framework_networkextension-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:faf4482e957bc76a78d3784ee5b010f9f562eb606118a6a3a30edd59f89f430a", size = 14659, upload-time = "2026-05-30T12:17:33.068Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-notificationcenter"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/d4/62b27947aa2ff2228b49083245e622eb4840f68c58d6d3e89041f597b5dc/pyobjc_framework_notificationcenter-12.2.tar.gz", hash = "sha256:d7a20fd67851d91db142765aa823a5c60c03c37957cea310a4eaad37640c085e", size = 22134, upload-time = "2026-05-30T12:40:48.715Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/68/0714ce93f20dbe977c2b3c8ff8538ede846538da92014bc23ad94eee5044/pyobjc_framework_notificationcenter-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:687dc4faa1b1911d3de836bd85e5614d89aff6ca4270b9c486bf2ca8d5371e5d", size = 9851, upload-time = "2026-05-30T12:17:34.841Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/f1/3cfe18719176846f680ab5c7fb3626997769b0134ea6684c2ed7f114f09f/pyobjc_framework_notificationcenter-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4f6031350c294b57670764f6cc8e37ec05555ac1f9154ccb6a60d12a103cff21", size = 9849, upload-time = "2026-05-30T12:17:36.601Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/37/7ba6f07424412b99f3eb9c4ef34e16d156f257b2670cd625d2ec0c7e2c6b/pyobjc_framework_notificationcenter-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1141c58ff04085ef388c7fc4e588d5be9facbfc6d63f405ea6940f990293c493", size = 9872, upload-time = "2026-05-30T12:17:38.161Z" },
+    { url = "https://files.pythonhosted.org/packages/46/ac/2b2465db73f0340538df30728e5cc4a1c3014066651b091406cf2fe96e0e/pyobjc_framework_notificationcenter-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d869a7689086ccb6f5c82a29684f38cbd2293e63a50fb8b06cec6151b497a73e", size = 9896, upload-time = "2026-05-30T12:17:39.78Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0d/bff8fbabbad5f0328852f0d9b7d87551b206c3c76ff9c5ecd863d7613643/pyobjc_framework_notificationcenter-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db911fd4de68f52abda8e812799e87721092f78ac575ec50bff82018e1efb06a", size = 10088, upload-time = "2026-05-30T12:17:41.723Z" },
+    { url = "https://files.pythonhosted.org/packages/18/bb/06fbcdcd37586878ce75cd61218594d0f3c4559262487b870dd4061f8394/pyobjc_framework_notificationcenter-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:3425e37a3eaa63dc63b8ca9556472e57d020bb6681885f1e36ef875e67ea07e6", size = 9955, upload-time = "2026-05-30T12:17:43.467Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/f1/3d1e94e67bcbc4dbdad682d421d2545e80bc08d0f742f71311e99c17bd2d/pyobjc_framework_notificationcenter-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:27dc6e162ff3fe446b50e276c97d7e811b71cacef460dc857b0cebc08e6a6286", size = 10165, upload-time = "2026-05-30T12:17:45.078Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/4d/800507135e5018b87343a4ab8cda11ee4d9b3018b3469d2f68f32a1607a7/pyobjc_framework_notificationcenter-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:e0b2b48ee6012b8019211d7e8910f5cdfcdfe846b54c79e7ed58deacff5d73fa", size = 9950, upload-time = "2026-05-30T12:17:46.653Z" },
+    { url = "https://files.pythonhosted.org/packages/32/22/09ff226c62948056d15f8b9f7dfdbba873f876f1496ac4193e1b4f26cc7e/pyobjc_framework_notificationcenter-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:7287b66979a21d94f132a4bdd2914f6e6d96823d7454c46841722b6d494ecd78", size = 10153, upload-time = "2026-05-30T12:17:48.179Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-opendirectory"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/43/1c4b9f4e3739c3ab763f42b6e51ea74afebafefa5662b2740a6fb812697a/pyobjc_framework_opendirectory-12.2.tar.gz", hash = "sha256:e9edbe26c4d9aa533f343264d34af96fbef958d0c3a833acd2d64cf0fdb138e7", size = 69875, upload-time = "2026-05-30T12:40:53.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/0d/6926ea3ba0f58e52e7a2260b416abd44c4680dc6c5c8e2212ccdd8d649cc/pyobjc_framework_opendirectory-12.2-py2.py3-none-any.whl", hash = "sha256:71d17cc1be29dd2ac50ae76fd654d233bed3b117854bf0ace021d8242a5a5566", size = 11910, upload-time = "2026-05-30T12:17:49.849Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-osakit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/bf/f6ea6b2e15151c79a22feda80d9e2c120d457cf16750c7751408f3dffc7c/pyobjc_framework_osakit-12.2.tar.gz", hash = "sha256:219efdbe36fa6bea1c780b28ad8a1b23ec4ca0ee9ad3cf040da192f883514b81", size = 18910, upload-time = "2026-05-30T12:40:55.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/ad/e79528da31d07f4d227c0f674b94a8a5b0aeac062d6a2df8363dbf0d99c9/pyobjc_framework_osakit-12.2-py2.py3-none-any.whl", hash = "sha256:604f428b00a0b1da1f40fc8a78db96e08b23abc7d666545a0909cc6e7b5ca2fd", size = 4143, upload-time = "2026-05-30T12:17:51.431Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-oslog"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/ba/dc92bab4a4be642226c3f6b71e0a100f70c27027728df00eeaaa588d04f8/pyobjc_framework_oslog-12.2.tar.gz", hash = "sha256:c2213dbb3edff318c731b300509c69bd922ad102311042dddcd9de8287e50a83", size = 22307, upload-time = "2026-05-30T12:40:57.943Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/77/e7d6ac4b9a226a29af470d2673fb0efffd5aa4bf00b7b944b806d7765c8d/pyobjc_framework_oslog-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7efafc8cd4700c9f48907f7f01e06ecfb91626735378a33d9ac1dff944297105", size = 7865, upload-time = "2026-05-30T12:17:53.009Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c5/d69b38c8c92bb0157e1c27331fda90515bb663e71e5b8543a360ea82d64f/pyobjc_framework_oslog-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:dfd0eceb469b156676fd0ae2265ab512c76c8b849a1544c99cee01f001bef05d", size = 7869, upload-time = "2026-05-30T12:17:54.822Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/62/e7ee1eceb1645615eebf7549e89cc9a5ee815d0a8d1058790faa68a780a7/pyobjc_framework_oslog-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3f88f4921707ed38da239d03f423929b126f0d8361c0500a382c76144b674f55", size = 7882, upload-time = "2026-05-30T12:17:56.321Z" },
+    { url = "https://files.pythonhosted.org/packages/be/13/df0e2bae8e19998101ba238a2cd27c147906c63cd42d1814293bc08f729b/pyobjc_framework_oslog-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ce52bdc6803bf980369d3f265339063fb71391fcf980acadf9f73c4b7af7413d", size = 7902, upload-time = "2026-05-30T12:17:57.82Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/cb/b73921c1ce8a78620c14f00f2907de7430a5dd78cd858b3b72cf43758ee1/pyobjc_framework_oslog-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:102c32f34f772befc22d37bbf3a6a70a88b3389ea6d25111217e84c5bfde40cf", size = 8081, upload-time = "2026-05-30T12:17:59.592Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d6/8945a6f9ff6f31f90a41e190d944bacd3d3115d73004eb778c95212fe9c6/pyobjc_framework_oslog-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:595f392d7966a28765dc35b7139243ee6cd1467a6edbb1f1ebe20af38e058542", size = 7943, upload-time = "2026-05-30T12:18:01.072Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ce/d0620e285ec8a2257dd7079d1fb3c44d6b853ce049abcfdefc5fa73d0155/pyobjc_framework_oslog-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7b4048471200aa35b7100dc58afc9c1c36b6b7a969070cec608b6b260a892259", size = 8143, upload-time = "2026-05-30T12:18:02.765Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6d/e7e9ea2ba0e4c4af69651f7aef78ddb2f35232f782526089c9dd727feeee/pyobjc_framework_oslog-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:041b952ad6bfc80637f827ed0007f34ac68352b1d51f83279ab6db66b89d1dc2", size = 7944, upload-time = "2026-05-30T12:18:04.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/50/b76c39a5cfed0476ab89926b1c324673f99571336d56d8a099dfcf6dcdc5/pyobjc_framework_oslog-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1bb0922c211b07f50022583ea54ea58cf651963982e325873c6813474c4f0ff0", size = 8145, upload-time = "2026-05-30T12:18:05.925Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-passkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/ed/68c8657d080f53706ea7e6cd77a4babb2b8f95a0c73471db5a56c5742988/pyobjc_framework_passkit-12.2.tar.gz", hash = "sha256:14a9b37b290942e86633ac59f923195d0038ff0f746443d914dfd5858cba9eff", size = 68267, upload-time = "2026-05-30T12:41:02.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6e/af313193bc8efabcfc8b4a4d6ff08786e0e154dd05d6cfaea7f5a604fcab/pyobjc_framework_passkit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9f315f778c967fd89a7d2c33ba4ba887836b6a7bdc2b652755c46278e91fb304", size = 14434, upload-time = "2026-05-30T12:18:07.838Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cb/af5b4d240e83d0d042c22c5afb5d7fc0c978e44753f76e4bc892dec460a4/pyobjc_framework_passkit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c915d8688e3a83b90388797840fd4fc019c7d3a3d501b8d20efb7aa00e74fa0f", size = 14431, upload-time = "2026-05-30T12:18:09.945Z" },
+    { url = "https://files.pythonhosted.org/packages/33/31/97632296672a105db7e30f005f036216f341a20d6b0c651f25a458eb970b/pyobjc_framework_passkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1e24dcfe31e1635b6d858c5386b8fde4bade3eefc869aa683b0bf681bf1d72ab", size = 14451, upload-time = "2026-05-30T12:18:11.899Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b0/dc2ca2ccf1377eb980220ea1b392803c0d7f42b2164960ed5a04361ec592/pyobjc_framework_passkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3ca56bc17cd5ac7fea74caec55f3329a2b21c9462f70f1799a1896cb2fc9c06d", size = 14465, upload-time = "2026-05-30T12:18:13.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/24/1355ea6c97237c844e689e1f6b92481c3382693590af67a637a7c5205df7/pyobjc_framework_passkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f58e668a4e827e2bfb7ddc41aae68025c980b5ec25d218ea8a49740159268f8e", size = 14627, upload-time = "2026-05-30T12:18:15.871Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/40/a96eae0e665cec73c5d9e0a5760dae1b623483349e618985772f09be400e/pyobjc_framework_passkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:737215ab0ae39960e4b94d70380b873e06002a8905589cafc92b01bb9e54af77", size = 14469, upload-time = "2026-05-30T12:18:17.816Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/fa/a0e28ff2e0fc0ba620a603df0b642a83a8b5c1468377e5b6a6c6100b4db6/pyobjc_framework_passkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6c47fead9168df3cb8985f572ae1bcbd200b5edfb8c50e8387df70c915e8e734", size = 14625, upload-time = "2026-05-30T12:18:19.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b5/8c9f7b433b4d4a773ec29b788254c700e5b269f28f8348c80e1a634cee5b/pyobjc_framework_passkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9e77169e91a10b33eaf650b9af160c8c4797a90f409577ccebf45cd5279dcd27", size = 14458, upload-time = "2026-05-30T12:18:21.763Z" },
+    { url = "https://files.pythonhosted.org/packages/16/28/5ce999f434a082e21c1a85f65232ada04eb5967244b18cf370645cdf8cd2/pyobjc_framework_passkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:8bf020af75bc581438700af5d5cf170d18bac9be8cc953dab057846dbf95bd4d", size = 14621, upload-time = "2026-05-30T12:18:23.636Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-pencilkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/f0/39d09038bea6f2130ed6ad9de9034a2ebf3babd9eb5ad75a70f60160cfd6/pyobjc_framework_pencilkit-12.2.tar.gz", hash = "sha256:a224250d5bd8490e619792570bf2b03849b875757c076412ef83bddf58a3d2c5", size = 20122, upload-time = "2026-05-30T12:41:04.877Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/d6/45dc7133e4d561b725718a2d8cd016605a6fe7bcf3f12a002c34a309ee4c/pyobjc_framework_pencilkit-12.2-py2.py3-none-any.whl", hash = "sha256:aec57e9ebe2a875d4fc17c46ef16ffcee74ba7551dcd6d83207efb05c3377187", size = 4245, upload-time = "2026-05-30T12:18:25.228Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-phase"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-avfoundation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/4e/3102eb1fa234c851e23213701d3cda26eb3516c61598dcc7e3f26eb17724/pyobjc_framework_phase-12.2.tar.gz", hash = "sha256:fc1ec192bf7aac2627425c5f1fdabc3df614d100d18a6273b25ec4593f257eca", size = 40747, upload-time = "2026-05-30T12:41:08.372Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/80/9d526e002b9be65dd80abc2cc5c62afe8a85f353282f33d212c6b44b52db/pyobjc_framework_phase-12.2-py2.py3-none-any.whl", hash = "sha256:e8b85d7b2743b61f8920ad044f7e8370de80e5a4ca4f85ff42b6047b04e5f821", size = 7187, upload-time = "2026-05-30T12:18:26.949Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-photos"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/a9/3845e4976742f15baf7decd63202b16326196596ee95271eb1eacbb388ed/pyobjc_framework_photos-12.2.tar.gz", hash = "sha256:126d2d2aa78ea0e704db807ee2c7f7b418d8a859a0cb8df6ee31e66fd371c2ab", size = 58662, upload-time = "2026-05-30T12:41:12.67Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/c7/5a8ac8be48a5c3f8bbb4651b96e85461a2f3950767b2e3d81bbebc4f841f/pyobjc_framework_photos-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:fc7898d31a348f981f48b79554e68099dfdb66028cb6d7800a210f130fb73f7b", size = 12490, upload-time = "2026-05-30T12:18:28.801Z" },
+    { url = "https://files.pythonhosted.org/packages/88/11/e5f3132a36f7cbcc48934200489f66f7205cfbf5f6626a85e7e056613035/pyobjc_framework_photos-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:aad8fade39d1b5e61f04755f9490a812f491d437c88dbcd42875f3cfe87bd76a", size = 12494, upload-time = "2026-05-30T12:18:30.731Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e4/71d6ff0833727d3958bf7dd0239d25a05a5d4d52475e443c5e25f6ffedbf/pyobjc_framework_photos-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0c9e2311970d031ee7fd5cb6531ac9236ed70902910cf448a2adad61c516be68", size = 12522, upload-time = "2026-05-30T12:18:32.426Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/39/2195f0457e021692c80db6b31334d26fa08db64ced2751040384de8b5fca/pyobjc_framework_photos-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2f3caf43105e0d142abc6b10bb851dc107158682d9dbb612d053cee80385f0f7", size = 12537, upload-time = "2026-05-30T12:18:34.198Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ca/3c305cec64c242f2f66533650ec955c93af89772a910c64c4eb4c6748ec2/pyobjc_framework_photos-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:59a9ac81947dc6140093ec2f4131842c8820f6ad9a51226c56e15b43ebacf011", size = 12715, upload-time = "2026-05-30T12:18:36.022Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/87/809159a91d74d25b098bf1b1551029329c348144caf726dc1aefd67892c6/pyobjc_framework_photos-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:facf2989cdf8cac7a34d6e5b6d410aa873b78edcd90da1e5d4812e30f5ad6b5b", size = 12586, upload-time = "2026-05-30T12:18:37.817Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/8e/4adf7cd8b7ce70ee16f28ab92258959f10e4de60ff8839f0230eddef60ca/pyobjc_framework_photos-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1931ea06e6bbb6025c3d24b0311415c3676c61157b1ccfe4f41eda12240adeaf", size = 12774, upload-time = "2026-05-30T12:18:39.731Z" },
+    { url = "https://files.pythonhosted.org/packages/02/28/00586042f82ecafd48e82d15ea6aebb2300b0f524a613b3f6cab1214621a/pyobjc_framework_photos-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:0ff24a985f6fb0a876346f320afe77f3cbc8617b8cacdb3cc010218187cb1d15", size = 12584, upload-time = "2026-05-30T12:18:41.51Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0863492ca4780a11ac86e5c6a309e9acc00271581e77dabc1544eeaa05b7/pyobjc_framework_photos-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b82f8aaed4f43dd344b45c81f2a661b607443b5bd221fe612f948a7f9a71acfe", size = 12767, upload-time = "2026-05-30T12:18:43.347Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-photosui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/62/9b4322779ac45e8971d613c23f19284d7c6ac2492b2384c8eaa4582e6dfd/pyobjc_framework_photosui-12.2.tar.gz", hash = "sha256:c85ebf27f523dca57fadf767a4d72739c760d7c7236f5e5c8fbe4f80e696c9fd", size = 33856, upload-time = "2026-05-30T12:41:15.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/be/fbb95b53d67a0add073789f1b149ce722f3807574ecc8e3eb90a84868769/pyobjc_framework_photosui-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:40d08f08072624e2ecaad4c58e5159d6f032815929faddf6716d1c1904265022", size = 11759, upload-time = "2026-05-30T12:18:45.161Z" },
+    { url = "https://files.pythonhosted.org/packages/93/0f/a7e82400150f6ab50442c098fb4c5bc82e708d7fd70fe03884007b408824/pyobjc_framework_photosui-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:fc462882da9e12d1b9e426402be0cadd93665c0112a299fa3fab1db0516504b0", size = 11757, upload-time = "2026-05-30T12:18:47.146Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/81/5233f2e0c255d73e0fe20cfdb5914bdd50c1df8c911ad5eba6759d870476/pyobjc_framework_photosui-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1bc96dba3085d5ae6d5f311ec4c82cdafb04b5519a6014e3ae7915086408346a", size = 11784, upload-time = "2026-05-30T12:18:48.825Z" },
+    { url = "https://files.pythonhosted.org/packages/99/c4/c2f9cc556bde2e1e85cc20103ef34705da6e695b542330d5fff7eff17cdd/pyobjc_framework_photosui-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2630d9f61df8f786b1a42a30872e856be2ae7a2fd21c995c5d7d88705cc784ed", size = 11793, upload-time = "2026-05-30T12:18:50.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/68/f9696cd18c479e67b9b911c5a8d7243034fe36c6bf6482add22ae1076dc0/pyobjc_framework_photosui-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9c3e0cdbca02ee749b3d56ff332a4a69b8d378550131df4e4003733c6331728d", size = 11994, upload-time = "2026-05-30T12:18:52.323Z" },
+    { url = "https://files.pythonhosted.org/packages/af/c7/5dbd150e31f3ba6a972f7006bad934836e2063c1c81c4a245cb4eb6e190a/pyobjc_framework_photosui-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:75ac87647349f556c91cca0d584720fefaa303fb472f20e31c4eefc4a7d7ffc2", size = 11791, upload-time = "2026-05-30T12:18:54.055Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a1/709f881022cff00e7b6f08fb53b68161be16b0979861adb465403de5b696/pyobjc_framework_photosui-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:70e9ab782e9ae83d79da7718e9db4c491ce7fdd58d18bc00a27e4b1e9ea113e8", size = 11976, upload-time = "2026-05-30T12:18:55.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/90/8ecf14ae1227be6b049c237a25f4c5986aa1a77661dd62d0e9550c4cbe61/pyobjc_framework_photosui-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:18cddf0afffb005cb06ef6c10c3ea61dc7387162264e469c2aaaf261970a1022", size = 11784, upload-time = "2026-05-30T12:18:57.48Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/de8dbad22bc3ceeb7ed61de59762a409a1773a066369df3cb9ff7016d0d4/pyobjc_framework_photosui-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:52f74cc40c1dc129e073331910b627bb53f457645ac1bd1802176cca23c49a1f", size = 11977, upload-time = "2026-05-30T12:18:59.182Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-preferencepanes"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/86/73de5b65736cea66bb0159d9a37c007abceee8ecd3a059211241aa2d77cb/pyobjc_framework_preferencepanes-12.2.tar.gz", hash = "sha256:4928aa6fb30b24af3aa7379125ceca91687e97b08715909689d549a0a73266d3", size = 25151, upload-time = "2026-05-30T12:41:18.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/5d/b75418c408c5e969352307b5fd4d739e55b3618cf94e729ba9768e453f2a/pyobjc_framework_preferencepanes-12.2-py2.py3-none-any.whl", hash = "sha256:ccd142fb1d26f20e660651008fce1440f0abc1897bd5ffb5546cd77e89bb31a6", size = 4803, upload-time = "2026-05-30T12:19:00.619Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-pushkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/40/23d8b7065434179984df6f4bb18c6ead5400ed2f85b7080282c600106022/pyobjc_framework_pushkit-12.2.tar.gz", hash = "sha256:8f6b6879920bf9650f2288adb0dc8f809a807825c29136b6492561712234b0b3", size = 20471, upload-time = "2026-05-30T12:41:22.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/44/2f8f8d44534ade5da866e1d6b19a0172ff31db1215785ef56b3016199bfc/pyobjc_framework_pushkit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:acf9232e744c633fd77d87c9eae28077176f32a3086dc684568d50427e872016", size = 8264, upload-time = "2026-05-30T12:19:03.807Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/da/3b1c52a2bc45bc30444251aaf556cc5268730c03502bc3ae1627f929bf15/pyobjc_framework_pushkit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:92d05e166222ddacc81aa3c5d80ebd60b84efbc6f1bcdec1ac7f0f07c2cee1f6", size = 8270, upload-time = "2026-05-30T12:19:05.672Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e6/c787ca0efe193b7f8eb907ef13eefb47efedf513d42214f5ec7411867a51/pyobjc_framework_pushkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:955d18de1963fa09f41fa797470f943d0f85f3d2ea5db3d618798e92e54b4575", size = 8282, upload-time = "2026-05-30T12:19:07.379Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/d315aac0efb5466a0235ea69aefac9883add2f5fb90ee363372abeaab299/pyobjc_framework_pushkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:358e5e381d37fc1199d0e18eae0ec9bc88145545c985a75ffae37918c0634a3c", size = 8299, upload-time = "2026-05-30T12:19:09.129Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6f/8ee291088ec4b6469b9b51674d0f160929395164483136cccf2569bb85c2/pyobjc_framework_pushkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:11a5efd1e08cce341b0882cf4b47ba120f288c04594d714c0149c2a357518b05", size = 8438, upload-time = "2026-05-30T12:19:10.855Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/40/1b139236ac991f39723b9fbed278f655be4d6837f90d10214203e442064e/pyobjc_framework_pushkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19dc136cfe89f43b3ff3e0643106aa4e527ac03936e50cc9d3bc2d91dd2a3226", size = 8356, upload-time = "2026-05-30T12:19:12.318Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/73/18dd6ab8aa631a616c88ff7451bd7d57c8f49d44c7a4aec0a7ad13ba3c6a/pyobjc_framework_pushkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4e8099d9db9c9a66b2b098dd36fa03116bbe82387bca27c34969eca207b74b6f", size = 8489, upload-time = "2026-05-30T12:19:14.024Z" },
+    { url = "https://files.pythonhosted.org/packages/26/d1/a80f3bed47908c156d83ef9b6d80c3a0a949ce4fad0f45e5bcf982d1240e/pyobjc_framework_pushkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:23654c78ddb89412ab0f57ab36734789566525de0d357e22edc22f30a63d7971", size = 8349, upload-time = "2026-05-30T12:19:15.479Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e4/c0fc4a461ba75e64bfe0681a1ea469932e8df8c5ae7536b438de6ee2dde1/pyobjc_framework_pushkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3d943e4c56d5e2ac5652c8b4d62187235d401d00fddce28e06a2db857772460c", size = 8495, upload-time = "2026-05-30T12:19:17.23Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-quartz"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/a3/5ae4c90c13999b46315f549694f25c374c48a9f7ab18f98ace6e74f4a5c1/pyobjc_framework_quartz-12.2.tar.gz", hash = "sha256:b343395d4790323b0376fe20c83ac468510ba19f65429323ca211708c939d107", size = 3215525, upload-time = "2026-05-30T12:44:27.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/13/e9471bbf5740a15b8a0c695a83091b7e6f14a0c827c29bb41e87a1871c88/pyobjc_framework_quartz-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:96201eb37192fde3abac348adacfc2d4e8af4e76d42752664d1e515f1db5d929", size = 217973, upload-time = "2026-05-30T12:19:30.731Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/91/5529c1434d62682a1c34a58dacdd901c96406e7a172d06f5e34ccdd3ccce/pyobjc_framework_quartz-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2dec68f8d5b42030fb0f44bf1169a208318393f216a68048b4336649d877293a", size = 217975, upload-time = "2026-05-30T12:19:44.654Z" },
+    { url = "https://files.pythonhosted.org/packages/96/98/3b1fa78ddb1cd10d0edd4d49a3d00301d941f535694ac444fbed53ec7504/pyobjc_framework_quartz-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8b238979d62b6e0b90d466477eee968d8f2f6720e850af2472e01cef349293b4", size = 218969, upload-time = "2026-05-30T12:19:58.528Z" },
+    { url = "https://files.pythonhosted.org/packages/96/56/670a847a3a8ee2799f405b876a2f20914f22b4865f1d8157169095c21d94/pyobjc_framework_quartz-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:214c19aadfd100d9202994a22fbced804f7d60f8473de6f292111cc1668f9373", size = 219383, upload-time = "2026-05-30T12:20:12.444Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ef/598bd4d1fb796305648c03667938f08bb59ed4e0bcdc1591fd2c6238abf2/pyobjc_framework_quartz-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4e0634ee9782e480587a074d1d08867fa7ef0d845c2f6cbaef6a48b7d2c3899f", size = 224436, upload-time = "2026-05-30T12:20:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b4/7ec90f6480b554173df109b570915c26d286c414d9444d2066fc93567781/pyobjc_framework_quartz-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:08f7c7b42de70875cee15f4d0e217471e382ffac44d0a5bcfd30f583b9b41adb", size = 219749, upload-time = "2026-05-30T12:20:40.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f7/9a6cc42345d7a89c7344763e931476c9bf00d3b16ef1e862b1f720709afe/pyobjc_framework_quartz-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:57553e7085191f9421ec78fe57a8a0c8462e39d675014ac1e4b389381f04535a", size = 224703, upload-time = "2026-05-30T12:20:54.835Z" },
+    { url = "https://files.pythonhosted.org/packages/41/76/a831a11a67fe36898b4b887bfe7694a291e08a96266416a832a9de97bec8/pyobjc_framework_quartz-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6fbd127d864108103d4980292ffca32bd9c1e5f643e0abd5773fdde2918afaca", size = 219804, upload-time = "2026-05-30T12:21:08.79Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/77/3223cef0bf8cc97f1d586ad1b6c79e04bfbe2a47a1fe5bd1ad3abd862325/pyobjc_framework_quartz-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:359738c88b12427a30d73a3d202002ab910e31eebf6bee4550495ec8aa64a004", size = 224750, upload-time = "2026-05-30T12:21:22.826Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-quicklookthumbnailing"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/c7/e19792f6473714f4144ff2c579f2a231eeb81e405388140471f9f6ffaa4c/pyobjc_framework_quicklookthumbnailing-12.2.tar.gz", hash = "sha256:b0104142f0eb950e849ea25f40c01715069e1bdb3de69949c1b4732c8f5c693f", size = 15771, upload-time = "2026-05-30T12:44:30.263Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/5d/012d04a9fe4117f727e0436b7b6c9a30f780e04ee51f1d6e28bb6d1a8700/pyobjc_framework_quicklookthumbnailing-12.2-py2.py3-none-any.whl", hash = "sha256:a60bdc283a44a70ad7a12840010b76d42ffd580c4bffb630da3874b229d30a74", size = 4306, upload-time = "2026-05-30T12:21:24.611Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-replaykit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/28/9562e12a0f13ba9c03ec59694af026500265cba2bc71468bf5985230ff3e/pyobjc_framework_replaykit-12.2.tar.gz", hash = "sha256:f971842973fad039642a67e3432b864e8bed815228d67d07b52174fceadca86f", size = 27206, upload-time = "2026-05-30T12:44:32.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/15/dcd47170fc5679ea87e4d984ce90658abdcf9dd951607d9147d6e527a46a/pyobjc_framework_replaykit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b09dab69900bcb31edec68aca369a131402c0f1bcf16c777eba68ef2b972a9e2", size = 10120, upload-time = "2026-05-30T12:21:26.318Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/8b/0b84274d5c20fe0b5adcc2bc62f52d5e41f7b5c2b8246478497fc3eb07cb/pyobjc_framework_replaykit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c35e2945e678b8b80e428783b71dbcb74c35eaf450159fd53ea42b027b3cdf39", size = 10117, upload-time = "2026-05-30T12:21:28.203Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f4/2377e7bcf93257ada33941e8ea7993357bde6e679fccfe44f9f36c9b9988/pyobjc_framework_replaykit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3b60c6b287dd8b991bd432acb4fe061f8939df56aa65741dc777565aa0615f68", size = 10149, upload-time = "2026-05-30T12:21:29.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/bf9e3cc9fb4f3629b42e510f40539e323af43597601bf1ae5275a8468572/pyobjc_framework_replaykit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ae67c235356b4442dd0765ba3b911acf6f597894ad27b6b6c322b55ea501be6e", size = 10165, upload-time = "2026-05-30T12:21:31.556Z" },
+    { url = "https://files.pythonhosted.org/packages/03/ad/a34116524dd3d7cae22cef8125a897c4533b9dff9236cf4e00f06ca01012/pyobjc_framework_replaykit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2040fe7d3da7ac485c32f620bc0a2ffb8c5c1052ca67e2d36db78533bbd84e9c", size = 10348, upload-time = "2026-05-30T12:21:33.309Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/2f/c6f524971e6f61e763ce6c36ea9ecca4d61d423e79c26fc715e06ebd879b/pyobjc_framework_replaykit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4479558bbaa1d0292e77d1d01b56eb6593a47310c9c49d213061b35094f0a948", size = 10220, upload-time = "2026-05-30T12:21:34.924Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/57/06b54386c5d2079172682193030fa39bae31872b9ab85c208145b7569a6b/pyobjc_framework_replaykit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:aa7785a906efcac0d5cd6c68c61bf0e0800c041c2a56ec179298a2df4af3f798", size = 10414, upload-time = "2026-05-30T12:21:36.53Z" },
+    { url = "https://files.pythonhosted.org/packages/34/37/cab6961855ff727e6ccc2e7766dd2429d042721f2929d38b3e2ecd174d07/pyobjc_framework_replaykit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9d429b4bc0f0ed7b07242e103f8652b79eca93e81d0730071377eb54b3c47152", size = 10219, upload-time = "2026-05-30T12:21:38.087Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/7a/9f755469b7ca6f962c0c3afa503ff6a67e5bc8f654728a1f2bea33a5bab2/pyobjc_framework_replaykit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:95be424c8b99c0beaa068fe999c2cf31a449095b9f89fb56bff2a5961d1995e3", size = 10410, upload-time = "2026-05-30T12:21:39.659Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-safariservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/e5/8caad7cc12d7452f9f78f931bec253f04577c6a876a9884834572223462c/pyobjc_framework_safariservices-12.2.tar.gz", hash = "sha256:35f76589201c9857f36fcae027c79ae2719d4463e1bb35996f78de9f570a0a58", size = 27300, upload-time = "2026-05-30T12:44:35.242Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/89/f4aefdb0163d8c12a70b641d079de598c553606e4cef0ad0a1d24849690b/pyobjc_framework_safariservices-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:237710861b293fb9f28654b75e04c9364e3d27e926864d03072da842f5d56f01", size = 7315, upload-time = "2026-05-30T12:21:41.152Z" },
+    { url = "https://files.pythonhosted.org/packages/72/30/a74468e4ea67e2d0e95df46bb22ac517c4d3891ec96ceb0cec415620f171/pyobjc_framework_safariservices-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:09f4baf9b5d95bde52d58f15127b21aeb388a556827e530257ea514cab58bf4d", size = 7320, upload-time = "2026-05-30T12:21:42.888Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2b/731f8bc8601aebb0e23032d5a0e6cd9af7abfb55192f95ec999c913443f0/pyobjc_framework_safariservices-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9657d68f73454f1f147ff4c6526fff28a5bafb769d628091cc8cca5d89882e", size = 7314, upload-time = "2026-05-30T12:21:44.344Z" },
+    { url = "https://files.pythonhosted.org/packages/83/56/c3bf80c5abf766078fc6815a91c287a72772eb675eb538fa8e3aad426dd5/pyobjc_framework_safariservices-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d7883793626c82eb645c99b719cffa856f8fa6d2bc19ce9fabedf5611888b7e9", size = 7339, upload-time = "2026-05-30T12:21:46.007Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/19/bbd38d764573a907e9287aec7fd065904b136042a6f4d8d9b488cdb67640/pyobjc_framework_safariservices-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f97571814b69ca81baa3570a4338e9c7679a7505c5f05b28938890ed71d95ff6", size = 7344, upload-time = "2026-05-30T12:21:47.611Z" },
+    { url = "https://files.pythonhosted.org/packages/84/6c/10d2e963d630ba86a0dd72d83ce9e6a8d59bea309d76a71868ec4bdfff3e/pyobjc_framework_safariservices-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6d5df844c6e10ef54a87ff9d847037978cd1cbf4ef87e31333a56726767ab5ff", size = 7371, upload-time = "2026-05-30T12:21:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/0f/fa12873da4842d5b0c253c3412a7e00251e7f5392007e5fd9f71a92c2d4d/pyobjc_framework_safariservices-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:79a9960e0d04487ac0554d25668efda8ba0bfeffc68936d841fdb1be9b44b93c", size = 7380, upload-time = "2026-05-30T12:21:50.689Z" },
+    { url = "https://files.pythonhosted.org/packages/58/9b/eec655a20a7732b2159ea8dda119b59fbaea7ae6864648e36fde50f314c9/pyobjc_framework_safariservices-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:de57e964f0dc86e40d9dd4b1a240fa889c80218970a1e716c45950d5da38ec34", size = 7390, upload-time = "2026-05-30T12:21:52.28Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/82/75e9d7f2662b252e073fb8ce771ca689cd733ede5bd9ee07e8198e1436d1/pyobjc_framework_safariservices-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:fad17d1e4f9a0a680cb9778c3aec4f31ebcf86ffbaa7f1850a368dd21b2075eb", size = 7394, upload-time = "2026-05-30T12:21:53.768Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-safetykit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/c2/7a6c1c356ba3d9164357c353142e6d9354f999b45f204c57c5f2162a47dd/pyobjc_framework_safetykit-12.2.tar.gz", hash = "sha256:3161c4cd35261615ea38e64bd1db9de19c66d18d4d350bbe7d4eb4f69207e256", size = 20867, upload-time = "2026-05-30T12:44:37.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/d6/6a991e8ee306f8a9cb7d22f516dab481076d969d9988de5201b145120048/pyobjc_framework_safetykit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9cfcb071eb57e10e94137dbc4dbc024999e496dd89162b46b086cc5dfa4836a5", size = 8565, upload-time = "2026-05-30T12:21:55.322Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/a2/f74154095e2c10048aeaf0461f9085e28e9ad87b302697cc43e8f618204d/pyobjc_framework_safetykit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3921cf98475557ab50ec05934f5bc603c1edc7a7b53f1c40da5a4d4dc767f40a", size = 8567, upload-time = "2026-05-30T12:21:57.03Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b9/57f5f140685596bce0587b8348c996ae03b5f3f399bd8513d63780b691fb/pyobjc_framework_safetykit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:13c471d8122a52bc0ae26263b22291475465fa00b5da488e096967c305d65bed", size = 8577, upload-time = "2026-05-30T12:21:58.553Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c9/f33171cb2129b39fc8ce4a2dfd5ccb9d5fd7fcff795b90efa85462490609/pyobjc_framework_safetykit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:93020a92a64dba726e8e1fb03079b4697d49e67f0338b33a63eab76a1a797033", size = 8594, upload-time = "2026-05-30T12:22:00.181Z" },
+    { url = "https://files.pythonhosted.org/packages/54/1d/2abc135c5b8674511bf72a194e2ee7d9fd23cc37ad6a9a8884451aa2a6b1/pyobjc_framework_safetykit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:6dee8522c45cca1017ebc52198a89d81cf12b4e1fc751e8fab87059326b9c9d2", size = 8748, upload-time = "2026-05-30T12:22:01.766Z" },
+    { url = "https://files.pythonhosted.org/packages/34/87/351f935618c953e54258ba6d83a72343afe4296417ea5479f90233c6d1a9/pyobjc_framework_safetykit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:650eeb355a74e39781dffe9ec364f9a7628f30f4bb4fd8080fdb850d90dad83f", size = 8644, upload-time = "2026-05-30T12:22:03.312Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8e/5960031b9c56da88e4fc96f4fe8eb19bd1c41acbfcb84ab0d9f0ed554032/pyobjc_framework_safetykit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b2994d2c0d49a18b41a627c504fafff167eb54511111c0bce132c20269a784d3", size = 8807, upload-time = "2026-05-30T12:22:05.281Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/3a/cdb5155f81decd0aee51a730129dc2826b5d84b4690585c8140093a2075a/pyobjc_framework_safetykit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a0ab5169593c99b96fbe09506fa89eed88e799c274cf70d99817699c253d3b11", size = 8646, upload-time = "2026-05-30T12:22:06.994Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a2/c5eee93c915e26b38c1f324aaeac223145d099572d6e7f0096999b3c8de4/pyobjc_framework_safetykit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e65386962f80aa4f85d11ee4f0470c05348b8282493336ca3adf9bb8feade375", size = 8804, upload-time = "2026-05-30T12:22:08.721Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-scenekit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/c8/963293a476d7c80f60d93e3da2b1f6016913e827fdde63d3b9b7ec96164b/pyobjc_framework_scenekit-12.2.tar.gz", hash = "sha256:de58706317e567d0a5f257f9a4a66fafa037c5c8ef79051c19066b42477e301f", size = 131982, upload-time = "2026-05-30T12:44:45.83Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/c2/89b602a605b599d81c1ca07edbe30fcd039051e1ebcaa5677cb776797671/pyobjc_framework_scenekit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:412dd99fb8d04ed37ffaaed62daad1fc31612b1f7203416bada0902aaf9df26a", size = 34735, upload-time = "2026-05-30T12:22:11.675Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f7/24cd14e52c7b12c8cd09639dc889be01df3f1a6e2d4ef5732d8e3bcae2b7/pyobjc_framework_scenekit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c2c016de827a9e2869e9f837482bad5f1e21f5b2047a26a8bd3e9506c78d94a0", size = 34734, upload-time = "2026-05-30T12:22:14.864Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b0/613f52cdd4b4fbe0735564ee8883d168d39b832c9146700fc9263a55ee4d/pyobjc_framework_scenekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e623bd497088caec95e666b8f99bfcf89096d943b90038bb243b582e8707e6ca", size = 34800, upload-time = "2026-05-30T12:22:18.024Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e1/c117e5db66ceb6c13f0bb44c40210749e2d9c61eb5d77d50e731dceb8865/pyobjc_framework_scenekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0b1795cf860b19fb04116236b6de3a46ffac9f8b03c46863128d36207cc53a40", size = 34827, upload-time = "2026-05-30T12:22:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/44/645de9525dbd6258954b8001336df1f3ae85559acae9a119049089975270/pyobjc_framework_scenekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0d0bcea0b7a4a13046a666a5b316c1b3ebfdd90a63226fcd5b7943fd9ee9d615", size = 35142, upload-time = "2026-05-30T12:22:24.247Z" },
+    { url = "https://files.pythonhosted.org/packages/49/56/8f9b1e188357488d143016852b1b203690a5d070d76e2266244daebca92a/pyobjc_framework_scenekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:7a28a88d7643c12c17a2bcc90899eb1c4d6750d48bc7fb71b8ea0bf9091c22df", size = 34933, upload-time = "2026-05-30T12:22:27.432Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/3b/51883f04be248965015f96045f449cda35c4dcc249c054d25244e552aa41/pyobjc_framework_scenekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3ffccf8f84a60f671261c1fb997e4f8ed55d71603db0aaf1806032307dcb86ed", size = 35225, upload-time = "2026-05-30T12:22:30.464Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8a/c1934d6cbd824ac2cd674f3adbb516f73fd55e9f8298e8c0bc785d3bd1cd/pyobjc_framework_scenekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c881852ddf8fde16d1d124c6c664e2938d3f00839df1375bf54dacf260d1f6cd", size = 34965, upload-time = "2026-05-30T12:22:33.666Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/15/3a3c0d53150ec202ee8fa55fa5d374d046cc63d22db74a7804214b38a108/pyobjc_framework_scenekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0b8b92b25f35889a7d05f350faf0986af2306430321e09a758469f043810cbf5", size = 35261, upload-time = "2026-05-30T12:22:36.7Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-screencapturekit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/e5/469c73f6ba9bf9ae6d4a93aa23838f288dabee88555402754dee000ec884/pyobjc_framework_screencapturekit-12.2.tar.gz", hash = "sha256:7f45f2e170b97dfde3e6c7d3b867ec3ec03caf3aac9259fde4ba0272d912b00e", size = 37813, upload-time = "2026-05-30T12:44:49.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/6c/7083c0165cc611b98b1035b32767ae763d1975bbd3196dcddde16efefce3/pyobjc_framework_screencapturekit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bd9c0f36ae2321caacb20a73e0f6948ee88561a76dc0798da9e4ef7ec1337803", size = 11542, upload-time = "2026-05-30T12:22:38.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/6a/917fffa6946c5f96b4feca18005ceda68670ed702473c2e2f0685d2d4062/pyobjc_framework_screencapturekit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3f763dd8fafdad4960c7b4b75bbf015adc0d8bf78cf76db1d3f130145ac369e4", size = 11544, upload-time = "2026-05-30T12:22:40.566Z" },
+    { url = "https://files.pythonhosted.org/packages/65/3a/461e7b200fb656c9581ae7e4bdbad58a81fc1b95b594a448b92b8858c5e7/pyobjc_framework_screencapturekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ea666ebfd9da6a3db9eb9a36b22834ab381842d2ce0fafe19e782a03ed592aee", size = 11576, upload-time = "2026-05-30T12:22:42.324Z" },
+    { url = "https://files.pythonhosted.org/packages/73/5e/e64b2a94e8f950dc2418a274049c01ad3f8f3f54fbabe6912c72a72dff5b/pyobjc_framework_screencapturekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ca8378bf217d3ac48db0bb62218b8bcf6b69bd35e1ba66608bec8c31e0f0fbf5", size = 11590, upload-time = "2026-05-30T12:22:44.063Z" },
+    { url = "https://files.pythonhosted.org/packages/21/25/892fe4f54b8ccecbcce6f05c98e377021ec4ada9b226b18523ac97c04025/pyobjc_framework_screencapturekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c1be8a80eaa2a929cde641526f81e7452ff156234372d27c5084df472a74843a", size = 11766, upload-time = "2026-05-30T12:22:45.744Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ed/94d8e98d2d035604e80ea72449b0e5a3fc63072a6f1aac7c76e3e5dff688/pyobjc_framework_screencapturekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d2b4d13114bcea42f4643ff263e4c5ac1d006289b2ed04ad0390180a4525bef6", size = 11646, upload-time = "2026-05-30T12:22:47.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b1/eef4bc88c093a68c65553a263ebef50fc1f280682e6bded1d0d1394e6b15/pyobjc_framework_screencapturekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8aa43d36d8840560c3521833b5c2abe45008bfd1c45c980a6fd85aa29430673c", size = 11850, upload-time = "2026-05-30T12:22:49.337Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/7c/21f8b109ff5fc2a5de9dfef5c7b2dd3a6678395636c9835419410bb29a8e/pyobjc_framework_screencapturekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:1784792b5809946eec69792429d332cd818614fb6899f7cce35f7c9d8c357355", size = 11641, upload-time = "2026-05-30T12:22:51.03Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3c/94f3c62be42642759ea9fe3428e8e859b3ecb738b9955ce35ade5d645797/pyobjc_framework_screencapturekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:560e81da652b05b0d10b16a62eeefa5e10cb05fabcae455f1c75da55c952be32", size = 11846, upload-time = "2026-05-30T12:22:52.781Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-screensaver"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/47/475b9d9462fb72f264c600178905e0f149d0dc3ac549940477cc582aa24c/pyobjc_framework_screensaver-12.2.tar.gz", hash = "sha256:2aefc58e53b42c33d0d06b4c846147c7b15b065254c588bef0ce8871ccf6d9d7", size = 22793, upload-time = "2026-05-30T12:44:51.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/63/5beac81bba1ad130c19eb55a5e005bea9ded335c67f9f76de56eb18ab5cc/pyobjc_framework_screensaver-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9cdf2b759f0c630a5e3e9d022ee4ffec49c0fae8c4eb120f57b3a662827cfb5f", size = 8542, upload-time = "2026-05-30T12:22:54.344Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/5f/fbcc5c4487512d16b67267501d38fc5d505e8ffbdd773cd4bbaa2e5edf2a/pyobjc_framework_screensaver-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4ad00c18fc710fb3ac2cc333415120ac8a98b9b6e86d791f16addccc4ba66ad0", size = 8542, upload-time = "2026-05-30T12:22:56.174Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/9f/e2c143ea0f0ccd29f8c7e199d2bc81d198ea0c6d3d63948b314f6a26afa4/pyobjc_framework_screensaver-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4572cb659fdde2df5e6fe9a6e6972e87a4a04ef60c64fb8766bdb6d281782f4a", size = 8463, upload-time = "2026-05-30T12:22:57.818Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/cc/168c45769e522b7982702c2b2af9891036e7653d8bc50a3871f529c9fb8a/pyobjc_framework_screensaver-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e4a2e2205effaa1dcbf5365e25011b057ae70deadeb29b0782c0af6dc2592f7c", size = 8481, upload-time = "2026-05-30T12:22:59.402Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/bd/f0ee37d17d48f64c1232cf89fcac33ba56454be63062ca50150ff0002799/pyobjc_framework_screensaver-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:921dc983e81b0aab7f102bcd115b4c5cbc347d251b00167ca58ccec7c6ba10cf", size = 8493, upload-time = "2026-05-30T12:23:01.134Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/a91eaee7dff0443e0930d9572d172370dccc15a2aefe37e2a21e01d04e35/pyobjc_framework_screensaver-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fa9e2b9527ecffa4cad752f50b02b521016641d07faf78717ce801a95f934598", size = 8526, upload-time = "2026-05-30T12:23:02.753Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6c/1660f902c6d3e985fc5b864744e8c3929381e30f0491cd3145c22da13dc7/pyobjc_framework_screensaver-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4b174df55aaad1040b17bb8856ba79ac3c76e2076163ff66b264b89b6e2ee2eb", size = 8543, upload-time = "2026-05-30T12:23:04.315Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/a3/45eb28982e10c6ddd124d6e31b07ec4de929242d4d92c661e3bf03d1e176/pyobjc_framework_screensaver-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:270331dc16e72e692e6b732d0536c289a3b46f60aa149a36b7c78518fbc8a0b9", size = 8560, upload-time = "2026-05-30T12:23:05.923Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/d5/4a810a651e854e90fc271bf4bb61d7f10d00530464062593b9b28c5081c3/pyobjc_framework_screensaver-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:d5a32f11b57ca5d3399a9bb39c1f7eb76a5f303a008e82e6f022013aa6c7f4ae", size = 8570, upload-time = "2026-05-30T12:23:07.642Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-screentime"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/e1/acd5b9635c905305cdd367d1e5e06f71db13c44ac3384f0241845b180272/pyobjc_framework_screentime-12.2.tar.gz", hash = "sha256:0f708bf1707f2db5c4d13397471bd13cb8c1516ea204d7c4cca8f448295caa4e", size = 14069, upload-time = "2026-05-30T12:44:52.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/a6/2bdf31496600ffcbbb958910e03726e238f6a0ac6a7f3862cdbc28cab9c1/pyobjc_framework_screentime-12.2-py2.py3-none-any.whl", hash = "sha256:ef463bf9cf66ab2679a6fdc3da0a51bca3050bee4ff7614ac714edaa13e36003", size = 3979, upload-time = "2026-05-30T12:23:09.049Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-scriptingbridge"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/81/59528ce5c27667c0effcb6af24d039767df0faafe3ad006f154a82d270ef/pyobjc_framework_scriptingbridge-12.2.tar.gz", hash = "sha256:b1420622d923cfe6218904a6a997eae4984653d32554b16374690c347f8ab55d", size = 21239, upload-time = "2026-05-30T12:44:55.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/d4/a13ded48d8da60a39daa6d9cbdc481a95666a3d3d4da500550d271d3a643/pyobjc_framework_scriptingbridge-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e58d8fa7a5e51f354a07174356887b575556aee0394ce1a7c27d0c8c211e2ab8", size = 8338, upload-time = "2026-05-30T12:23:10.851Z" },
+    { url = "https://files.pythonhosted.org/packages/49/cf/1088ebf54efd4c06379be9d3bf8d73a0ab93abb93c3288a5e2f34739fe61/pyobjc_framework_scriptingbridge-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6827941b343744cdb12b13b7af908a3f67b4016d56691719d42c09137637980f", size = 8337, upload-time = "2026-05-30T12:23:12.652Z" },
+    { url = "https://files.pythonhosted.org/packages/01/fb/e3ffa8a5812302b208d0063254c3f6b1560cb0cdc18862280df471c899e3/pyobjc_framework_scriptingbridge-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8292259f1ef59c503e003d96e05e489b6834cb6ac0ae92712cefed7a957bd7f3", size = 8359, upload-time = "2026-05-30T12:23:14.267Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/5b/ed96c67b88ce1408f1778d1235a7c3c354980e4c925ce53bfbea0b424c78/pyobjc_framework_scriptingbridge-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ea7944907fe696a8192f2a9861e148b9a0161ac3415ab6ce6e76230181a10264", size = 8376, upload-time = "2026-05-30T12:23:15.823Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/57/9658c1a8576038e571308c3f21a6f38050808a7e379b1149c9b55abed746/pyobjc_framework_scriptingbridge-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8dfab9213a60840f15d0ebb2572237fea569ff69d2a593f524e8c7074b6cf657", size = 8525, upload-time = "2026-05-30T12:23:17.429Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/70/d4476462f9a922b4346a1aba5d43280102f718a95d33d42ade716deb6991/pyobjc_framework_scriptingbridge-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:be526303d2304e1cc88f00b673153f52e4af8324d1a58833442bec9164e4342b", size = 8413, upload-time = "2026-05-30T12:23:19.16Z" },
+    { url = "https://files.pythonhosted.org/packages/64/bc/e742f299d2a929b4e4c3a3e82e6a1db0dad05e69c6cd75c9c9f122eef559/pyobjc_framework_scriptingbridge-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:cfc8f1fb2ecd22cdf5bd3ad7c7d1b10329d7302b69761c07a32c2810d016aa6a", size = 8567, upload-time = "2026-05-30T12:23:20.691Z" },
+    { url = "https://files.pythonhosted.org/packages/73/76/335f77cd6ed5f8cc921998f10f8ecf588352c41402d46584d29855dab94e/pyobjc_framework_scriptingbridge-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:db40b1c7670f909198984ba1a57154ad6d896af425c9599ec8e6ba5921d0f9c4", size = 8414, upload-time = "2026-05-30T12:23:22.275Z" },
+    { url = "https://files.pythonhosted.org/packages/24/2f/31cad6ed0e2ba683ca8f7c5fd285fd266fc09ca105ba3ae1ce1934f606e3/pyobjc_framework_scriptingbridge-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:31cf0969d00e61a2f783ca5865d9d650a4be0ad1afded93cd575125187285693", size = 8567, upload-time = "2026-05-30T12:23:23.877Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-searchkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-coreservices" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/f1/2240da12e22d6e7273f60bc7fa7ec160ab67d8a3c7801010d480f661a16d/pyobjc_framework_searchkit-12.2.tar.gz", hash = "sha256:aec05c1fa302e11a8e1e737a67ed8ce2bf1e04e9e249796b3b923e90e7b07b9f", size = 31137, upload-time = "2026-05-30T12:44:57.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/ef/4e69b33a88e31e6d4e2ef9d266771b81bd20fce0eeffc1fa7c79ce9b3ec7/pyobjc_framework_searchkit-12.2-py2.py3-none-any.whl", hash = "sha256:eb004bbc4522e7e7a8ee3751539056e18c204fd591ac8a2ffa6a8146117ab3fe", size = 3732, upload-time = "2026-05-30T12:23:25.282Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-security"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/3c/7778dd8e196373feabc54841b87e495148da3fe20d305f39397546afaaee/pyobjc_framework_security-12.2.tar.gz", hash = "sha256:ef4d2d852a09360929e284c6f355964d84ac88b170207de1ac299fa1e1c33e40", size = 181056, upload-time = "2026-05-30T12:45:09.053Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/20/ae0df3c79c234d90d65aa6a98df043be8f40915ae544a59fe35a6ab37d00/pyobjc_framework_security-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ece714c9d18e7d8c4b8d1222133d7c3db52b2166b651e2ded57f77e99d59ae40", size = 41284, upload-time = "2026-05-30T12:23:28.858Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6a/6eb47295add8dd275d04fd87d2fb37a21a73f42ed30fc8664ec1776b78cc/pyobjc_framework_security-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:92c4814f722aa0673757ac50a46c4fa3b934e22da2acca6d57ecf346e744c5db", size = 41285, upload-time = "2026-05-30T12:23:32.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/72/be521a3961089017555936422be5b8a27c3cbceba84445bb1bdf7d602727/pyobjc_framework_security-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:817986dfa66e5a323ada063f4af52e699e7ac58aeea054a54344f2ad5af9683b", size = 41278, upload-time = "2026-05-30T12:23:35.974Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ea/20d93a62d2f3d54dccac9e3d9de617d27c229ccce42b8bd0d7f4bb4461aa/pyobjc_framework_security-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:703b8544d2623a854f438b13ef4561402e6228eacfb0f0b2cbf28d2704815f44", size = 41278, upload-time = "2026-05-30T12:23:39.428Z" },
+    { url = "https://files.pythonhosted.org/packages/17/a7/9725d152c8f23c6f2d3bb7fc2c2c9bbcbc7908a91de935c80fc5ed54c6c5/pyobjc_framework_security-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:10f03ed38e915f823640cbc19d5a921ee29ae266f0d76a2910c53fcd7cd61447", size = 42156, upload-time = "2026-05-30T12:23:42.945Z" },
+    { url = "https://files.pythonhosted.org/packages/75/39/6cf09f7d53a37dc9be7ff2215d067fead65229c54e7153885f1a2bdba57f/pyobjc_framework_security-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a837738a85884518fa7d50de4b88c1df0fcc67241a05dec1b36272cb3aa37e22", size = 41350, upload-time = "2026-05-30T12:23:46.406Z" },
+    { url = "https://files.pythonhosted.org/packages/59/3a/a479f9aa83d7b2f763afeb33f06f23d23948cfb81ce55e6ff04c91b514c1/pyobjc_framework_security-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:448b9658b59bcf56f4bcdf9345592fb719db711cb0f490f75cdffc82121b7c8f", size = 42904, upload-time = "2026-05-30T12:23:49.901Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/8c/a6024c130e82cf471fc1ea479fe9f387712ba22ff9d9db7b9450bcec3dd5/pyobjc_framework_security-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:65845ed21358e07544b57adebcf0b18de80afcc51c9c1da705689e35aa33d9f9", size = 41354, upload-time = "2026-05-30T12:23:53.349Z" },
+    { url = "https://files.pythonhosted.org/packages/55/1e/1ec868d695d173c6d44d5ed9b1f86b1398839a1539589ae545422548fbba/pyobjc_framework_security-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e1ffef0aff259884e728cdf4105610c462eeb7f9f624a670c24ca47cb4744eef", size = 42924, upload-time = "2026-05-30T12:23:56.846Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-securityfoundation"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-security" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/20/7fc0158fb92a894699ecf510c3be138c249817276c8346e70fd2a8868371/pyobjc_framework_securityfoundation-12.2.tar.gz", hash = "sha256:03d51d2945f4ceeb7f5fe60e28f9f18f9e96797152467d523d374f6f242eb89f", size = 13080, upload-time = "2026-05-30T12:45:11.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/86/f3fe3bea55f684182e65a4762204802c5fdd7f0b67db77f5dff2a2b3b2f6/pyobjc_framework_securityfoundation-12.2-py2.py3-none-any.whl", hash = "sha256:7e1c8307799cc819cf5891ed046b78eae4907e267592456688fe15f5892ec16f", size = 3801, upload-time = "2026-05-30T12:23:58.268Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-securityinterface"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-security" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/21/d164e409e47ae4460d9320d21de17c825017731a870dee1a2905fd187127/pyobjc_framework_securityinterface-12.2.tar.gz", hash = "sha256:096ea141b84f5128d367f4a7800073c801200bde86a451c735708137a4f23183", size = 27756, upload-time = "2026-05-30T12:45:13.639Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/6b/be4fc4ffc4f351a9db37d301863f76cd35dbee38c20306dad99fdecb7007/pyobjc_framework_securityinterface-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:914aef1b76e4cb9b3abbc4b1c12c3621b26acb794d20107d9041cc0aa6b7aa9b", size = 10715, upload-time = "2026-05-30T12:24:00.153Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/ae/8ceb6a0bcae2417dd814b02fb26932304692b2ba33d597f611731b71fe8b/pyobjc_framework_securityinterface-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:de3314104a883b2ac1da753fcb643a0e6dc03b49d65e8dce59fdcc291f49b3f2", size = 10718, upload-time = "2026-05-30T12:24:02.106Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/75/9d541b257b320ad7f76237399e6bfeebe96a1dfb877b32ab5c08bf39c0c8/pyobjc_framework_securityinterface-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1022c258f7caabf5cb5267da7c48766ee3329942d228782f9ce70080b34aed5b", size = 10786, upload-time = "2026-05-30T12:24:04.084Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/6a/39f94ce520d5661866ba15c69264eec1af67ed8e757d5ba9c25ddf0c5577/pyobjc_framework_securityinterface-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8741dff8c98a9cf585e5dd582c3fc2df124a0b5b885e9c128a53afb960b6e4fb", size = 10795, upload-time = "2026-05-30T12:24:06.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/9d/a18302f5aac77c33b8f3e6e6b529d3cca2d934c893c880b756c8bd6434d5/pyobjc_framework_securityinterface-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d1e56bce8179bb4b5e71986162491423173c6178663e5ca9f1f5c4ac0a493adb", size = 11136, upload-time = "2026-05-30T12:24:07.847Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/98/f738a5e68a4f19e650f9614d83fb043d4e18895f38aa4b1515c765e0c8cf/pyobjc_framework_securityinterface-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a54d16c9e0a0810059bd8a64debe77854d357b974b387d0fa55879845e67e46e", size = 10835, upload-time = "2026-05-30T12:24:09.467Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ce/5b0b179384f9b5cfdc7c5718a81011ec3d347d525a7da735e7189d1a9a6d/pyobjc_framework_securityinterface-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ad5b7b6f33981ebf1857042708fa56f0bb3040656f9ff63e0bc4b76407ff96d6", size = 11180, upload-time = "2026-05-30T12:24:11.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/9f/9c72ef65d981f36d8e7d55974498a2a38c7b2a4f119afe23472d010f34c9/pyobjc_framework_securityinterface-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:94881d2f4267629385296f5814949e0ee03f051f86987ddf0286c66ca12996f8", size = 10833, upload-time = "2026-05-30T12:24:12.822Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/1d4f371c224583ef7c850db3f1b20e7f7a5bd65532d561408789a1f19777/pyobjc_framework_securityinterface-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b7cf4225eb732c473eccad19a14a0b11d3ad38e41bfd0bed0447bfbcc8fc339b", size = 11184, upload-time = "2026-05-30T12:24:14.686Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-securityui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-security" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/f0/bd802a0bca727076fc117b57046a953bbf57cb41656fda917ebf066f287f/pyobjc_framework_securityui-12.2.tar.gz", hash = "sha256:9ce580490d7be95d7ef4b6cfdb9af80b62be486932a89aa402accc86596df934", size = 12587, upload-time = "2026-05-30T12:45:15.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/a5/db3bc24bd588cb704bb7db16f0f73177b0488c7577d676ced3932f1f41ee/pyobjc_framework_securityui-12.2-py2.py3-none-any.whl", hash = "sha256:d6cc86e9c039e8a1ac0227947277fb2b46ca2b9f9bb1fb7f7b081a3717ac045e", size = 3603, upload-time = "2026-05-30T12:24:16.206Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-sensitivecontentanalysis"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/f9/e18f459b2957f208718e7ff6a9f2715ad66509bb3bb1d4988d4c5820941b/pyobjc_framework_sensitivecontentanalysis-12.2.tar.gz", hash = "sha256:796d6cd3696daa7ac9116b35e7b2d520e86b687a8433443b755db8fd0cdd8315", size = 14411, upload-time = "2026-05-30T12:45:17.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/37/3c92718706b58f76eeacbafc5d6ba1b09a5ff684cd8f47ee7b53dc139d70/pyobjc_framework_sensitivecontentanalysis-12.2-py2.py3-none-any.whl", hash = "sha256:5beb7d718e6dea0b17c14560ebaa3474f7aa349e412f974573cfae84cd7121b7", size = 4246, upload-time = "2026-05-30T12:24:17.732Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-servicemanagement"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/d6/c31e62d53305b30110cae00013b0947b5cec17ee77afe3e1376d5fe1ea1c/pyobjc_framework_servicemanagement-12.2.tar.gz", hash = "sha256:9c7b698f4354a36ad0448dccba57e724ac682a1276eef3971b8d85d7ac7a6488", size = 15263, upload-time = "2026-05-30T12:45:18.771Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/67/d02639a189926546ddd2afd5015c0a5574e8310c2a59633bff0ad2b90b2a/pyobjc_framework_servicemanagement-12.2-py2.py3-none-any.whl", hash = "sha256:fa8b9d3bcfd0d2e6feb0884f3a95fda9cd681baf0b0ca457ec3f611de9439f7f", size = 5427, upload-time = "2026-05-30T12:24:19.271Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-sharedwithyou"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-sharedwithyoucore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/bb/afb864c9b6835bae72d55208e52d79734a88d597edc89c437a717da34ef5/pyobjc_framework_sharedwithyou-12.2.tar.gz", hash = "sha256:215aefe1baee8d31dce55b38bd653cdecf0a74dddcf89277d64fcb8d6beafb9d", size = 27301, upload-time = "2026-05-30T12:45:21.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/23/5552f96ffc1e6aa643ee872224eada670230d5f732eb63de3992a9fdaa2a/pyobjc_framework_sharedwithyou-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:63bf688cd265766ff2c518017ce26068d78f59b395c5382e6756c1329b9727a7", size = 8792, upload-time = "2026-05-30T12:24:20.996Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/57/e69a25f2abd982f07c3a9d5c5a3f0c132cef52f602057ab04355a92fdecc/pyobjc_framework_sharedwithyou-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5b019d02a66a3087c43cbcaa43ca95e287ce478636d9b630e2c9518559dbceab", size = 8794, upload-time = "2026-05-30T12:24:22.76Z" },
+    { url = "https://files.pythonhosted.org/packages/93/26/421a8222319cc41cdcddc0fc7a0c8f096fe313971cb92e50f56f50098a27/pyobjc_framework_sharedwithyou-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eaecd376e2a3e682d7e666703a2a03d22a1c39cf38762e36863b7a20a3c9da07", size = 8808, upload-time = "2026-05-30T12:24:24.426Z" },
+    { url = "https://files.pythonhosted.org/packages/22/2d/5df7613183733cb6d8bcb811d3b423cf97a24a12803cda0caaaa5018e5c1/pyobjc_framework_sharedwithyou-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1e6d829807fb4edd2eaf5752319649b99a4574d359cd0742c71c7ec0037fec82", size = 8826, upload-time = "2026-05-30T12:24:25.996Z" },
+    { url = "https://files.pythonhosted.org/packages/16/cc/5b5bb308f516f9ad75089595f3bf06eb08e1641cf4b66747473cb45bdf12/pyobjc_framework_sharedwithyou-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ee9b7aba9c09b8f7c75982cfc714f16d2c8db9dff54eaba689b4ee51f84c2124", size = 8962, upload-time = "2026-05-30T12:24:27.619Z" },
+    { url = "https://files.pythonhosted.org/packages/41/08/24a827de4d50388848aef2c162756b3bcf24545f2650dfe6602939df53b6/pyobjc_framework_sharedwithyou-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9556e5da95153991712b9556f5c19804a98c578c6a3e41fe240d414c77319484", size = 8871, upload-time = "2026-05-30T12:24:29.228Z" },
+    { url = "https://files.pythonhosted.org/packages/72/33/91efbfb9e4b41aa40180e3e835f18988dfa6c79f4897afbcea5e043eb99a/pyobjc_framework_sharedwithyou-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7cc06ff9b28cf3b30f599c96e076ae885d02511a02ee41d9e3127fd0230d2b9b", size = 9017, upload-time = "2026-05-30T12:24:31.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/d3/9350031f1e0bac76cb84a3cd34df609992980c1b69586b904cccb98110c3/pyobjc_framework_sharedwithyou-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:1557bd65b7eb6ddbad3bb152ea31b2f1cb7bffdb525de8ae400bbeb1cac8e1e0", size = 8866, upload-time = "2026-05-30T12:24:32.741Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1b/75c970532fa1dc09d3fe297d4078d6e6d239989a821ddbd3e0427aa634e5/pyobjc_framework_sharedwithyou-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:53b4e3b844c9d9f8105350ce49028702f7c4e03da01e63cfe39d325d6c853cf2", size = 9014, upload-time = "2026-05-30T12:24:34.347Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-sharedwithyoucore"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/02/4b1809c63319c277d88542576f86b7d7abcffd57ccd876d47d4623d6d5fb/pyobjc_framework_sharedwithyoucore-12.2.tar.gz", hash = "sha256:212bd551676cf0ae791eb8d7b5f6a4b10090e2d407721124d691e3020f709e51", size = 24303, upload-time = "2026-05-30T12:45:23.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/3e/71d6b7bdd01728f5f22c05838ce2b26e98839f89e4f979e9d415392dc472/pyobjc_framework_sharedwithyoucore-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1cbe189c6143713a73d90333e0b2c06c19fe00fa01a038fffebd61b0e9876b3f", size = 8558, upload-time = "2026-05-30T12:24:35.969Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ac/10372cb2e830473981ae87a3cac8021958dbfe905c90a8d0f958b391b21b/pyobjc_framework_sharedwithyoucore-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:91240bf161f281ebc447389cbae1cce419922b7b90df406e8cdd25480fdd84a1", size = 8556, upload-time = "2026-05-30T12:24:37.667Z" },
+    { url = "https://files.pythonhosted.org/packages/32/eb/09c4906bcfa9d67629cc6e950018c0e070b2a3130eb66dc58502d423b9b4/pyobjc_framework_sharedwithyoucore-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:091e58f4e1d976c0e6cedb3955f05e7376b2f5c7b226510affe7107428b80cb6", size = 8577, upload-time = "2026-05-30T12:24:39.278Z" },
+    { url = "https://files.pythonhosted.org/packages/34/3e/913bc40fce99ee370c940261eb59d65bd4f9961354c5059bd4d5612e32b2/pyobjc_framework_sharedwithyoucore-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3cc10c8a03892a3da8bff22235e31baa24a931f5bcd1994fc0124a197f14f70e", size = 8594, upload-time = "2026-05-30T12:24:40.949Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/94/67b218f72f4a6be6926691fc85266437edd7fcc837cec755a43bc0daa206/pyobjc_framework_sharedwithyoucore-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0286e5dfb8bc9530de31b0e686d052019d91e17fff3ea35c0338ac62e23659b6", size = 8721, upload-time = "2026-05-30T12:24:42.525Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b8/062c40dc958ad481a1936c334111c9630d3ad542b1a0e7ccac0c95bc7552/pyobjc_framework_sharedwithyoucore-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:24b9233ff69030a7e55615a80b8c1dc13049ec6d14ae673aec3b6a5ebaf0fc5f", size = 8643, upload-time = "2026-05-30T12:24:44.325Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1e/35e59ed5475d2343f8d03ce568a94aaec9a82262983fe2ddef425e841a33/pyobjc_framework_sharedwithyoucore-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:49d0217ff0569e575a9cc1c432cc4147e4a2307d701fa2bc287471424f139aae", size = 8787, upload-time = "2026-05-30T12:24:46.042Z" },
+    { url = "https://files.pythonhosted.org/packages/44/56/92de20611af1f8cb82d23f50556ec1f3bd421664f3d38485eb0f3d5818b7/pyobjc_framework_sharedwithyoucore-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c0c3d6f7b763ec13a4f12d43cfadb80b13490d802de47cb63a982ea84895ba08", size = 8641, upload-time = "2026-05-30T12:24:47.74Z" },
+    { url = "https://files.pythonhosted.org/packages/12/05/d7d4b49116e31e02eaab9acb583c5ab5febbedf041ecf49a80de8e4c81ab/pyobjc_framework_sharedwithyoucore-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:afe3582b4af25afa5bf94a6af3cd7cdfa3bc966f754502d3054c419754e67ca3", size = 8781, upload-time = "2026-05-30T12:24:49.333Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-shazamkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/c5/5cc4e2c0cb5e3fb3a3e3a4eb75aa85da70c5491125efef25e581516ec108/pyobjc_framework_shazamkit-12.2.tar.gz", hash = "sha256:9bfd2790b331b36ebdd9f80dab1fcc80b816ee19a1fb5ae981e5b4a8fb2e7084", size = 26080, upload-time = "2026-05-30T12:45:25.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/9c/79db4a96a380e49dd71704dbd52aa73fd02f263b0f35af4880a3a3f856b1/pyobjc_framework_shazamkit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b468eacd73768fff1d61663aac488ff218e1ead510d8255a469cecca649739dc", size = 8618, upload-time = "2026-05-30T12:24:50.894Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d6/3372353f90f4880f63baa9e145ced0201f4ea75f5c8ff1dac26cd1506357/pyobjc_framework_shazamkit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ce9c79b1f558f2804c819e0f0d933a50d3c217aa23478e7e4c7d8121e97c2548", size = 8614, upload-time = "2026-05-30T12:24:52.58Z" },
+    { url = "https://files.pythonhosted.org/packages/90/06/c4d7d2d455acdbe009e2cc91040260ca288b502b9ad76e4f05661470b7ea/pyobjc_framework_shazamkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8033175f28a4f0bead5878a6e420bdd4e60d00281e50b7d711105ad9d4248748", size = 8637, upload-time = "2026-05-30T12:24:54.279Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e4/837c888b09e330599601446b0da9ec3101ee1ad4250113c5f4a040ea76d1/pyobjc_framework_shazamkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:05b0f1efc47471a2962f947dcf764355086a37061307880ca4853df3d7d202df", size = 8648, upload-time = "2026-05-30T12:24:55.896Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/48/ca405138c3deae6a18b8750ab8b1e688add932e149ce234bb132b999e034/pyobjc_framework_shazamkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ef389bb99ac4c74741fa1b08f4b08721cbeed3522f2d8e167a9105545d5d29f6", size = 8796, upload-time = "2026-05-30T12:24:57.441Z" },
+    { url = "https://files.pythonhosted.org/packages/47/25/b0cec78700270e3a99215b60566a28c6dee4e70dd2d6cd93f8d31399d24e/pyobjc_framework_shazamkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d116b4e3e09c92ee33dbe4852570510ab7ca0f43a1f02d708ef10b7d6a681b19", size = 8707, upload-time = "2026-05-30T12:24:59.124Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d7/1e07eda03786619d6c30c717cbc1163351098217068032d31170eff9b311/pyobjc_framework_shazamkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:dc79ae05fed89d1aab4762ce23e9bcbeda300990c88d1fcbadda87b6425c40cb", size = 8854, upload-time = "2026-05-30T12:25:00.71Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2a/d3ca6f9ca9b0d5c22bdad0bc41621778af5d36e30134a6dea414031c7fcd/pyobjc_framework_shazamkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f5a0f3410c2852c057f79bfcc00627cb6b429ebbb72803d72422258f005c7f1c", size = 8703, upload-time = "2026-05-30T12:25:02.295Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e6/90918334be4850363b06b0d0773547d57969238f446fd37b6268b44117d6/pyobjc_framework_shazamkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c20fb1da41721b3818f4f1253f11d29b0f0568ab5b2c96724c6eecc74ce26bd0", size = 8853, upload-time = "2026-05-30T12:25:03.89Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-social"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/8e/30527d2219e08e0d042c1190ffb64425aca051701f50823d5376a22bf573/pyobjc_framework_social-12.2.tar.gz", hash = "sha256:0f5e8c3e6bfd36f8c552b58b42d8d1ff4c8bf18c74776cdc3e830c272a904118", size = 13754, upload-time = "2026-05-30T12:45:27.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/93/e8f2405693ca24878b1fe1cf58d4aa58b293f4e774af64a56aeba904b33b/pyobjc_framework_social-12.2-py2.py3-none-any.whl", hash = "sha256:d012f52721d694000b37999b2fed213332bf89e8a682f4d29656db4d8c6c7087", size = 4464, upload-time = "2026-05-30T12:25:05.261Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-soundanalysis"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/0a/19357da779f1b8942f69acfaa3f4568c0b117d6c1b5820af2a50d25dde31/pyobjc_framework_soundanalysis-12.2.tar.gz", hash = "sha256:37dee57e3f75121b690550601fc136e0931f3be56a87357cdfae7696886850fc", size = 15773, upload-time = "2026-05-30T12:45:29.585Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/8b/fb4db5583f5be6a5537baa1ecc39ae56f2bc1bdd6fc8dc7912e7c48b36fa/pyobjc_framework_soundanalysis-12.2-py2.py3-none-any.whl", hash = "sha256:d669deee79636bc6858e40039d5c9b4cca47af7b4cf042c787c52f39b5b5ab40", size = 4221, upload-time = "2026-05-30T12:25:06.842Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-speech"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d7/b4c297150b863946fc4064dd927445d0539140524629e4d0b12f704577c0/pyobjc_framework_speech-12.2.tar.gz", hash = "sha256:14058f3ab48e29a68de5925297754a8bc6157b60c17cb24b3e8560290769e9aa", size = 27785, upload-time = "2026-05-30T12:45:32.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/9f/b26b1931fb7a534949108fe9689f36c327d27891c31de1d50d702efab0aa/pyobjc_framework_speech-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:68d2f2d756de46b3892d8eefb51b7674d28758394b8b1e5a866b7c0bcc7d22b5", size = 9254, upload-time = "2026-05-30T12:25:08.669Z" },
+    { url = "https://files.pythonhosted.org/packages/46/9e/2f324e5a54334ba042be856af2c69eff628b911119d7731ca441d04b608a/pyobjc_framework_speech-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:010596c5b5456a7b023e7638b90cde66fa404020905734f5bdfec1a319b358cb", size = 9256, upload-time = "2026-05-30T12:25:10.572Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/23/11012a4842dffdc15e30910f7cc6ae45c7b137859e3d1916c7c7558e4e74/pyobjc_framework_speech-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8d940d444912b69f6ec02878a0fab554305bb9c196c87550033a212dec758a0e", size = 9263, upload-time = "2026-05-30T12:25:12.18Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bb/4262b2565e6fd0137b07b661a828acc48d65c6280124755feeac8fd1964b/pyobjc_framework_speech-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4647b2775c3bdd3016fb5cce155dd03ca7a8f04902211868a68099511e8ea9f7", size = 9285, upload-time = "2026-05-30T12:25:13.879Z" },
+    { url = "https://files.pythonhosted.org/packages/96/48/4071527182ef72ee5e31158cfbdf11d6f97265708e94a0a1ed138f2620e0/pyobjc_framework_speech-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:df58c5d6ec1ac5425565a1544659c8c45c78b0f7984ac50ff4590b5b6b872a5d", size = 9441, upload-time = "2026-05-30T12:25:15.502Z" },
+    { url = "https://files.pythonhosted.org/packages/37/97/0bb1b78cfcf5613a1e9e90043cda358791f275d366274efea11ae9c08b2d/pyobjc_framework_speech-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:74993681f0d7ef50a5c132346f74142729c477fb917a584f84c204ba6fd4332c", size = 9343, upload-time = "2026-05-30T12:25:17.081Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e1/ce08ba2974fd740b8dd9ec79215807a5d178a91dfdf0b264361c51813f5c/pyobjc_framework_speech-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3ad06446848adcc7b03f731e60147122ed599e523a54a325585f401c53c045e5", size = 9502, upload-time = "2026-05-30T12:25:18.724Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/31/51968e6e9633e0dba0d54558579fe7b3f2147cf99179b9aa9c6e80f9eb26/pyobjc_framework_speech-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:dd88f54107bf75bdce4445734453ad5ca3446e12cdc9ef270414ce5254fe011f", size = 9333, upload-time = "2026-05-30T12:25:20.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ea/5a661d61a5ba35faf697bdd08a23fd81afa1683ae2d11b01f7df0446b54a/pyobjc_framework_speech-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5dbd2321eb4a6d39e53143798b5b23388d975b4b7fb1cf0e91089a21c36286cb", size = 9493, upload-time = "2026-05-30T12:25:22.091Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-spritekit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/84896e2233d2f90444e3be44282ad6e8600b485ce96c37566ed5bd255204/pyobjc_framework_spritekit-12.2.tar.gz", hash = "sha256:75e8fd8040f77c7585247004b9c59971de84cbcb707070f391c8508888750565", size = 83896, upload-time = "2026-05-30T12:45:37.754Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/ed/915c90f8afd74ee6a18353ff3f6531174f97bea13c3d54832c0861f2a587/pyobjc_framework_spritekit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:45eeb82aca9dd5204cc3a326e5038ea71e49ddf761c7b5da077b550b0ed8ef67", size = 18561, upload-time = "2026-05-30T12:25:24.098Z" },
+    { url = "https://files.pythonhosted.org/packages/27/27/33e711eacc576ab013c07665e958fd06e0c7b8e445ff110ce5b792236c02/pyobjc_framework_spritekit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a50917e755aa06394132d5a5151002373991f75d765049b133853641e89b3805", size = 18559, upload-time = "2026-05-30T12:25:26.418Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5a/0aca87af17d9000be6893349d3968c36d3f40c2c2e3ef1fadc4fa2e4bad2/pyobjc_framework_spritekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a9f5a77acbd93f2280ae8a098b7fd1690c2b16f93fcee7dacca350dbff196deb", size = 18623, upload-time = "2026-05-30T12:25:28.551Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/39/abc521893bd60cf5b88ece0091e83fd30717c58a2dbce712d9d9da2e5b3b/pyobjc_framework_spritekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d8ce3c810728a0a54f0af3063ed7ae45a8d0ae6c5a5ba405d02d08cf2c2bc6e5", size = 18645, upload-time = "2026-05-30T12:25:30.826Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/44/aaa0c92b8bf0b9b32c13fc62fdf506e3a868f3451670291441fe008bf9e9/pyobjc_framework_spritekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a8a68b20f5377ee1530f752bb693388a3dcc085b1c2cdaf6930427d1cf5791a4", size = 18914, upload-time = "2026-05-30T12:25:32.947Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ba/23397f87cd54bfcecd8be53e52b00882405ad27036eae8a5c835b7acc9c2/pyobjc_framework_spritekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a7009d0693b72308500f9297cad80d8d95545d58637fcc43129a744c7c18d662", size = 18615, upload-time = "2026-05-30T12:25:35.01Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cd/93164071434421d26d3c6b707494f2e5536b8eccdd779ba6aff4cd4a7569/pyobjc_framework_spritekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5a1b4c138f57ae297c5842370bd13f188238da8430bd0f4687a420c3545192fc", size = 18892, upload-time = "2026-05-30T12:25:37.06Z" },
+    { url = "https://files.pythonhosted.org/packages/38/9b/731043fc52dd2f51b817b24d365a78a8c7f2be9a31136f13021bdd6fca85/pyobjc_framework_spritekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:2a5d2ab99193bfd9af9adbb78e2e6805f2714dfa2d8fb440830f79d21eca06b5", size = 18630, upload-time = "2026-05-30T12:25:39.323Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e9/ed3a076908faecef04e17a57889c444f2d5339a3c439b18cfd5d618eee2a/pyobjc_framework_spritekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0bc636ce5448dbcfbb0306cec2eca6170b68c11a3041a671a52a1a6f5e127aea", size = 18902, upload-time = "2026-05-30T12:25:41.406Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-storekit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/ce/3c5e9ee38040e4770af6aafa0fd11080b34a20dc2c718d2524db5b048bce/pyobjc_framework_storekit-12.2.tar.gz", hash = "sha256:f50699484da541b9d028503441bcb745eeff0becadc75556783aaf76b8764975", size = 40947, upload-time = "2026-05-30T12:45:41.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/14/0c5551efbf8fe0f4e8fc4830829f6e9d218fd3fc081526c1430151de15f1/pyobjc_framework_storekit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:14521707869ee8176986e0d70964d92d4da8d3fb51604bb1457994bd8b83031f", size = 12871, upload-time = "2026-05-30T12:25:43.242Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e7/7de34b8de1cdc7c6b08479217ea2ee79099ea6c56124d5f2183a7af2a158/pyobjc_framework_storekit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:09664af8a888bcf52ad917b17e808317b826020dd690325327b8204b9086aafd", size = 12871, upload-time = "2026-05-30T12:25:45.325Z" },
+    { url = "https://files.pythonhosted.org/packages/39/80/d8447ff5cdf292df364c12ca0d912a29247a2caba0e710f4f0a02461ab9d/pyobjc_framework_storekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e0acf29d337a0b046bb4cc8d876823e56f83a9530933842eef270a12a2e9c9d5", size = 12880, upload-time = "2026-05-30T12:25:47.112Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b7/16adfa4c5aedad949ea10a751c60e343745afe889706bb8d71491ff57732/pyobjc_framework_storekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:94d2daae9e5166cfa9d694acb2e51bf1d3856cf7ce6c74a84e13d80dbe6915ec", size = 12894, upload-time = "2026-05-30T12:25:48.888Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c9/bcf7f4c1087b7f83d190335d2149e8ecd5591064419ea820dac09b47bf4b/pyobjc_framework_storekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:922da8a72885d79c3c30dd3d36e9a966dcdd642c08f258b4b099a3f0e3ded643", size = 13091, upload-time = "2026-05-30T12:25:50.719Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8f/ca5b9b3688df3d30e564d6f48f9d63456a5bf76c98a5c0746f261766b7d0/pyobjc_framework_storekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:1e8b62a74c2174e8685471fcb302a0cf263b521b9e14ff65018eb2e3c13beacd", size = 12885, upload-time = "2026-05-30T12:25:52.619Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/8d/9f63e339267bc7f73f9fb901e0164c56309789ddaa70e68e0fd10dc6bfd7/pyobjc_framework_storekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b0629d80932a2ee24c60b67ba2ee868071422d6b56a99fa1e14163d00a5213b7", size = 13074, upload-time = "2026-05-30T12:25:54.464Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/b0/61ec475dcfbd8ccfda19fc2030ff68981486951b91881dc7e69daba6b74a/pyobjc_framework_storekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3f5b6030c8e1353eebbe98e3ea90e0d0f0353ee014d2a8b5746b580c7ccfdcf4", size = 12878, upload-time = "2026-05-30T12:25:56.295Z" },
+    { url = "https://files.pythonhosted.org/packages/19/39/32b266ce05533e3273926a380fdacdc6d1c83404bf8cfe1292c02b770537/pyobjc_framework_storekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:6204fbbf29f01875cc6683999fc6f627dc6edf4bded6bed68583422ed0d847f4", size = 13080, upload-time = "2026-05-30T12:25:58.095Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-symbols"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/06/042965972619d440c69037105764accd700053c658dbcbc2914ba4682ab5/pyobjc_framework_symbols-12.2.tar.gz", hash = "sha256:06c00d97047ee79fad95f95380d308c6dc1200d688cf4adf954382d65f138b10", size = 14785, upload-time = "2026-05-30T12:45:43.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/de/168b3925a76417978e5bc5921c8ac0a278e5a672302a20ca10f18d317695/pyobjc_framework_symbols-12.2-py2.py3-none-any.whl", hash = "sha256:abc83c18ef8733897667d0b4d79400e3c38828347985bcad4aaf40b0cd61c94a", size = 3526, upload-time = "2026-05-30T12:25:59.498Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-syncservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coredata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/e4/ac36cf4a79c52c865d92b148b024ee0fcda7e9efa45017cc64654558654b/pyobjc_framework_syncservices-12.2.tar.gz", hash = "sha256:354f7aab848d4f2ce055886a083d07be752ebedf5fe1dcb3cbedd489fd4bfa05", size = 34830, upload-time = "2026-05-30T12:45:46.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/6e/661bab84c7e86bf6215883d3b6b035c2cfba6679ddcc74a2d4ff5fe6494d/pyobjc_framework_syncservices-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ead2c76df0c3a60cf884272e24c18e1b36b5213c3c033f7af33900267bee57be", size = 13385, upload-time = "2026-05-30T12:26:01.499Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/af/f98c8737973eb44495462d39a4cce906c69b84f7b863d6bd7e938990e1f1/pyobjc_framework_syncservices-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:99effb76631d7696e344c2828e586871f6b139f50706037695f77246d1b09446", size = 13383, upload-time = "2026-05-30T12:26:03.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a6/01f21cf774b952fcca49f23a67c9d2f4a52b7bf5e2436a4911bc69e4077a/pyobjc_framework_syncservices-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:87e95555da2ab0f87e8b3e48df7515e61cd5929f331a1c6cd9ba4f8b92310fe2", size = 13414, upload-time = "2026-05-30T12:26:05.587Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1c/1ef02418ff43f53ac9ef49035b34fcdf664fcd5632d3d796cafddd01fd57/pyobjc_framework_syncservices-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a9ff8eb0475033f24434b1dfd7f77a8c458f9ef7ed692e59b9e5a26c22692e0d", size = 13429, upload-time = "2026-05-30T12:26:07.387Z" },
+    { url = "https://files.pythonhosted.org/packages/21/ea/df2f2e636b8616ccb4c8d2b15ddd29275245ba60a7666dc9287b4fe977a5/pyobjc_framework_syncservices-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:10c1dff31d1499b618b3741956219577f2254b04df2fbf10a65a49ed3ff3dff2", size = 13599, upload-time = "2026-05-30T12:26:09.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/0a/6971856780f54f9f2ed94dd034fce70e02653dad10902badb10ad2c1442d/pyobjc_framework_syncservices-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d7944f195da7488e89df0f18130a5ed6db29fcbd9404e76d108f9e4aeccf2576", size = 13404, upload-time = "2026-05-30T12:26:11.164Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/06/b8b39fb6130c49c9747ad52836bfd61308771a08f3ba4a6192fecc34005b/pyobjc_framework_syncservices-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:05ea5b32ed1ad19c958103ba9a2bee6696c0e217e2259c49908d710b2255f01c", size = 13586, upload-time = "2026-05-30T12:26:13.073Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6f/505ddd49c8c5236a05d46bac82f00989d50c8f9cee425843971435b0ad35/pyobjc_framework_syncservices-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:35b96ea6b1e85124039dbb195ee46b6bc1986c4fe43cd44dc376f8f4cf01e382", size = 13398, upload-time = "2026-05-30T12:26:14.907Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c6/6d70e0ee36a927e77c02336744103e1da4b99af9654634717100be525f79/pyobjc_framework_syncservices-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f80b37b92d409b22b9a63d67f45f75c91b14986b6939bf69a11a55497953c651", size = 13581, upload-time = "2026-05-30T12:26:16.823Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-systemconfiguration"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/de/30ce4e5e41d2bc965b5598ba4f3595ac3eaa088e26cc99d519f68d62c7b9/pyobjc_framework_systemconfiguration-12.2.tar.gz", hash = "sha256:017bb958c436b6aa90e04a99fe3fdce3787e8c1db80d165ff0071273bdbf242f", size = 63332, upload-time = "2026-05-30T12:45:50.691Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/c6/dbd103e5f22013e3480170fdcbc8b04223868a56427ba4126aefd856e614/pyobjc_framework_systemconfiguration-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c09e3d1e45c3c48aa23600004c78db3389610a89928765d44bb63a24695ee222", size = 21643, upload-time = "2026-05-30T12:26:19.167Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/df/714ec9269ac707b36c905151b9227e6431219d3e1badb8040b6621c79510/pyobjc_framework_systemconfiguration-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ec3c855574a463f9a0aab068d9c9016232652631f92275c51aaefd34ebee696d", size = 21648, upload-time = "2026-05-30T12:26:21.696Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/cc/c105a396dcabb8eb9c787c8447a379c6041db3971e89946e843ad07ae059/pyobjc_framework_systemconfiguration-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1e2784dfd11381c5f420ca4c93966c6fbbe3f726899c49aef81a3a11fc55c38e", size = 21542, upload-time = "2026-05-30T12:26:24.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e3/fb4e684f873347039ea5136c0a5f7a0ae18ce7b4caaee8508e013fd47f03/pyobjc_framework_systemconfiguration-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d0b290b3cfd77fde1f4234590afa0be7785c02ff2cd5b591ef8d07e2cd0caecd", size = 21533, upload-time = "2026-05-30T12:26:26.467Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0e/948a070637f7f0ffcf2dd3b5a323c77694a1ed0ae04e54dd4fddea9cfac2/pyobjc_framework_systemconfiguration-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d4b81bb37f365891a14bb4a09d735784a0bbe2c594b89a1cb87e17f1db7abac8", size = 21946, upload-time = "2026-05-30T12:26:28.795Z" },
+    { url = "https://files.pythonhosted.org/packages/18/07/9b72143a735bd5d17e5e81e3862097438c8020acecb9e72511584e86718c/pyobjc_framework_systemconfiguration-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8a384b7cc722a7a266707bf3f145cb4cca88facea5000ef2928327ad3de1ea51", size = 21563, upload-time = "2026-05-30T12:26:31.289Z" },
+    { url = "https://files.pythonhosted.org/packages/40/70/db8f3860f1fb56a80407b16ab3b2a33f4d3e71834556eeeeb6e16ebdfe0a/pyobjc_framework_systemconfiguration-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ac6f7e2c54223d7aae5bc0b71880bede7e26b5ee754c11a23f4bd5cedd4dda45", size = 21956, upload-time = "2026-05-30T12:26:33.889Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8a/2ac3a3c0599159944b940bc8a8882048490980f51ecc1ce8d579c09c484d/pyobjc_framework_systemconfiguration-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a3971c02199f6b85830f5f29610478133ec9fdea8e3f82208fb58f2f4db822c7", size = 21571, upload-time = "2026-05-30T12:26:36.357Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f4/38ec9b9994fcd6ec4dae5ed58650882e108fb6fb269f6edf21e25c052dd0/pyobjc_framework_systemconfiguration-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:6e54a0df0b04b09f0bd7665db7c4887750ac70d243acbc9b8bf146947796cc1e", size = 21962, upload-time = "2026-05-30T12:26:38.715Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-systemextensions"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/4a/49dd15416665943fe08999c3d5d8675c6dc153c720b9cc17e83215350a46/pyobjc_framework_systemextensions-12.2.tar.gz", hash = "sha256:2ec1edcd9d12451ef74969eae546b4661514381d7d60221240560ca9a743f506", size = 21675, upload-time = "2026-05-30T12:45:52.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/fc/90f64a3b67527510705e9a982911d8639862fdc8bb324439be512e4ca3c3/pyobjc_framework_systemextensions-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e2b56bd2e44c140ce8d23dc5a2ac411359112acd31778be0e05173b10938ad9", size = 9190, upload-time = "2026-05-30T12:26:40.388Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/77/290084e1159e781f2099a4eae7db02b997b0ad7e193c578977bf24ff27bf/pyobjc_framework_systemextensions-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:fd8f35950c2908dd020d47308f8dba3f3934e29520aa8bf8fb0f0a4bd206ffea", size = 9188, upload-time = "2026-05-30T12:26:42.096Z" },
+    { url = "https://files.pythonhosted.org/packages/44/f1/24d65afb6a7e5cfaebe2d9f36eccb4e97ae18c0222fd36dcf44a592664e1/pyobjc_framework_systemextensions-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e82bc31c3b847e293006e749ad17004b5e046e9cda2a8ab74310b9e6b431d4f0", size = 9201, upload-time = "2026-05-30T12:26:43.706Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/76/f9490cb2be6a6c06ba2132a50d33d368dd90a917284a712614eec818c08b/pyobjc_framework_systemextensions-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dc3c41d413a867483511edbd3332d3a13fa0011119fadf0e4c642ea1b97b7bec", size = 9217, upload-time = "2026-05-30T12:26:45.252Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/a9e07ceece91b207e2554166675f299f05b0fe9af93868b91eaeedfeb2d0/pyobjc_framework_systemextensions-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8c131f836a61df9064020382b6b1b80965799ae44cdb197ef4696167e0796bf2", size = 9375, upload-time = "2026-05-30T12:26:46.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/5a/606fab2d2bd2d0ca4ab834b7a73547ae5f8faa095e64f20e210f976733ec/pyobjc_framework_systemextensions-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8accafc90d9707cbbc35461b37d00ecac48e569440ad935d23ab6e28cf8ebb9d", size = 9289, upload-time = "2026-05-30T12:26:48.411Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6b/34403dc90bf0f59f6bc2aee0d386c2d18f85885f90d672702292a69e4c90/pyobjc_framework_systemextensions-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0a7b8a301e288a7d2f560f7028226393eb4fc8a34f32b23ad1693ecf851684dc", size = 9446, upload-time = "2026-05-30T12:26:49.95Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/85/6f85d38abf47a979fa658c18c1fe905de891177438b4a2ca293a787d1dbb/pyobjc_framework_systemextensions-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:fa8b186c217230aa74044df091e3bd2d3a0b962ba47a8465727d914767b9288d", size = 9279, upload-time = "2026-05-30T12:26:51.503Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/05/6959ac75f0c08862681fa1fa46527e1d0f51f9a846176515f1ca6ba8e4e6/pyobjc_framework_systemextensions-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0cf56fa70539445d64c7582ad7ee7ea11f7f15d2f4ce24745d3123522bdae666", size = 9440, upload-time = "2026-05-30T12:26:53.046Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-threadnetwork"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/e6/8b1744871062c39cce64d43ab20b11344ef5f1b93993c1b737da2faa3acd/pyobjc_framework_threadnetwork-12.2.tar.gz", hash = "sha256:2d7df5938094e3aa93210a079ebf3e801a20c84a3b759573ddf05ec2c2cbf083", size = 13327, upload-time = "2026-05-30T12:45:54.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/7e/dfa9e914c1f192d6afdb504efc01f5aac777a73d43cfe103896bb5072ee2/pyobjc_framework_threadnetwork-12.2-py2.py3-none-any.whl", hash = "sha256:08c7a03e11c60dca7b3f219db744986b90b8797d61b6842e0c0bad192e723f48", size = 3805, upload-time = "2026-05-30T12:26:54.517Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-uniformtypeidentifiers"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/54/e270da2b0b4ab1fb0dc7f4e616d1a6e141583f88409c0742f6ebfcf7a064/pyobjc_framework_uniformtypeidentifiers-12.2.tar.gz", hash = "sha256:19cc82f1bbf3bc0999597779711422f6c9d7340634d699ae64d9bc7c0d79f984", size = 20704, upload-time = "2026-05-30T12:45:56.773Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/19/4f314697bc8f519fe6505afe51d83d7fdcae93239b7bab5941f4bebc1f9e/pyobjc_framework_uniformtypeidentifiers-12.2-py2.py3-none-any.whl", hash = "sha256:f140a378cfe6a8ca47ce3b04fd5a4c4bec1fcbedac8acc87e2c18985bb805203", size = 5019, upload-time = "2026-05-30T12:26:56.001Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-usernotifications"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/c3/f1d43ac73b5fce42a00bcb68ac53edd7180217df60a25985e2477c9c389b/pyobjc_framework_usernotifications-12.2.tar.gz", hash = "sha256:b7773e84fe40e746f706055267ba2b1dc9e0a34e6575719f1e515354f72583a0", size = 33908, upload-time = "2026-05-30T12:45:59.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/8f/fca8c66401c80c8ddf0423e605efca534ab34761c573b00fbd936288bd64/pyobjc_framework_usernotifications-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b1dac8eaa52624a1d26f90b47f9d0eeea15cd4180c559e54d66bbfc29277191b", size = 10174, upload-time = "2026-05-30T12:26:57.685Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/20/86b2be8ebbd9cea3b916001677ecf983b79ee754cc1848c8e628d19e8225/pyobjc_framework_usernotifications-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:495cbeec617a5ad270c1fd88b689b0516912615a8c849614dddf0a6e6e63e25b", size = 10173, upload-time = "2026-05-30T12:26:59.388Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/39/d9dbc214cd2516c6ad0ff28f97c50c0e8178b8b293f61974bf2efc5b4e2c/pyobjc_framework_usernotifications-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b5533378b934430f73bb0092df19e54d67ab9f3e61ac8116a0480916c8c4c0b9", size = 10185, upload-time = "2026-05-30T12:27:00.986Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/e3/a962cbd3739cbb01b2b5697e336babb15307fb473500524bd7e730446b7e/pyobjc_framework_usernotifications-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dbc51fc214446f622b4670bca7efb8969ad84cdee21672da3c872fa3aff5aff5", size = 10198, upload-time = "2026-05-30T12:27:02.504Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8e/2a44292fc4e96682054f74a1aab1c303fa5caf5820e5cd67b0d23b52750f/pyobjc_framework_usernotifications-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e329301b42181a95c2ac5f71491529ac1260afa9b26b16a104db275bbafdcb18", size = 10357, upload-time = "2026-05-30T12:27:04.132Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/00/659908e2a3654564727daddc494624531e9950274627130b74f918e9fa84/pyobjc_framework_usernotifications-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c227579be5f40579b6345400578c0f0c56dc85811d56b912937ee2408dd00b83", size = 10265, upload-time = "2026-05-30T12:27:05.736Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f5/0996481a6c3c99c42c5eff47c8d136b84a5a1108276dadf4f58830c73814/pyobjc_framework_usernotifications-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:969f60adca5420ea1c4a42b3d5eb0aa0654ddfca4ca3a10a9774933b8bac65fc", size = 10421, upload-time = "2026-05-30T12:27:07.286Z" },
+    { url = "https://files.pythonhosted.org/packages/22/2e/04150a39eeb077dd1a637744c5920f3f64590a022c38573a1c12987472ec/pyobjc_framework_usernotifications-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3889af591a44859a11ed4c2ea4a7bdd90ed61d17bb3b27dd4aade24d80a0bda5", size = 10256, upload-time = "2026-05-30T12:27:09.278Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/e1a7f0b6b19c4f73341a1ae1dd9d063998777fe092c5f8ca5e84906e7187/pyobjc_framework_usernotifications-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1656cc4d2be411447196df1c8b63466000bfaccbf144ab97715ec42eecbd497f", size = 10423, upload-time = "2026-05-30T12:27:10.858Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-usernotificationsui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-usernotifications" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/5f/d58600259b0b99ff3745eef91570d0ced05fa1b26083f2846082acc15249/pyobjc_framework_usernotificationsui-12.2.tar.gz", hash = "sha256:8c3298cddd27be794ad46a2783304b6fb1f0ad4d65933c34ba3e43e58ecdb406", size = 13462, upload-time = "2026-05-30T12:46:01.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/29/f4413e1941e153a770b2d85faee4d3a4f9be67b69f5823f63db8dd091356/pyobjc_framework_usernotificationsui-12.2-py2.py3-none-any.whl", hash = "sha256:a5d92117c2d18e2b6365f5e39daf45a68491a66ac9103b1bc94df43b8868c256", size = 3930, upload-time = "2026-05-30T12:27:12.318Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-videosubscriberaccount"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/3d/cace0ae1dd453f9da495311675d4fabe7adf89e94e7b99e26f45ba0fa713/pyobjc_framework_videosubscriberaccount-12.2.tar.gz", hash = "sha256:821f5485545238fd997dc26aff8ab2c838b43d664a7ec6a030ba67b09c2b799d", size = 21360, upload-time = "2026-05-30T12:46:03.619Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/03/f3b0c4ed85b4883d5fcd48ba2efd807507c3a5ce7c3aa7d4366dce81f503/pyobjc_framework_videosubscriberaccount-12.2-py2.py3-none-any.whl", hash = "sha256:b158b03e1432dc229fabc96451f5ac8db5ab228792354f0f26419a973777c700", size = 4866, upload-time = "2026-05-30T12:27:14.012Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-videotoolbox"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/2c/af5a91d12bb265697fb13ccdbac7068e04e8f40c36139b314ea477982aa3/pyobjc_framework_videotoolbox-12.2.tar.gz", hash = "sha256:33d0838f706c771667b0be5737036d303b677bb243ba64df9ea2fa6860ea9f76", size = 64923, upload-time = "2026-05-30T12:46:08.377Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/80/00ed989fbf13dce19ce27df559228148a56f682e1a0d5ab3395bf14fe866/pyobjc_framework_videotoolbox-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0405b5eb003b7e80950514256317786d4671100b399bfb7f0bac6096ab5a0187", size = 18851, upload-time = "2026-05-30T12:27:16.518Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/3b/b36051ee2e0fa9fa6e7c4182be8b984a3277b15501a9ce3e8100201a2a4a/pyobjc_framework_videotoolbox-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bc68009e4043ee5591b0c64bb0b7f8730ac9fed163b7eb4b96cb0e854c3ce3ea", size = 18847, upload-time = "2026-05-30T12:27:18.854Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/de/d4f998122a36cc7f7bd07c297a30f776455e00b27d24fd63b778c72421d8/pyobjc_framework_videotoolbox-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:36576a1cebd379efeff58f7e016fb2eef5bfe36c4649f7fb197157fe61842b5e", size = 18983, upload-time = "2026-05-30T12:27:20.923Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/08/48b4af0452930b1865dee4e847113d5b6d2530a19ad111b6f551d8b5bd8a/pyobjc_framework_videotoolbox-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3393990f9f566dadada78b06c134bcefcabd50731b5322110759e0d26d9ca280", size = 18999, upload-time = "2026-05-30T12:27:22.983Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/d111f5d93f88f0d4d7150d318a6e089b0e08196cc29bdcae3c6af7c9891b/pyobjc_framework_videotoolbox-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:06dea99b364c3628037332c5fbffcb341f32a4cc7acd0ea4813a83b78fe1f70c", size = 19209, upload-time = "2026-05-30T12:27:25.22Z" },
+    { url = "https://files.pythonhosted.org/packages/33/45/f3bf7ebc231abb84a57fd5125850883380ea9a7cbb5f1c218cc7a8a3c386/pyobjc_framework_videotoolbox-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:49f12920f8a7ed85c110145dd628b38d387319a2b7cd399e70b5359aa8724614", size = 18996, upload-time = "2026-05-30T12:27:27.37Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/34/79754107f661cb958871f52b0c8b0a935f6b09a118ab4b56fa53780d0a67/pyobjc_framework_videotoolbox-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:58a547a45fb92c9335f52814cd234a80383cbadd0f5e8897d11b5ddaec6606f8", size = 19192, upload-time = "2026-05-30T12:27:29.434Z" },
+    { url = "https://files.pythonhosted.org/packages/10/40/5cb09ce331ca581b9cc9e50cfb22deede8862dc40386174785fe84ef3a58/pyobjc_framework_videotoolbox-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:ca98d2604f00273bac4977cba830ebe48a2b0a0b5d8068b551599780ac0045c2", size = 18999, upload-time = "2026-05-30T12:27:31.523Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/a3/852fd3029533d7a94c86f00383fab060dc77664bdc330b7734c87877fbaf/pyobjc_framework_videotoolbox-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f3a916bbaa8826e91f8ef9cd53564fd3be33135d92acdadfc7e85b49d3245c8d", size = 19193, upload-time = "2026-05-30T12:27:33.643Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-virtualization"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/b4/16c8280c717f393e524e32de93bcb18952ca852ebbf5aaed38dac68d2e01/pyobjc_framework_virtualization-12.2.tar.gz", hash = "sha256:021249f0cd72e4756dfba096bda0e9ebd9294ba7738f1bdbb2742e461ac5671e", size = 49152, upload-time = "2026-05-30T12:46:12.317Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/7a/ed1ecc5be5422b11627ae3ba3b8f5b9854f6d6670e2644110b6ae15a462e/pyobjc_framework_virtualization-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bfbe2c80ca1fea61f99321f3b082594a3aa48c7d9aa54ef6729b31e9ba55f956", size = 13568, upload-time = "2026-05-30T12:27:35.509Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/05/c81f758f9358412a31217ff87d84a8e8da010406dd10a00de36a78ca980e/pyobjc_framework_virtualization-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:30e86b9821085fcd7a7acaa99623f091b4c8a7e6c2f1d940fe39be4b4489025d", size = 13570, upload-time = "2026-05-30T12:27:37.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/39/c348fdc27fc68729faeaf8510596ee70a4d97d9fe51b68c365c47a1bd5cb/pyobjc_framework_virtualization-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2b9fbd756c7fc8fb0a78b235612e643e9bebe04f6e047ecb7e80a832510c744b", size = 13600, upload-time = "2026-05-30T12:27:39.302Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/a2e2a3676286359dcf4d5898652e904925006dba0eca959759472be37651/pyobjc_framework_virtualization-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:48667f1318bdc3e3599123dafb1d9df3369a6d8d3a64fb36f9eaf86ef2ea4808", size = 13617, upload-time = "2026-05-30T12:27:41.616Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/22/3e04b58c4a1ecc27518a8c5b8ca13cea7b74106928b1bd130a0564cb54a6/pyobjc_framework_virtualization-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:68e8989bf2cfb294116cdfd583d6ac092f9209ccca2af5b79fb697adbdae4653", size = 13821, upload-time = "2026-05-30T12:27:43.448Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c8/8fa0b9ca53e7ab283d65c0ecde625344e55c493f2b31f330944171c119ec/pyobjc_framework_virtualization-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:365f797477eec5cc79f076e7a986937ff54d2ca1a136b4e0bb0fcac4bfa888aa", size = 13606, upload-time = "2026-05-30T12:27:45.26Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/10/0455b8ebef3412e7247867dc760dac1c8c0c1a4eb30fb45830f088b0cf3b/pyobjc_framework_virtualization-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6a1dbdba76fa72829662547deaedf9bc38829be245e88a0781fb83934a2caded", size = 13814, upload-time = "2026-05-30T12:27:47.066Z" },
+    { url = "https://files.pythonhosted.org/packages/72/48/5ea61a159ed12a9715233e1b90af5a8d384c9964f402f1f2e03dbf41197a/pyobjc_framework_virtualization-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:e4c38f21be12dc1199dd263cf5ab8e07290f98d9462c8873827e43d37332a9dc", size = 13596, upload-time = "2026-05-30T12:27:48.924Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3e/ddb09e174928a927512643f531e69823ffda8487c258eaa0705b56bec4bf/pyobjc_framework_virtualization-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b3531955330c0bb91daffd28f161c9c481a4683c2ff17b944bf216126d3580c5", size = 13807, upload-time = "2026-05-30T12:27:50.789Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-vision"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreml" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/51/aed3761cfa2f0335a8fc4cdfa04c54b3fece5242745d5dd2370f38efcff5/pyobjc_framework_vision-12.2.tar.gz", hash = "sha256:0e90244f98ede5ec16ac129ed4bbd7cf0ec07247bac6f06e9cb612db23a68a3b", size = 72582, upload-time = "2026-05-30T12:46:17.468Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/76/e94433cbf3d9ee9284278cc37135fa4deb7eff246bac02d123a14e17c1bc/pyobjc_framework_vision-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ed1eed217d5c86bbc09e78b4a7f1b415116a722b55948aaf7862f555c103d771", size = 21770, upload-time = "2026-05-30T12:27:53.082Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/50/b74a06439eb71b26b909e47d05ab512162027433f20a4d74b66426dec524/pyobjc_framework_vision-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:47274c6167434a20be81c3506b49414f85d946a528ff930622b8a6dd758b9b95", size = 21767, upload-time = "2026-05-30T12:27:55.562Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e6/c8606a1a106f5361360762eb26a9736ad4ea9528202b85b6dfe2a9e8a82f/pyobjc_framework_vision-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:77628f8c12a2f8072e8a8ab780cd0fd716f279153dcd883ce058bf2d1843b16d", size = 16924, upload-time = "2026-05-30T12:27:57.619Z" },
+    { url = "https://files.pythonhosted.org/packages/79/34/9c92c1d70a98818edb4e113f771bb264c2e7f08ec6bba501e0196c500dc4/pyobjc_framework_vision-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:df4d7d3ccdd723334ab62e6e2051d04e3554724be90102db353874938f101e05", size = 16938, upload-time = "2026-05-30T12:27:59.678Z" },
+    { url = "https://files.pythonhosted.org/packages/16/a5/1cf2213da57b1941f788baf0505c3cc4c98fbbdcdf1ac3a19290331ca4d1/pyobjc_framework_vision-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:76737fa3440c504993995537643b6529d47c1affecba426f00c716cd93a07a9b", size = 17081, upload-time = "2026-05-30T12:28:01.972Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f3/3f87679134adab71b2366c5349fe3a68eb2edcf5ff62fcb872855243e6e2/pyobjc_framework_vision-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b6d12bcb96d711a4b5d1743aa7b1af7dec9e2f840b0e5ec200aed262da3fb587", size = 16917, upload-time = "2026-05-30T12:28:04.196Z" },
+    { url = "https://files.pythonhosted.org/packages/26/e2/4c1419e9429bed0c1bac0fa6ea705c32c8d9e098fa5ba3f8b49a4f916ff0/pyobjc_framework_vision-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:45c7d3fda44f740b4c0a9c1b86d9af137994172f2990e0650112f7eb8e77e48e", size = 17068, upload-time = "2026-05-30T12:28:06.264Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/8a/6da11857e32d588c16cd474dc768c45e31e0b6e9fc48d10b34a12850e6fb/pyobjc_framework_vision-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c08a08dd979886e2435a53714ef95af6da4a0dc1b2e37236cdd292b5b8707060", size = 16906, upload-time = "2026-05-30T12:28:08.786Z" },
+    { url = "https://files.pythonhosted.org/packages/92/f4/01b8d88c29f46f3b7690d49e0a5ddf992a2ee214e83451820301607f3b95/pyobjc_framework_vision-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3d9080e4882e292c2d3c0726127e516a5c7774e96faf199a2c74aafcc1b6aa60", size = 17073, upload-time = "2026-05-30T12:28:10.836Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-webkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ba/0e17f151d80854285a84b3c96f48d55b0c61ae683060a52cd50084ef4c64/pyobjc_framework_webkit-12.2.tar.gz", hash = "sha256:498353fe812006f7fe2829a679018fcff3ed2684aa31c08d8a8af929ee9283b6", size = 332359, upload-time = "2026-05-30T12:46:37.677Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/59/770a2a333588af203a0a68e92e5c98a212d58d5a800e16e4cb729e624a86/pyobjc_framework_webkit-12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2b5343662bc2d03fce3dad516b71b06a23ca5c1fec92fb56a407f8fa2e09691e", size = 50234, upload-time = "2026-05-30T12:28:15.732Z" },
+    { url = "https://files.pythonhosted.org/packages/df/4a/ba30efafb42f4510dfa22f42b64f3e74ca631635d7d3ae3dbab53ad0e687/pyobjc_framework_webkit-12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a31e87a68bcff0d633f05105df4582fba6c85cae1e5e2529dec957e833bc63cc", size = 50230, upload-time = "2026-05-30T12:28:21.014Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ae/0cfe909116627905542390c7d6a33a3090b6e7f2174b9d75f9c8a661d431/pyobjc_framework_webkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bd1e0f6f340a5516c853aa59fde381e002f2c109ae64a05ad4e99a2b74375fcb", size = 50337, upload-time = "2026-05-30T12:28:24.926Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/32/bea045cf4e2c697ea9b68ed7d60b0e765a8b0e46d30a4eb26bf178be817c/pyobjc_framework_webkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9fafcbf5a071cf9ad3fbc28155a99287ff9dc9efcaa41fe3ed3d79b6e5576450", size = 50367, upload-time = "2026-05-30T12:28:28.846Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/3e/d29fc44f6d346a5a97883ae76bfa030a5b6ff3b019bafd58ad8ea14588d2/pyobjc_framework_webkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:751f3138441c81fdddc555f0bd31f5f3ad3ec72ae2ed626af24925ce32054353", size = 50840, upload-time = "2026-05-30T12:28:32.75Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e1/12288f728e2862d7932a1b21aa5a059ae67708900e4f0873c88053edb761/pyobjc_framework_webkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6cba6e76e33c62369d0fa8cb4b83959db4c53888173cb3546a15cd998c8e8aec", size = 50475, upload-time = "2026-05-30T12:28:36.862Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/98/6373d02bc5dd9653207f1f766e55c2659aa01b65bf94b9d00584e7142312/pyobjc_framework_webkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:43a18df9a8d6b6f1f003a732eee0a0fcd01c2d31566be2b2ba8ee732c1a32cf9", size = 50938, upload-time = "2026-05-30T12:28:40.942Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/22/22d4b3d39d41fa94aa8bb904ec546199d940edcdbc9594c4ad3517d49692/pyobjc_framework_webkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:50dbd5210f80c7834b1af2b675712f6134217d713f2b2a8d9f96cf29be6ec8f0", size = 50469, upload-time = "2026-05-30T12:28:45.058Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1b/09cb42c5ede2a5025c4695b2beb37216a4d200511aa3eb4b9faadf1a517d/pyobjc_framework_webkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e8895b2cbc8b5d4c1475a3094771d3b8e6dbbd19ec3200922b1cd91d649e8043", size = 50936, upload-time = "2026-05-30T12:28:49.013Z" },
+]
+
+[[package]]
+name = "pypiwin32"
+version = "223"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/e8/4f38eb30c4dae36634a53c5b2cd73b517ea3607e10d00f61f2494449cec0/pypiwin32-223.tar.gz", hash = "sha256:71be40c1fbd28594214ecaecb58e7aa8b708eabfa0125c8a109ebd51edbd776a", size = 622, upload-time = "2018-02-26T00:43:23.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/1b/2f292bbd742e369a100c91faa0483172cd91a1a422a6692055ac920946c5/pypiwin32-223-py3-none-any.whl", hash = "sha256:67adf399debc1d5d14dffc1ab5acacb800da569754fafdc576b2a039485aa775", size = 1674, upload-time = "2018-02-26T00:43:23.108Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyttsx3"
+version = "2.99"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "comtypes", marker = "sys_platform == 'win32'" },
+    { name = "pyobjc", marker = "sys_platform == 'darwin'" },
+    { name = "pypiwin32", marker = "sys_platform == 'win32'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/4e/a37786f666f4f084fc45e026ca1e63f7b49ac0d90b53fa35ae62b73c96a8/pyttsx3-2.99.tar.gz", hash = "sha256:a18a5601530a570c43491b4112887fc34c47e118fc937287db8d21905da1f74e", size = 33968, upload-time = "2025-07-08T12:24:21.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/14/9fb5842581f0419b5eb85f8c26c1c0c0f4cf6b4d5be638ae3157316a2650/pyttsx3-2.99-py3-none-any.whl", hash = "sha256:ff3e4ff756c24d72b9f3f2f304e0edaafd0f58adb0e6f4b90d930440cda8b207", size = 32157, upload-time = "2025-07-08T12:24:20.299Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/1b/9cfdeac80ee45bebbbcb31f1b7b99a0d81a1c72de48d837be984e0e88b1d/pywin32-312-cp310-cp310-win32.whl", hash = "sha256:772235332b5d1024c696f11cea1ae4be7930f0a8b894bb43db14e3f435f1ff7e", size = 6361387, upload-time = "2026-06-04T07:49:14.329Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b1/7afc96d041d982c27bc2df6f853d43f01fd273e3d39d04be3647ddeb533d/pywin32-312-cp310-cp310-win_amd64.whl", hash = "sha256:5dbc35d2b5320dc07f25fa31269cfb767471002b17de5eb067d03da68c7cb2db", size = 6926780, upload-time = "2026-06-04T07:49:16.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/4140da9ad54108e517f4a16b2d83da3033e08662144623e1239587cb7db6/pywin32-312-cp310-cp310-win_arm64.whl", hash = "sha256:3020656e34f1cf7faeb7bccd2b84653a607c6ff0c55ada85e6487d61716deabd", size = 4307203, upload-time = "2026-06-04T07:49:18.993Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/a9/3abdf488f1bf3d24c699415e454ed554a6350d5d89ce183be1ee0a3361ac/ruff-0.15.17.tar.gz", hash = "sha256:2ec446937fd16c8c4de2674a209cc5af64d9c6f17d21fbf1151054fa0bcf5219", size = 4743346, upload-time = "2026-06-11T17:54:47.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/4d/e11259f5da07cb6afb2d074c31bf09da9671993f7329d4f15d2fdc458301/ruff-0.15.17-py3-none-linux_armv6l.whl", hash = "sha256:d9feddb927fc68bd295f5eebc587a7e42cfaf9b65f60ca4a2386febff575da8f", size = 10856677, upload-time = "2026-06-11T17:54:49.533Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3e/772d679e1a0dc058e58875bd2c0cb713a0530877b4a76fee3c7966df0d49/ruff-0.15.17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25805a226d741c47d274a35ad5c10a7dde175fcddfa511d7cf3da0a21eb3eab7", size = 11223443, upload-time = "2026-06-11T17:55:00.573Z" },
+    { url = "https://files.pythonhosted.org/packages/68/58/bd41f7688b2fd5623012605130ed70e60aa7f2244baa3d5066bdd61530c8/ruff-0.15.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f6ad73b14c2d18a3bf8ad7cb6974294d7f613a7898604826058e6ac64918ef4d", size = 10566458, upload-time = "2026-06-11T17:55:07.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5b/733371013fcf1ec339e477ece6ab42bfe10bdd9bba8ee88a9516aa56bfc0/ruff-0.15.17-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ba0c1e4f95bcb3869d0d30cbd5917071ef2e28665abfec970cdab0492c713ed", size = 10914483, upload-time = "2026-06-11T17:55:05.501Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/cc/6f24251cc0252f7239391ccb85833f320efad14ebe5b443943f37ced6332/ruff-0.15.17-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81647960f10bff57d2e51cadd0c3950fe598400c852863a038720ef5b8cca91e", size = 10647497, upload-time = "2026-06-11T17:54:57.733Z" },
+    { url = "https://files.pythonhosted.org/packages/68/dd/0d10c17ce1a1624d6fc3156309c3f834fdb5dfaad026ec90c85684f3990e/ruff-0.15.17-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e01a84ddbc8c16c23055ba3924476850f1bbc1917cebbb9376665a63e74260d", size = 11416967, upload-time = "2026-06-11T17:54:51.461Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/91/556bfb156f6144f355e831c23db00b2fc4120f86b3ce81cc5f7fd2df51f3/ruff-0.15.17-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84fe9f653152f8f294f9f7e03bf3a453d8b4a27f7a59c78c8666167f2b17b96c", size = 12335770, upload-time = "2026-06-11T17:54:45.793Z" },
+    { url = "https://files.pythonhosted.org/packages/88/82/8b5999aa13355e926f06d9f42a32dcca862f623bf0363785ff89d607dffd/ruff-0.15.17-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c0fe88a7676e7a05b73174d4d4a59cb2ac21ff8263583f87a81a6018475a978", size = 11575441, upload-time = "2026-06-11T17:54:32.661Z" },
+    { url = "https://files.pythonhosted.org/packages/11/93/f10377bb04109ca0e8cbc483ff1982c54b6d418210041776f93e8cdc7fa9/ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecfc3c7878fff94633ab0348524e093f9ce3243080416dd7d14f8ba400174719", size = 11557614, upload-time = "2026-06-11T17:54:34.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a6/eeeae7f7d5493df41649ab3db92f086b2d0a30199e4efdf8e3dd7a033f24/ruff-0.15.17-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b8461180b22420b1bdc289909410930761629fddf2a5aaf60fae1ab26cedc4c4", size = 11544450, upload-time = "2026-06-11T17:54:39.042Z" },
+    { url = "https://files.pythonhosted.org/packages/32/88/5991ce565129a24dd4a00db1254b3b5db2e53018cbe4018ea5a89738e727/ruff-0.15.17-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6eccbe50a038b503e7140b441aa9c7fc8c1f36edf23ebef9f4165c2f28f568b7", size = 10892524, upload-time = "2026-06-11T17:55:09.432Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1d/0fdd248313425f55223968af04b0a42125466a8d88d21c1d99c6af0a51e8/ruff-0.15.17-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:382fc0521025f5a8ad447d8bdd523545d0d7646adb718eb1c2dac5065ec27c0f", size = 10659573, upload-time = "2026-06-11T17:54:36.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/0e/072e8260deb9461062ce9311ced27a8e541229a6ffd483013dd37661e43e/ruff-0.15.17-py3-none-musllinux_1_2_i686.whl", hash = "sha256:456d41fcd1b2777ad63f09a6e7121d43f7b688bbc76a800c10f7f8fb1f912c3f", size = 11127818, upload-time = "2026-06-11T17:55:03.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b4/55060a34163121498014696b5f656db5b8c6963768f227dbf0d76b311073/ruff-0.15.17-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1a04bcc94ae6194e9db05d16ad31f298a7194bfbcb08258bbe589cee1d587b8", size = 11655901, upload-time = "2026-06-11T17:54:53.562Z" },
+    { url = "https://files.pythonhosted.org/packages/49/71/9b29d6b87cef468d697f43c6a91e3fae4a80185779d7d5a4ef27d173439f/ruff-0.15.17-py3-none-win32.whl", hash = "sha256:596065960ab1ff593f744220c9fe6580eda00a95003cffa9f4048bb5b1bf0392", size = 10925574, upload-time = "2026-06-11T17:54:55.723Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b2/8fc77f3723228836fa5d12497eb71c808f83782e10d058d2b15cfa14640b/ruff-0.15.17-py3-none-win_amd64.whl", hash = "sha256:6769e5fa1710b179b92e0bfa5a51735b35baea9013dadb06d5f44cbcf9547084", size = 12058788, upload-time = "2026-06-11T17:54:41.042Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c7/c53e8dbff9c9dc4b7928773421ae294a5d28fcb8dcda1a089579d3a7e510/ruff-0.15.17-py3-none-win_arm64.whl", hash = "sha256:f3be1fbb34bcdfd146240d8fb92a709d4c2c8191348580a3c044ec60fa0b4456", size = 11355275, upload-time = "2026-06-11T17:54:43.635Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sound-lib"
+version = "0.8.8"
+source = { git = "https://github.com/accessibleapps/sound_lib.git#65c9e45235f93c32e633c33e7bdea4e00f4d5520" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "libloader" },
+    { name = "lxml" },
+    { name = "platform-utils" },
+    { name = "requests" },
+    { name = "tqdm" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.68.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/05/0d5260f1f1ca784f4a4a0def9cbe6affe587f5b4025328d446c3d67765f4/tqdm-4.68.2.tar.gz", hash = "sha256:89c230e8dbc67c7615c142487111222f878c77427ea09549960f62389e258add", size = 171923, upload-time = "2026-06-09T13:26:42.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/75/1a0392bcc21c44dcdf87b3cf2d137e7829be2c083a1e38d44efca3d57a16/tqdm-4.68.2-py3-none-any.whl", hash = "sha256:d4240441fb5353290b87d6a85968c9decc131a99b8c7faa28269d829de669ede", size = 78578, upload-time = "2026-06-09T13:26:40.731Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/74/221f58decd852f4b59cc3354cccaf87e8ef695fede361d03dc9a7396573b/websockets-16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:04cdd5d2d1dacbad0a7bf36ccbcd3ccd5a30ee188f2560b7a62a30d14107b31a", size = 177343, upload-time = "2026-01-10T09:22:21.28Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/22ef6107ee52ab7f0b710d55d36f5a5d3ef19e8a205541a6d7ffa7994e5a/websockets-16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8ff32bb86522a9e5e31439a58addbb0166f0204d64066fb955265c4e214160f0", size = 175021, upload-time = "2026-01-10T09:22:22.696Z" },
+    { url = "https://files.pythonhosted.org/packages/10/40/904a4cb30d9b61c0e278899bf36342e9b0208eb3c470324a9ecbaac2a30f/websockets-16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:583b7c42688636f930688d712885cf1531326ee05effd982028212ccc13e5957", size = 175320, upload-time = "2026-01-10T09:22:23.94Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/2f/4b3ca7e106bc608744b1cdae041e005e446124bebb037b18799c2d356864/websockets-16.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7d837379b647c0c4c2355c2499723f82f1635fd2c26510e1f587d89bc2199e72", size = 183815, upload-time = "2026-01-10T09:22:25.469Z" },
+    { url = "https://files.pythonhosted.org/packages/86/26/d40eaa2a46d4302becec8d15b0fc5e45bdde05191e7628405a19cf491ccd/websockets-16.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df57afc692e517a85e65b72e165356ed1df12386ecb879ad5693be08fac65dde", size = 185054, upload-time = "2026-01-10T09:22:27.101Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ba/6500a0efc94f7373ee8fefa8c271acdfd4dca8bd49a90d4be7ccabfc397e/websockets-16.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2b9f1e0d69bc60a4a87349d50c09a037a2607918746f07de04df9e43252c77a3", size = 184565, upload-time = "2026-01-10T09:22:28.293Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b4/96bf2cee7c8d8102389374a2616200574f5f01128d1082f44102140344cc/websockets-16.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:335c23addf3d5e6a8633f9f8eda77efad001671e80b95c491dd0924587ece0b3", size = 183848, upload-time = "2026-01-10T09:22:30.394Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8e/81f40fb00fd125357814e8c3025738fc4ffc3da4b6b4a4472a82ba304b41/websockets-16.0-cp310-cp310-win32.whl", hash = "sha256:37b31c1623c6605e4c00d466c9d633f9b812ea430c11c8a278774a1fde1acfa9", size = 178249, upload-time = "2026-01-10T09:22:32.083Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/5f/7e40efe8df57db9b91c88a43690ac66f7b7aa73a11aa6a66b927e44f26fa/websockets-16.0-cp310-cp310-win_amd64.whl", hash = "sha256:8e1dab317b6e77424356e11e99a432b7cb2f3ec8c5ab4dabbcee6add48f72b35", size = 178685, upload-time = "2026-01-10T09:22:33.345Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wxpython"
+version = "4.2.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/43/81657a6b126ffc19163500a8184d683cec08eb4e1d06905cd0c371c702d0/wxpython-4.2.5.tar.gz", hash = "sha256:44e836d1bccd99c38790bb034b6ecf70d9060f6734320560f7c4b0d006144793", size = 58732217, upload-time = "2026-02-08T20:40:42.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/79/5760d6c1175b34a19151ef4ade3eae2287f8d0a1632c883d52b3b9754ce6/wxpython-4.2.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c97ccd3f2da567eff43f71948d9ace86c91dc80aa834e7b2dbeacd95eabbe9c6", size = 17763615, upload-time = "2026-02-08T20:39:28.406Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/d0/c1f54823d6f491c519934842c856d30dd365e6dd3d2e7d2fc97e5988d151/wxpython-4.2.5-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:402c61ea6c9f2904b0e0c2ffbd04ed38ad6ae4f25e0d9de529dbf44da0685346", size = 18812631, upload-time = "2026-02-08T20:39:31.794Z" },
+    { url = "https://files.pythonhosted.org/packages/16/4e/e6fb441868988c8f1eff9903fc3943387699e6cb4f03f09c37f935bb955c/wxpython-4.2.5-cp310-cp310-win32.whl", hash = "sha256:d7e3b69a1f2ad383e8305efee11130dbe7542b6f6d8d5ba02fdce3cfc4c67ad6", size = 14804965, upload-time = "2026-02-08T20:39:34.763Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/48/9d861888d3f9ff6d0559fe6578020d65fb5f5f8821be384a33d9331cfb4e/wxpython-4.2.5-cp310-cp310-win_amd64.whl", hash = "sha256:74fc76f8d22226e607d7072278cc09052da0cda508dea14a9933b014a4e5aeeb", size = 16823187, upload-time = "2026-02-08T20:39:37.834Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/42/bf668af08ec8214e035921026c9de2cdea42921e3ec99adcb13caadf4b3b/wxpython-4.2.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a5ecb93cc17e09e90d71a1f8d99a543268a5f019aeec058b24374926f79bb6fc", size = 17762422, upload-time = "2026-02-08T20:39:40.995Z" },
+    { url = "https://files.pythonhosted.org/packages/66/15/1ea546fac050367e8e7771fcde314636444f2df71828eedd60f2c4bb89c0/wxpython-4.2.5-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:26f80c81a150c90c14b50cbb246b7048d65d737d0206d28a6860171b273af932", size = 18811865, upload-time = "2026-02-08T20:39:44.483Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b3/06405cbaf7168648c913c4737b810bccb6b434f0693832cbe621d0852827/wxpython-4.2.5-cp311-cp311-win32.whl", hash = "sha256:ade4d6b39c39770146ce1010df7d7a5a767d148b478133d49c36dffb0880a174", size = 14508676, upload-time = "2026-02-08T20:39:48.17Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/95/5b4928819f161fb4cb38a5b5a001abb8d66500b2399bf20f914215e8e17e/wxpython-4.2.5-cp311-cp311-win_amd64.whl", hash = "sha256:508de82ac2b64aa575a543949c44dc7f83a734622bed01d8501474ab454f7bb7", size = 16566588, upload-time = "2026-02-08T20:39:51.49Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e3/64a16f064b188903c5ade786468bb1221879f500e0aae98acc70be9c0f7d/wxpython-4.2.5-cp311-cp311-win_arm64.whl", hash = "sha256:9bf5704eedd21bd1fe3143d8ed1cfe8250e1fbb651eb6c17a73533136745fe5a", size = 15530728, upload-time = "2026-02-08T20:39:54.533Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b7/aa689ba41312a94079e692f7a5a5c0bd1c6086bc929c9eb13f3b5c6bda58/wxpython-4.2.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:310772b05372c2daa76fefa7e57d20106b522d53b49d3edc3d9ac1fde7e3782e", size = 17774402, upload-time = "2026-02-08T20:39:57.348Z" },
+    { url = "https://files.pythonhosted.org/packages/21/66/4ea97c2b6e8e627e645b3a8a2f6e4d5db3c1799845d730fd3df91b5ac294/wxpython-4.2.5-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:10bba0d56547f34d12b5450e8c73e32ff821aed10a2f34a0c666c8355eb9ee98", size = 18855177, upload-time = "2026-02-08T20:40:00.588Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/3a/5136bf39877640c8a254f1370279943366d04d321461a450fcef53722f38/wxpython-4.2.5-cp312-cp312-win32.whl", hash = "sha256:e7079d9a7374b3fd5896bdea7c73faa8da52e1fbcce5368796b5c22d7de747a6", size = 14519633, upload-time = "2026-02-08T20:40:03.577Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/2c2c9dbf78f9524daf79014337e193531332c3598b16ccc11290dad9c17f/wxpython-4.2.5-cp312-cp312-win_amd64.whl", hash = "sha256:c54962f0524662d16591a03c786cd4d71bc43c70ede8244e0a5a59aa3979d124", size = 16577057, upload-time = "2026-02-08T20:40:06.002Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/10/a7ed092d0426cc98ab1a907c9e6161d8846e0de0450447b877048a8ef4e3/wxpython-4.2.5-cp312-cp312-win_arm64.whl", hash = "sha256:cda1fb351caa4555bd18717f610c9a3b03d25e64db4a22e004b141f91d02fa8c", size = 15537110, upload-time = "2026-02-08T20:40:09.022Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/b9/1fee711ad5c26e7bbd4e10fae14b2ce0499684a084c3c60169373496ceae/wxpython-4.2.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f7ec6b028e8b1c4cad1ecb5c8402c2cae7840a25758be0fc209e56df86d1cac", size = 17775906, upload-time = "2026-02-08T20:40:12.031Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/53/521a79cbb169ab6b123e79ea23ebafe3046c1999a431b6fc864f1217bb86/wxpython-4.2.5-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:77ac5335d8e4aae92732fc039df24a58181cdfb5bc7931692f1f9415e9eeee7d", size = 18857767, upload-time = "2026-02-08T20:40:14.486Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ea/a69ad0a1e7b01876619982b6cf8db0e26d0f3776b9be73b61d9f0662a2ce/wxpython-4.2.5-cp313-cp313-win32.whl", hash = "sha256:0985f190565b94635f146989886196a7e9faced8911800910460919cb72668cc", size = 14520419, upload-time = "2026-02-08T20:40:17.401Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/bd/d2698369dbc43aa5c9324c23fdd5cd3b23c245861e334b1d976209913f90/wxpython-4.2.5-cp313-cp313-win_amd64.whl", hash = "sha256:3fd3649fc4752f1a02776b7057073c932e5229bbab2031762b01532bcc6bd074", size = 16576741, upload-time = "2026-02-08T20:40:20.646Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/4e/4181734a2bc05940ba4feb3feb2474416b1dc12c329a2ac164632582c4d6/wxpython-4.2.5-cp313-cp313-win_arm64.whl", hash = "sha256:b794d9912464990ea1fd3744fb73fbd7446149e230e5a611ba40eb4ac74755a1", size = 15537287, upload-time = "2026-02-08T20:40:24.658Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/a1/9d8a7c5f60bb311257b04e3a3d9bbf12e4ab1fcc92811a007bbdf43b1e5f/wxpython-4.2.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:af2d8388eb3f0d8eaae0713a35c307293435ec279f215a2bbf521b738d7fc91b", size = 17783876, upload-time = "2026-02-08T20:40:27.739Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9c/32862d321db8927f37d2572e606cf480e013942e5c6ce39fef37c4a713cb/wxpython-4.2.5-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:1925485c9b90e79f869272eff2b99438538b00505f9d148d51358dc8e92116b6", size = 18864211, upload-time = "2026-02-08T20:40:30.523Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a7/261bf54686192ebefc42b494da97ba3312bd01c1d37a964f0cb83f271cf0/wxpython-4.2.5-cp314-cp314-win32.whl", hash = "sha256:230ecb4de65a8d2f8bc30bccd4d64366ac3a7cf53759b77920de927d156ad9c5", size = 14859697, upload-time = "2026-02-08T20:40:33.108Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/9a/73f12041178db3728a809ce37c2b64409291cb45567b2918df478f0ceb20/wxpython-4.2.5-cp314-cp314-win_amd64.whl", hash = "sha256:eb1c228f0c20ed93f2799ebd81780abc7fd65cfa8f6b65e989b68c0c18c52707", size = 16947346, upload-time = "2026-02-08T20:40:35.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/49/3a39f5fe78a7194c848919c4b681f432fe937006e2e5182a17dd519f8c91/wxpython-4.2.5-cp314-cp314-win_arm64.whl", hash = "sha256:d4439bf4b18ac720afbcf51c37d7822ba62ab6999501e96cce1dfc2f55a19344", size = 15809574, upload-time = "2026-02-08T20:40:38.859Z" },
+]


### PR DESCRIPTION
## Summary
- add AccessiClock system tray support with text menu actions for show, announce time, test chime, settings, and exit
- add configurable announce-time global hotkey support with a safe default of Ctrl+Alt+T when enabled
- add sound_lib audio output device enumeration/selection, a keyboard-friendly Audio Device dialog, and Settings controls
- persist tray, hotkey, and audio-device settings through the uv-enabled config path

## Verification
- uv sync --group dev
- uv run pytest -q
- uv run ruff check src tests
- uv run mypy src
- wx runtime accessibility smoke for main labels, Settings controls, Audio Device dialog names/defaults
- wx tray runtime smoke for tray creation and tray action dispatch

## Accessibility
- visible text labels for all new controls and tray commands
- keyboard-reachable Audio Device button/dialog and Settings controls
- status text updates for tray/hotkey/audio-device actions
- no unlabeled icon-only UI added